### PR TITLE
Add `has_kernel` function

### DIFF
--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -9,6 +9,7 @@ from kernels.layer import (
 from kernels.utils import (
     get_kernel,
     get_locked_kernel,
+    has_kernel,
     install_kernel,
     load_kernel,
 )
@@ -16,6 +17,7 @@ from kernels.utils import (
 __all__ = [
     "get_kernel",
     "get_locked_kernel",
+    "has_kernel",
     "load_kernel",
     "install_kernel",
     "use_kernel_forward_from_hub",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,6 +41,9 @@ def test_gelu_fast(kernel, device):
     [
         ("kernels-community/activation", "main", True),
         ("kernels-community/triton-layer-norm", "main", True),
+        # Repo only contains Torch 2.4 kernels (and we don't
+        # support/test against this version).
+        ("kernels-test/only-torch-2.4", "main", False),
         ("google-bert/bert-base-uncased", "87565a309", False),
     ],
 )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from kernels import get_kernel
+from kernels import get_kernel, has_kernel
 
 
 @pytest.fixture
@@ -34,6 +34,19 @@ def test_gelu_fast(kernel, device):
     )
 
     assert torch.allclose(y, expected)
+
+
+@pytest.mark.parametrize(
+    "kernel_exists",
+    [
+        ("kernels-community/activation", "main", True),
+        ("kernels-community/triton-layer-norm", "main", True),
+        ("google-bert/bert-base-uncased", "87565a309", False),
+    ],
+)
+def test_has_kernel(kernel_exists):
+    repo_id, revision, kernel = kernel_exists
+    assert has_kernel(repo_id, revision=revision) == kernel
 
 
 def test_universal_kernel(universal_kernel):


### PR DESCRIPTION
This function checks whether a kernel build exists for the current environment (Torch version and compute framework).