### PR TITLE
Do not use kernels without backward when training

### DIFF
--- a/docs/kernel-requirements.md
+++ b/docs/kernel-requirements.md
@@ -119,10 +119,17 @@ requirements:
 - The `forward` method has a signature that is compatible with the
   `forward` method that it is extending.
 
+The only exception to the _no class variables rule_ is addition of a
+`has_backward` class variable. This variable is used to indicate whether
+the layer has a backward pass implemented (`True` when absent).
+
 This is an example of a pure layer:
 
 ```python
 class SiluAndMul(nn.Module):
+    # This layer does not implement backward.
+    has_backward: bool = False
+
     def forward(self, x: torch.Tensor):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -223,7 +223,7 @@ def test_fallback_used_when_training():
         {
             "Linear": {
                 Device(type="cuda"): LayerRepository(
-                    repo_id="kernels-community/kernels-test",
+                    repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearImplicitBackward",
                 )
             }
@@ -242,7 +242,7 @@ def test_fallback_used_when_training():
         {
             "Linear": {
                 Device(type="cuda"): LayerRepository(
-                    repo_id="kernels-community/kernels-test",
+                    repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearBackward",
                 )
             }
@@ -261,7 +261,7 @@ def test_fallback_used_when_training():
         {
             "Linear": {
                 Device(type="cuda"): LayerRepository(
-                    repo_id="kernels-community/kernels-test",
+                    repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearNoBackward",
                 )
             }


### PR DESCRIPTION
Kernel layers can be marked to be inference-only by setting the `has_backward` class variable to `False`. If a layer is in training mode, we will use the fallback `forward`.