### PR TITLE
Add `use_kernel_forward_from_hub` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ the Hub.
 
 ## 📚 Documentation
 
+- [Using layers](docs/layers.md)
 - [Locking kernel versions](docs/locking.md)
 - [Using kernels in a Docker container](docs/docker.md)
 - [Kernel requirements](docs/kernel-requirements.md)

--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -76,6 +76,26 @@ might use two different commits that happen to have the same version
 number. Git tags are not stable, so they do not provide a good way
 of guaranteeing uniqueness of the namespace.
 
+## Layers
+
+Kernels can provide a `layers` attribute containing a Python module with
+layers. Such layers can be used directly by downstream users or through
+the `use_hub_kernel` decorator. For Torch, layers must be a subclass of
+[`nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html).
+
+To accommodate portable loading, `layers` must be defined in the main
+`__init__.py` file. For example:
+
+```python
+from . import layers
+
+__all__ = [
+  # ...
+  "layers"
+  # ...
+]
+```
+
 ## Python requirements
 
 - Python code must be compatible with Python 3.9 and later.

--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -78,10 +78,64 @@ of guaranteeing uniqueness of the namespace.
 
 ## Layers
 
-Kernels can provide a `layers` attribute containing a Python module with
-layers. Such layers can be used directly by downstream users or through
-the `use_hub_kernel` decorator. For Torch, layers must be a subclass of
-[`nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html).
+A kernel can provide layers in addition to kernel functions. A layer from
+the Hub can replace the `forward` method of an existing layer for a certain
+device type. This makes it possible to provide more performant kernels for
+existing layers. See the [layers documentation](layers.md) for more information
+on how to use layers.
+
+### Writing layers
+
+To make the extension of layers safe, the layers must fulfill the following
+requirements:
+
+- The layers are subclasses of `torch.nn.Module`.
+- The layers are pure, meaning that they do not have their own state. This
+  means that:
+  - The layer must not define its own constructor.
+  - The layer must not use class variables.
+- No other methods must be defined than `forward`.
+- The `forward` method has a signature that is compatible with the
+  `forward` method that it is extending.
+
+This is an example of a pure layer:
+
+```python
+class SiluAndMul(nn.Module):
+    def forward(self, x: torch.Tensor):
+        d = x.shape[-1] // 2
+        output_shape = x.shape[:-1] + (d,)
+        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+        ops.silu_and_mul(out, x)
+        return out
+```
+
+For some layers, the `forward` method has to use state from the adopting class.
+In these cases, we recommend to use type annotations to indicate what member
+variables are expected. For instance:
+
+```python
+class LlamaRMSNorm(nn.Module):
+    weight: torch.Tensor
+    variance_epsilon: float
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return rms_norm_fn(
+            hidden_states,
+            self.weight,
+            bias=None,
+            residual=None,
+            eps=self.variance_epsilon,
+            dropout_p=0.0,
+            prenorm=False,
+            residual_in_fp32=False,
+        )
+```
+
+This layer expects the adopting layer to have `weight` and `variance_epsilon`
+member variables and uses them in the `forward` method.
+
+### Exporting layers
 
 To accommodate portable loading, `layers` must be defined in the main
 `__init__.py` file. For example:

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -54,7 +54,7 @@ by name using the `register_kernel_mapping` function. For example:
 ```python
 kernel_layer_mapping = {
     "SiluAndMul": {
-        Device(type="cuda"): LayerRepository(
+        "cuda": LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
             revision="layers",

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -65,6 +65,19 @@ kernel_layer_mapping = {
 register_kernel_mapping(kernel_layer_mapping)
 ```
 
+This will register the kernel mapping in the current context, which is
+normally global. It is recommended to scope the mapping to where it is
+used with the `use_kernel_mapping` context manager:
+
+```python
+with use_kernel_mapping(kernel_layer_mapping):
+    # Use the layer for which the mapping is applied.
+    ...
+```
+
+This ensures that the mapping is not active anymore outside the
+`with`-scope.
+
 ## Using a kernel layer as a replacement for an existing layer
 
 An existing layer in a library can be Kernel Hub-enabled using the

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -35,7 +35,12 @@ decorator can be made extensible by by monkeypatching it using the `replace_kern
 from somelibrary import SiluAndMul
 
 replace_kernel_forward_from_hub(SiluAndMul, "SiluAndMul")
+register_kernel_mapping(kernel_layer_mapping)
 ```
