### PR TITLE
Make the forward pass `torch.compile` compatible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.10", "3.12"]
-        torch-version: ["2.5.1", "2.6.0"]
+        torch-version: ["2.6.0", "2.7.0"]
 
     env:
       UV_PYTHON_PREFERENCE: only-managed

--- a/README.md
+++ b/README.md
@@ -61,4 +61,5 @@ the Hub.
 - [Environment variables](docs/env.md)
 - [Using kernels in a Docker container](docs/docker.md)
 - [Kernel requirements](docs/kernel-requirements.md)
+- [Frequently Asked questions](docs/faq.md)
 - [Writing kernels](https://github.com/huggingface/kernel-builder/blob/main/docs/writing-kernels.md) using [kernel-builder](https://github.com/huggingface/kernel-builder/)

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -23,33 +23,98 @@ class SiluAndMul(nn.Module):
         return F.silu(input[..., :d]) * input[..., d:]
 ```
 
-The decorator changes the layer, so that other implementations of the `forward`
-method can be registered using the name `SiluAndMul`.
+The decorator does not change the behavior of the class -- it annotates
+the class with the given name (here `SiluAndMul`). The `kernelize` function
+described below uses this name to look up kernels for the layer.
 
 ### External layers
 
 An existing layer that does not (yet) have the `use_kernel_forward_from_hub`
-decorator can be made extensible by by monkeypatching it using the `replace_kernel_forward_from_hub` function.
+decorator can be made extensible using the `replace_kernel_forward_from_hub`
+function:
 
 ```python
 from somelibrary import SiluAndMul
 
 replace_kernel_forward_from_hub(SiluAndMul, "SiluAndMul")
-register_kernel_mapping(kernel_layer_mapping)
 ```
-
-The `register_kernel_mapping` call maps the name `SiluAndMul` to actual
-hub kernels. See the [Registering a hub kernel for a layer](#registering-a-hub-kernel-for-a-layer)
-section for more information.
 
 **Warning:** we strongly recommend using layers with a decorator, since
 it signifies that the maintainer intends to keep the `forward` signature
 compatible with layers from the hub.
 
+## Kernelizing a model
+
+A model will not use Hub kernels by default, even if it contains extensible
+layers. To enable the use of Hub kernels in the model, it needs to be
+'kernelized' using the `kernelize` function. This function traverses the
+model graph and replaces the `forward` methods of extensible layers for which
+Hub kernels are registered. Kernelize can be used as follows:
+
+```python
+model = MyModel(...)
+model = kernelize(model)
+```
+
+**Note:** the `kernelize` function modifies the model in-place, the model
+itself is returned as a convenience.
+
+### Kernel device
+
+Kernels can be registered per device type. For instance, separate `cuda` and
+`metal` kernels could be registered for the name `SiluAndMul`. By default,
+`kernelize` will try to infer the device type from the model's parameters.
+You can pass the device type to `kernelize` if the device type cannot be
+inferred (e.g. because the model has no parameters):
+
+```python
+model = MyModel(...)
+model = kernelize(model, device="cuda")
+```
+
+### Backprop
+
+Not all Hub kernels support backprop. If a model is going to be used with
+backprop for training, then we want to avoid that `kernelize` uses such
+kernels. By default, `kernelize` will exclude inference-only kernels when
+the kernelized model is set to training (`Model.train()`). You can override
+this behavior using the `needs_backwards`:
+
+```python
+model = MyModel(...)
+model = kernelize(model, needs_backward=False)
+```
+
+### `torch.compile`
+
+Not all Hub kernels support `torch.compile`. If you want to compile a model
+after kernelizing it, pass the `needs_torch_compile` argument to ensure that
+only kernels that support `torch.compile` will be loaded:
+
+```python
+model = MyModel(...)
+model = kernelize(model, needs_torch_compile=True)
+```
+
+### Fallback forward
+
+The `needs_backwards`/`needs_torch_compile` arguments will fall back to
+the layer's original `forward` if the registered kernels do not support
+backprop/`torch.compile`. You can let `kernelize` raise an exception
+instead by using `use_fallback=False`:
+
+```python
+model = MyModel(...)
+model = kernelize(model, needs_torch_compile=True, use_fallback=False)
+```
+
+This can be useful if you want to guarantee that Hub kernels are used.
+
 ## Registering a hub kernel for a layer
 
-Once a layer is made extensible, users can register hub kernels for it
-by name using the `register_kernel_mapping` function. For example:
+`kernelize`` relies on kernel mappings to find Hub kernels for layers.
+Kernel mappings map a kernel name such as `SiluAndMul` to a kernel on
+the Hub. For example:
 
 ```python
 kernel_layer_mapping = {
@@ -61,7 +126,11 @@ kernel_layer_mapping = {
         )
     }
 }
+```
 
+You can register such a mapping using `register_kernel_mapping`:
+
+```python
 register_kernel_mapping(kernel_layer_mapping)
 ```
 
@@ -72,7 +141,7 @@ used with the `use_kernel_mapping` context manager:
 ```python
 with use_kernel_mapping(kernel_layer_mapping):
     # Use the layer for which the mapping is applied.
-    ...
+    model = kernelize(model)
 ```
 
 This ensures that the mapping is not active anymore outside the

--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -1,11 +1,11 @@
 from kernels.layer import (
     Device,
     LayerRepository,
+    kernelize,
     register_kernel_mapping,
     replace_kernel_forward_from_hub,
     use_kernel_forward_from_hub,
     use_kernel_mapping,
-    kernelize,
 )
 from kernels.utils import (
     get_kernel,

--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -5,6 +5,7 @@ from kernels.layer import (
     replace_kernel_forward_from_hub,
     use_kernel_forward_from_hub,
     use_kernel_mapping,
+    kernelize,
 )
 from kernels.utils import (
     get_kernel,
@@ -26,4 +27,5 @@ __all__ = [
     "replace_kernel_forward_from_hub",
     "LayerRepository",
     "Device",
+    "kernelize",
 ]

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -253,9 +253,7 @@ def kernelize(
     return model
 
 
-def use_kernel_forward_from_hub(
-    layer_name: str, *, device: Device = Device(type="cuda"), use_fallback: bool = True
-):
+def use_kernel_forward_from_hub(layer_name: str):
     """
     Replace the forward function of a layer using a layer from the kernel hub.
     This decorator can be applied to a layer and replaces the forward method
@@ -328,22 +326,6 @@ def _validate_layer(*, check_cls, cls):
             raise TypeError(
                 f"Forward signature does not match: different kind of arguments ({param} ({param.kind}) and {ref_param} ({ref_param.kind})"
             )
-
-
-def _is_torchdynamo_compiling():
-    # Importing torch._dynamo causes issues with PyTorch profiler (https://github.com/pytorch/pytorch/issues/130622)
-    # hence rather relying on `torch.compiler.is_compiling()` when possible (torch>=2.3)
-    try:
-        import torch
-
-        return torch.compiler.is_compiling()
-    except Exception:
-        try:
-            import torch._dynamo as dynamo  # noqa: F401
-
-            return dynamo.is_compiling()
-        except Exception:
-            return False
 
 
 def _find_device(model: "nn.Module") -> Device:

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -149,7 +149,7 @@ def kernelize(
     modules_list = [("", module_)] if not traverse_graph else module_.named_modules()
 
     for _, module in modules_list:
-        if hasattr(module, "kernel_layer_name"):
+        if hasattr(module, "kernel_layer_name") or not traverse_graph:
             layer_name = module.kernel_layer_name
             fallback_forward = module.forward
 

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -123,11 +123,8 @@ def replace_kernel_forward_from_hub(
     kernelize(cls, traverse_graph=False, device=device, needs_backward=needs_backward, use_fallback=use_fallback)
 
 
-import torch.nn as nn
-
-
 def kernelize(
-    module_: nn.Module,
+    module_,
     traverse_graph: bool = True,
     device: Device = Device(type="cuda"),
     needs_backward: bool = False,
@@ -149,7 +146,6 @@ def kernelize(
     cached_layer: Dict[LayerRepository, nn.Module] = {}
     is_compiling = _is_torchdynamo_compiling()
     # If we don't traverse the graph, we stop after the first module
-
     modules_list = [("", module_)] if not traverse_graph else module_.named_modules()
 
     for _, module in modules_list:

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -96,8 +96,10 @@ def register_kernel_mapping(
     mapping: Dict[str, Dict[Union[Device, str], LayerRepository]]
 ):
     """
-    Allows one to register a mapping between a layer name the corresponding kernel to use, depending on the device.
-    This should be use in conjunction with `use_kernel_hub_forward` decorator on the classname.
+    Allows one to register a mapping between a layer name the corresponding
+    kernel to use, depending on the device. This should be use in conjunction
+    with `kernelize`.
+
     Exemple usage:
 
     ```python
@@ -151,8 +153,9 @@ def kernelize(
     use_fallback: bool = True,
 ):
     """
-    Iterate over all modules in the model and replace the forward method of modules
-    that have a kernel_layer_name attribute with the corresponding kernel layer.
+    Iterate over all modules in the model and replace the `forward` method of
+    extensible layers for which kernels are registered using `register_kernel_mapping`
+    or `use_kernel_mapping`.
 
     Args:
         model: The PyTorch model to kernelize
@@ -255,12 +258,7 @@ def kernelize(
 
 def use_kernel_forward_from_hub(layer_name: str):
     """
-    Replace the forward function of a layer using a layer from the kernel hub.
-    This decorator can be applied to a layer and replaces the forward method
-    of the layer with that of a layer from the hub. The replacement is done
-    when a layer matching `layer_name` and device type is registered through
-    `register_layer_mapping`. The device type is inferred from the first
-    argument to `forward`.
+    Make a layer extensible using the name `layer_name`.
     """
 
     def decorator(cls):

--- a/tests/kernel_locking/kernels.lock
+++ b/tests/kernel_locking/kernels.lock
@@ -1,54 +1,82 @@
 [
   {
     "repo_id": "kernels-community/activation",
-    "sha": "6a030420d0dd33ffdc1281afc8ae8e94b4f4f9d0",
+    "sha": "fd6842e88f1f23f198551d78a4541b8eb07e0538",
     "variants": {
       "torch25-cxx11-cu118-x86_64-linux": {
-        "hash": "sha256-3e39de10721a6b21806834fc95c96526b9cfe2c2052829184f2d3fa48ef5849d",
+        "hash": "sha256-61e3e51b5b59b30d4a6ba943a5e6e4ef5a9c8260cc4bca40b9fb462c0777842b",
         "hash_type": "git_lfs_concat"
       },
       "torch25-cxx11-cu121-x86_64-linux": {
-        "hash": "sha256-b0dee22c65bb277fa8150f9ea3fc90e2b1c11f84b5d760bbf4ab9c7a4b102e58",
+        "hash": "sha256-baa6b872040730bd1d676c011381f6f626fb96189837b828f587c806af8994fa",
         "hash_type": "git_lfs_concat"
       },
       "torch25-cxx11-cu124-x86_64-linux": {
-        "hash": "sha256-8960cf857d641d591a7c2d4264925cc2bf7b4a6f9d738b74082b2fb0806db19a",
+        "hash": "sha256-c1ec7457847fa1f0e4ab43234dfc3cd0959977e03dc2ffe89b4f6b90970c7965",
         "hash_type": "git_lfs_concat"
       },
       "torch25-cxx98-cu118-x86_64-linux": {
-        "hash": "sha256-0496e04c2900a2dc7ab0f3b95fe8ce9da69faab6b5ca3f55ddd62c26c81268d0",
+        "hash": "sha256-412f9c841f20741e42f2c6cdb8c7da0e33ab436b219975acffe18b62b97ecd7c",
         "hash_type": "git_lfs_concat"
       },
       "torch25-cxx98-cu121-x86_64-linux": {
-        "hash": "sha256-172b793b24dfed3dcb9adc7d3487f260c05b310c598fc6ee8abb3e230c59a0a8",
+        "hash": "sha256-2fde7f97859506e000c1072b3916c0a75bc8cee750a9853ea8b68199e7b57bcd",
         "hash_type": "git_lfs_concat"
       },
       "torch25-cxx98-cu124-x86_64-linux": {
-        "hash": "sha256-12f5e66f32dc4cf4b21f43f76efad198556024da67a1ce28e88ea2d49ad8bdcc",
+        "hash": "sha256-93309986f39a64a5630378108154866f0545178fa8dfef9b8f8ccfef9a78608e",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx11-cu118-x86_64-linux": {
-        "hash": "sha256-bb70e2f36f0b4d12868956c2ad713c756570ff0e0eb4cf7fc3a78ebde617975b",
+        "hash": "sha256-3284d3c64b76d92c1ee930bce8013aff307f16eefb16c2d5dea9f2ca70e71e1f",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx11-cu124-x86_64-linux": {
-        "hash": "sha256-a745732eb9ec5d6a54565dbeec5b3c983cc6aa072a4a2576ab2fef9b2a600005",
+        "hash": "sha256-36a8c93773c08ddf8ef624a8a6b2866be26d1861450dfe1ecac0bed59f9ffa47",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch26-cxx11-cu126-aarch64-linux": {
+        "hash": "sha256-f5afb734520f587717665659798ff738a69e5ae1e34d4bd95624edd18fb165cd",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx11-cu126-x86_64-linux": {
-        "hash": "sha256-1160684ca09c065864f27c5c110281807a1ec31d603bf05fcb974e9e7cfe35cc",
+        "hash": "sha256-940841a7cb44f76c9a896d8b39f5bc0e0420f1c4c05ae9423da96778de4d1f2c",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx98-cu118-x86_64-linux": {
-        "hash": "sha256-24459d068943b93e4d55e94811469bf7e850d7958785132b108f1240724b846f",
+        "hash": "sha256-8e0f907830c3acc8c6bebfc162c744012ff6973e8110d7bf8ecd74b492418204",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx98-cu124-x86_64-linux": {
-        "hash": "sha256-5b009ba63ab6d52ac1aaf70057a2d0fa6ea5d1788a2416111be02103c6bcaaaf",
+        "hash": "sha256-0833414cbe658baec55b7ff63537cddccc973fe99e3c03008cced5e66e38b6c1",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch26-cxx98-cu126-aarch64-linux": {
+        "hash": "sha256-d94fa59a13a5b623b2071aadcd1e6c8477c4d557fd06ad144f15b46b1fc71aab",
         "hash_type": "git_lfs_concat"
       },
       "torch26-cxx98-cu126-x86_64-linux": {
-        "hash": "sha256-05128889b4bdaf9ef58f3c07d93218deaa08e06f9121931b47efef8826482e4a",
+        "hash": "sha256-64784f5f2f9e232d0f2fd824fbc47eadde505e3c232f351bead5b04c429c65c2",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch27-cxx11-cu118-x86_64-linux": {
+        "hash": "sha256-bcba3765f061649bac0e5a9159bea8349ced4780e24a2330aa62ce0f8d3a9d78",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch27-cxx11-cu126-aarch64-linux": {
+        "hash": "sha256-e4625df5706af025c70bd824d952b928d9a2965eeaefda72fc47be0fae680c5e",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch27-cxx11-cu126-x86_64-linux": {
+        "hash": "sha256-7d7d3e655f34a7b03d5603d7c1ab723ef3efc823291762421a8b3a4aa51bd405",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch27-cxx11-cu128-aarch64-linux": {
+        "hash": "sha256-60e076194dcd55b32c5aca72f09816cba0fff52f340c8a063b17ff0577154d99",
+        "hash_type": "git_lfs_concat"
+      },
+      "torch27-cxx11-cu128-x86_64-linux": {
+        "hash": "sha256-f0a3802382efdcd78b40601187a9c416579a24ef2ed5a60d2296ef0951a89597",
         "hash_type": "git_lfs_concat"
       }
     }


### PR DESCRIPTION
This PR updates the flow of replace_kernel_forward_from_hub to ensure the appropriate forward pass is selected before model compilation. It introduces a new function `kernelize` that can be called to replace the forward before the model is compiled. It can also be called after registering new kernels for more flexibility