### PR TITLE
Make the forward pass torch.compile compatible

### DIFF
--- a/src/kernels/utils.py
+++ b/src/kernels/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import platform
 import sys
+import torch
 from importlib.metadata import Distribution
 from pathlib import Path
 from types import ModuleType
@@ -32,10 +33,9 @@ def _get_cache_dir() -> Optional[str]:
 
 
 CACHE_DIR: Optional[str] = _get_cache_dir()
-
+CXXABI_VARIANT = "cxx11" if torch.compiled_with_cxx11_abi() else "cxx98"
 
 def build_variant() -> str:
-    import torch
 
     if torch.version.cuda is not None:
         cuda_version = parse(torch.version.cuda)
@@ -47,7 +47,7 @@ def build_variant() -> str:
         raise AssertionError("Torch was not compiled with CUDA or ROCm enabled.")
 
     torch_version = parse(torch.__version__)
-    cxxabi = "cxx11" if torch.compiled_with_cxx11_abi() else "cxx98"
+    cxxabi = CXXABI_VARIANT
     cpu = platform.machine()
     os = platform.system().lower()
 


### PR DESCRIPTION
This PR updates the flow of `replace_kernel_forward_from_hub` to ensure the appropriate forward pass is selected **before** model compilation. This change is necessary because many of the operations involved are not compatible with `torch.compile`.

**Note:** We still need to address how to handle `self.training` and `x.device`, as these are only accessible at runtime.