+
+The `register_kernel_mapping` call maps the name `SiluAndMul` to actual
+hub kernels. See the [Registering a hub kernel for a layer](#registering-a-hub-kernel-for-a-layer)
+section for more information.
 
 **Warning:** we strongly recommend using layers with a decorator, since
 it signifies that the maintainer intends to keep the `forward` signature

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,86 @@
+# Layers
+
+A kernel can provide layers in addition to kernel functions. A layer from
+the hub can replace the `forward` method of an existing layer for a certain
+device type. This makes it possible to provide more performant kernels for
+existing layers.
+
+For Torch kernels, layers are subclasses of [`torch.nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html)
+with the following requirements:
+
+- They do not have their own state, but layers can use the state of the
+  layer that they are extending.
+- The `forward` method has a signature that is compatible with the
+  `forward` method that it is extending.
+
+## Making a layer extensible with kernels from the hub
+
+### Using a decorator
+
+A layer can be made extensible with the `use_kernel_forward_from_hub`
+decorator. For example:
+
+```python
+@use_kernel_forward_from_hub("SiluAndMul")
+class SiluAndMul(nn.Module):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        d = input.shape[-1] // 2
+        return F.silu(input[..., :d]) * input[..., d:]
+```
+
+The decorator changes the layer, so that other implementations of the `forward`
+method can be registered using the name `SiluAndMul`.
+
+### External layers
+
+An existing layer that does not (yet) have the `use_kernel_forward_from_hub`
+decorator can be made extensible by by monkeypatching it using the `replace_kernel_forward_from_hub` function.
+
+```python
+from somelibrary import SiluAndMul
+
+replace_kernel_forward_from_hub(SiluAndMul, "SiluAndMul")
+```
+
+**Warning:** we strongly recommend using layers with a decorator, since
+it signifies that the maintainer intends to keep the `forward` signature
+compatible with layers from the hub.
+
+## Registering a hub kernel for a layer
+
+Once a layer is made extensible, users can register hub kernels for it
+by name using the `register_kernel_mapping` function. For example:
+
+```python
+kernel_layer_mapping = {
+    "SiluAndMul": {
+        Device(type="cuda"): LayerRepository(
+            repo_id="kernels-community/activation",
+            layer_name="SiluAndMul",
+            revision="layers",
+        )
+    }
+}
+
+register_kernel_mapping(kernel_layer_mapping)
+```
+
+## Using a kernel layer as a replacement for an existing layer
+
+An existing layer in a library can be Kernel Hub-enabled using the
+`use_hub_kernel` decorator. This decorator will replace the existing
+layer if the kernel layer could be loaded successfully.
+
+For example:
+
+```python
+@use_hub_kernel(
+    "kernels-community/activation",
+    layer_name="SiluAndMul",
+    revision="layers",
+)
+class SiluAndMul(nn.Module):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        d = input.shape[-1] // 2
+        return F.silu(input[..., :d]) * input[..., d:]
+```

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -72,23 +72,3 @@ with use_kernel_mapping(kernel_layer_mapping):
 
 This ensures that the mapping is not active anymore outside the
 `with`-scope.
-
-## Using a kernel layer as a replacement for an existing layer
-
-An existing layer in a library can be Kernel Hub-enabled using the
-`use_hub_kernel` decorator. This decorator will replace the existing
-layer if the kernel layer could be loaded successfully.
-
-For example:
-
-```python
-@use_hub_kernel(
-    "kernels-community/activation",
-    layer_name="SiluAndMul",
-    revision="layers",
-)
-class SiluAndMul(nn.Module):
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        d = input.shape[-1] // 2
-        return F.silu(input[..., :d]) * input[..., d:]
-```

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,17 +1,12 @@
 # Layers
 
 A kernel can provide layers in addition to kernel functions. A layer from
-the hub can replace the `forward` method of an existing layer for a certain
+the Hub can replace the `forward` method of an existing layer for a certain
 device type. This makes it possible to provide more performant kernels for
 existing layers.
 
-For Torch kernels, layers are subclasses of [`torch.nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html)
-with the following requirements:
-
-- They do not have their own state, but layers can use the state of the
-  layer that they are extending.
-- The `forward` method has a signature that is compatible with the
-  `forward` method that it is extending.
+See [Kernel requirements](kernel-requirements.md) for more information the
+requirements of Hub layers.
 
 ## Making a layer extensible with kernels from the hub
 

--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -1,3 +1,23 @@
-from kernels.utils import get_kernel, get_locked_kernel, install_kernel, load_kernel
+from kernels.layer import (
+    Device,
+    LayerRepository,
+    register_kernel_mapping,
+    use_kernel_forward_from_hub,
+)
+from kernels.utils import (
+    get_kernel,
+    get_locked_kernel,
+    install_kernel,
+    load_kernel,
+)
 
-__all__ = ["get_kernel", "get_locked_kernel", "load_kernel", "install_kernel"]
+__all__ = [
+    "get_kernel",
+    "get_locked_kernel",
+    "load_kernel",
+    "install_kernel",
+    "use_kernel_forward_from_hub",
+    "register_kernel_mapping",
+    "LayerRepository",
+    "Device",
+]

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -69,10 +69,24 @@ def use_kernel_mapping(mapping: Dict[str, Dict[Device, LayerRepository]]):
 
 def register_kernel_mapping(mapping: Dict[str, Dict[Device, LayerRepository]]):
     """
-    Register a layer mapping.
+    Allows one to register a mapping between a layer name the corresponding kernel to use, depending on the device. 
+    This should be use in conjunction with `use_kernel_hub_forward` decorator on the classname. 
+    Exemple usage:
+    
+    ```python
+    from kernels import LayerRepository, register_kernel_mapping
 
-    This function registers a mapping from a layer identifier and device type
-    to a layer in a kernel repository.
+    kernel_layer_mapping = {
+      "LlamaRMSNorm": {
+          "cuda": LayerRepository(
+              repo_id="kernels-community/activation",
+              layer_name="RmsNorm",
+              revision="layers",
+          ),
+      },
+    }
+    register_kernel_mapping(kernel_layer_mapping)
+    ```
     """
     # Merge with existing mappings.
     for new_kernel, new_device_repos in mapping.items():

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -1,0 +1,184 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Dict
+
+from .utils import get_kernel
+
+if TYPE_CHECKING:
+    from torch import nn
+
+
+@dataclass(frozen=True)
+class Device:
+    type: str
+
+    # In the future we might add compute capabilities, etc.
+
+    def __eq__(self, other):
+        return isinstance(other, Device) and self.type == other.type
+
+    def __hash__(self):
+        return hash(self.type)
+
+
+@dataclass
+class LayerRepository:
+    """
+    Repository and name of a layer.
+    """
+
+    layer_name: str = field(
+        metadata={"help": "The name of the layer in the kernel repository."}
+    )
+    repo_id: str = field(metadata={"help": "The kernel hub repository with the layer."})
+    revision: str = field(
+        default="main", metadata={"help": "The revision of the layer."}
+    )
+
+
+_KERNEL_MAPPING: Dict[str, Dict[Device, LayerRepository]] = {}
+
+
+def register_kernel_mapping(mapping: Dict[str, Dict[Device, LayerRepository]]):
+    """
+    Register a layer mapping.
+    This function regiters a mapping from a layer identifier and device type
+    to a layer in a kernel repository.
+    """
+    # Merge with existing mappings.
+    for new_kernel, new_device_repos in mapping.items():
+        device_repo = _KERNEL_MAPPING.setdefault(new_kernel, {})
+        for new_device, new_repo in new_device_repos.items():
+            device_repo[new_device] = new_repo
+
+
+def replace_kernel_forward_from_hub(cls, layer_name: str, *, use_fallback: bool = True):
+    """
+    Replace the forward function of a layer using a layer from the kernel hub.
+    This function monkeypatches a layer, replacing the `forward` method
+    of the layer with that of a layer from the hub. The replacement is done
+    when a layer matching `layer_name` and device type is registered through
+    `register_layer_mapping`. The device type is inferred from the first
+    argument to `forward`.
+    """
+
+    fallback_forward = cls.forward
+
+    cached_forward: Dict[Device, Callable] = {}
+
+    def forward(self, x, **args):
+        kernel = _KERNEL_MAPPING.get(layer_name)
+        if kernel is None:
+            if not use_fallback:
+                raise ValueError(f"No layer mapping for `{layer_name}`")
+            return fallback_forward(self, x, **args)
+
+        device = getattr(x, "device", None)
+        if device is None:
+            return fallback_forward(self, x, **args)
+
+        # Short-circuit if we already loaded the layer.
+        arch = Device(type=device.type)
+        layer_forward = cached_forward.get(arch, None)
+        if layer_forward is not None:
+            return layer_forward(self, x, **args)
+
+        repo = kernel.get(arch)
+        if repo is None:
+            if not use_fallback:
+                raise ValueError(
+                    f"No layer mapping for `{layer_name}` with device type `{device.type}`"
+                )
+            return fallback_forward(self, x, **args)
+
+        layer = _get_kernel_layer(
+            repo_id=repo.repo_id,
+            layer_name=repo.layer_name,
+            revision=repo.revision,
+        )
+
+        # We have to validate against the original signature.
+        orig_forward = cls.forward
+        try:
+            cls.forward = fallback_forward
+            _validate_layer(check_cls=cls, cls=layer)
+        finally:
+            cls.forward = orig_forward
+
+        layer_forward = layer.forward
+        cached_forward[arch] = layer_forward
+
+        return layer_forward(self, x, **args)
+
+    cls.forward = forward
+
+
+def use_kernel_forward_from_hub(layer_name: str, *, use_fallback: bool = True):
+    """
+    Replace the forward function of a layer using a layer from the kernel hub.
+    This decorator can be applied to a layer and replaces the forward method
+    of the layer with that of a layer from the hub. The replacement is done
+    when a layer matching `layer_name` and device type is registered through
+    `register_layer_mapping`. The device type is inferred from the first
+    argument to `forward`.
+    """
+
+    def decorator(cls):
+        replace_kernel_forward_from_hub(cls, layer_name, use_fallback=use_fallback)
+        return cls
+
+    return decorator
+
+
+def _get_kernel_layer(*, repo_id: str, layer_name: str, revision: str) -> "nn.Module":
+    """Get a layer from a kernel."""
+
+    kernel = get_kernel(repo_id, revision=revision)
+
+    if getattr(kernel, "layers", None) is None:
+        raise ValueError(
+            f"Kernel `{repo_id}` at revision `{revision}` does not define any layers."
+        )
+
+    layer = getattr(kernel.layers, layer_name, None)
+    if layer is None:
+        raise ValueError(f"Layer `{layer_name}` not found in kernel `{repo_id}`.")
+    return layer
+
+
+def _validate_layer(*, check_cls, cls):
+    # The layer must have at least have the following properties: (1) it
+    # must be stateless; (2) the forward signature should correspond to
+    # the signature it is replacing; (3) forward should not call other
+    # methods.
+
+    from torch import nn
+
+    if not issubclass(cls, nn.Module):
+        raise TypeError(f"Layer `{cls}` is not a Torch layer.")
+
+    # We verify statelessness by checking that the does not have its own
+    # constructor (since the constructor could add member variables)...
+    if cls.__init__ is not nn.Module.__init__:
+        raise TypeError("Layer must not override nn.Module constructor.")
+
+    # ... or predefined member variables.
+    torch_module_members = {name for name, _ in inspect.getmembers(nn.Module)}
+    cls_members = {name for name, _ in inspect.getmembers(cls)}
+    if cls_members - torch_module_members != set():
+        raise TypeError("Layer must not contain additional members.")
+
+    # Check whether the forward signatures are similar.
+    params = inspect.signature(cls.forward).parameters
+    ref_params = inspect.signature(check_cls.forward).parameters
+
+    if len(params) != len(ref_params):
+        raise TypeError(
+            "Forward signature does not match: different number of arguments."
+        )
+
+    for param, ref_param in zip(params.values(), ref_params.values()):
+        if param.kind != ref_param.kind:
+            raise TypeError(
+                f"Forward signature does not match: different kind of arguments ({param} ({param.kind}) and {ref_param} ({ref_param.kind})"
+            )

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -9,7 +9,7 @@ from kernels import (
     register_kernel_mapping,
     use_kernel_forward_from_hub,
 )
-from kernels.layer import _validate_layer, _KERNEL_MAPPING, use_kernel_mapping
+from kernels.layer import _KERNEL_MAPPING, _validate_layer, use_kernel_mapping
 
 kernel_layer_mapping = {
     "SiluAndMul": {

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -1,0 +1,98 @@
+import pytest
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+from kernels import (
+    Device,
+    LayerRepository,
+    register_kernel_mapping,
+    use_kernel_forward_from_hub,
+)
+from kernels.layer import _validate_layer
+
+kernel_layer_mapping = {
+    "SiluAndMul": {
+        Device(type="cuda"): LayerRepository(
+            repo_id="kernels-community/activation",
+            layer_name="SiluAndMul",
+            revision="layers",
+        )
+    }
+}
+
+register_kernel_mapping(kernel_layer_mapping)
+
+
+class SiluAndMul(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Used to check that we called hub kernel.
+        self.n_calls = 0
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self.n_calls += 1
+        d = input.shape[-1] // 2
+        return F.silu(input[..., :d]) * input[..., d:]
+
+
+@use_kernel_forward_from_hub("SiluAndMul")
+class SiluAndMulWithKernel(SiluAndMul):
+    pass
+
+
+@pytest.mark.parametrize("device", ["cuda", "cpu"])
+def test_hub_forward(device):
+    torch.random.manual_seed(0)
+
+    silu_and_mul = SiluAndMul()
+    X = torch.randn((32, 64), device=device)
+    Y = silu_and_mul(X)
+
+    silu_and_mul_with_kernel = SiluAndMulWithKernel()
+    Y_kernel = silu_and_mul_with_kernel(X)
+
+    torch.testing.assert_close(Y_kernel, Y)
+
+    assert silu_and_mul.n_calls == 1
+    if device == "cuda":
+        assert silu_and_mul_with_kernel.n_calls == 0
+    else:
+        assert silu_and_mul_with_kernel.n_calls == 1
+
+
+def test_layer_fallback_works():
+    @use_kernel_forward_from_hub("SiluAndMulNonExisting")
+    class SiluAndMulWithKernelFallback(SiluAndMul):
+        pass
+
+    # Check that we don't raise an exception for a non-existing kernel.
+    SiluAndMulWithKernelFallback()
+
+
+def test_validate_kernel_layer():
+    class BadLayer(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.foo = 42
+
+    with pytest.raises(TypeError, match="not override"):
+        _validate_layer(cls=BadLayer, check_cls=SiluAndMul)
+
+    class BadLayer2(nn.Module):
+        foo: int = 42
+
+    with pytest.raises(TypeError, match="not contain additional members"):
+        _validate_layer(cls=BadLayer2, check_cls=SiluAndMul)
+
+    class BadLayer3(nn.Module):
+        def forward(self, x: torch.Tensor, foo: int) -> torch.Tensor: ...
+
+    with pytest.raises(TypeError, match="different number of arguments"):
+        _validate_layer(cls=BadLayer3, check_cls=SiluAndMul)
+
+    class BadLayer4(nn.Module):
+        def forward(self, *, x: torch.Tensor) -> torch.Tensor: ...
+
+    with pytest.raises(TypeError, match="different kind of arguments"):
+        _validate_layer(cls=BadLayer4, check_cls=SiluAndMul)


### PR DESCRIPTION
This decorator replaces a layer's `forward` with the `forward` of a layer on the hub.

---

This change combines #45 and https://github.com/huggingface/transformers/pull/36680:

* Like the transformers PR and unlike #45, we only replace `forward` functions. We only know upon the `forward` call what the device is, so we can only dispatch it to the correct layer at that point.
* Like the transformers PR, the decorator does not directly assign a layer from the hub, but a symbolic name. Hub layers can then be registered by this name through `register_kernel_mapping`.
* `register_kernel_mapping` is changed following @LysandreJik 's suggestion in https://github.com/huggingface/transformers/pull/36680.
* Compared to https://github.com/huggingface/transformers/pull/36680, we validate that the 'donor' layers:
  * They must be pure (no constructor, no member variables, no additional methods beyond `forward`).
  * The `forward` method must have the same number of arguments and the arguments must have the same kind. We can loosen up this requirement a little in the future.