### PR TITLE
PoC: allow users to lock the kernel revisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,15 @@ name = "hf-kernels"
 version = "0.1.0"
 description = "Download cuda kernels"
 authors = [
-    {name = "OlivierDehaene", email = "olivier@huggingface.co"},
-    {name = "Daniel de Kok", email = "daniel@huggingface.co"},
-    {name = "David Holtz", email = "david@huggingface.co"},
-    {name = "Nicolas Patry", email = "nicolas@huggingface.co"}
+  { name = "OlivierDehaene", email = "olivier@huggingface.co" },
+  { name = "Daniel de Kok", email = "daniel@huggingface.co" },
+  { name = "David Holtz", email = "david@huggingface.co" },
+  { name = "Nicolas Patry", email = "nicolas@huggingface.co" },
 ]
 readme = "README.md"
+
+[project.entry-points."egg_info.writers"]
+"hf_kernels.lock" = "hf_kernels.lockfile:write_egg_lockfile"
 
 [dependencies]
 python = "^3.9"

--- a/src/hf_kernels/lockfile.py
+++ b/src/hf_kernels/lockfile.py
@@ -1,0 +1,28 @@
+from typing import Any, List
+
+
+def _get_nested_attr(d, attr: List[str]) -> Any:
+    for a in attr:
+        d = d.get(a)
+        if d is None:
+            break
+    return d
+
+
+def write_egg_lockfile(cmd, basename, filename):
+    import json
+    import os
+    import tomllib
+
+    cwd = os.getcwd()
+    pyproject = os.path.join(cwd, "pyproject.toml")
+    with open(pyproject, "rb") as f:
+        data = tomllib.load(f)
+
+    kernel_versions = _get_nested_attr(data, ["tool", "kernels", "dependencies"])
+    if kernel_versions is None:
+        return
+
+    kernel_versions_json = json.dumps(kernel_versions, indent=2)
+
+    cmd.write_or_delete_file(basename, filename, kernel_versions_json)

--- a/src/hf_kernels/utils.py
+++ b/src/hf_kernels/utils.py
@@ -1,4 +1,10 @@
+from types import ModuleType
+from typing import List, Optional
 import importlib
+import importlib.metadata
+from importlib.metadata import Distribution
+import inspect
+import json
 import platform
 import sys
 import os
@@ -50,6 +56,10 @@ def get_kernel(repo_id: str, revision: str = "main"):
 
 
 def load_kernel(repo_id: str, revision: str = "main"):
+    locked_revision = _get_caller_locked_kernel(repo_id)
+    if locked_revision is not None:
+        revision = locked_revision
+
     filename = hf_hub_download(
         repo_id, "build.toml", local_files_only=True, revision=revision
     )
@@ -59,3 +69,36 @@ def load_kernel(repo_id: str, revision: str = "main"):
     repo_path = os.path.dirname(filename)
     package_path = f"{repo_path}/build/{build_variant()}"
     return import_from_path(package_name, f"{package_path}/{package_name}/__init__.py")
+
+
+def _get_caller_locked_kernel(name: str) -> Optional[str]:
+    for dist in _get_caller_distributions():
+        lock_json = dist.read_text("hf_kernels.lock")
+        if lock_json is not None:
+            return json.loads(lock_json).get(name)
+    return None
+
+
+def _get_caller_distributions() -> List[Distribution]:
+    module = _get_caller_module()
+    if module is None:
+        return []
+
+    # Look up all possible distributions that this module could be from.
+    package = module.__name__.split(".")[0]
+    dist_names = importlib.metadata.packages_distributions().get(package)
+    if dist_names is None:
+        return []
+
+    return [importlib.metadata.distribution(dist_name) for dist_name in dist_names]
+
+
+def _get_caller_module() -> Optional[ModuleType]:
+    stack = inspect.stack()
+    # Get first module in the stack that is not the current module.
+    first_module = inspect.getmodule(stack[0][0])
+    for frame in stack[1:]:
+        module = inspect.getmodule(frame[0])
+        if module is not None and module != first_module:
+            return module
+    return first_module


### PR DESCRIPTION
This change allows Python projects that use kernels to lock the kernel revisions on a project-basis. For this to work, the user only has to include `hf-kernels` as a build dependency. During the build, a lock file is written to the package's pkg-info. During runtime we can read it out and use the corresponding revision. When the kernel is not locked, the revision that is provided as an argument is used.