### PR TITLE
Add `get_local_kernel` function

### DIFF
--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -9,6 +9,7 @@ from kernels.layer import (
 )
 from kernels.utils import (
     get_kernel,
+    get_local_kernel,
     get_locked_kernel,
     has_kernel,
     install_kernel,
@@ -17,6 +18,7 @@ from kernels.utils import (
 
 __all__ = [
     "get_kernel",
+    "get_local_kernel",
     "get_locked_kernel",
     "has_kernel",
     "load_kernel",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,12 +1,20 @@
 import pytest
 import torch
 
-from kernels import get_kernel, has_kernel
+from kernels import get_kernel, get_local_kernel, has_kernel, install_kernel
 
 
 @pytest.fixture
 def kernel():
     return get_kernel("kernels-community/activation")
+
+
+@pytest.fixture
+def local_kernel():
+    package_name, path = install_kernel("kernels-community/activation", "main")
+    # Path is the build variant path (build/torch-<...>), so the grandparent
+    # is the kernel repository path.
+    return get_local_kernel(path.parent.parent, package_name)
 
 
 @pytest.fixture
@@ -32,6 +40,22 @@ def test_gelu_fast(kernel, device):
     y = torch.empty_like(x)
 
     kernel.gelu_fast(y, x)
+
+    expected = torch.tensor(
+        [[0.8408, 1.9551, 2.9961], [4.0000, 5.0000, 6.0000], [7.0000, 8.0000, 9.0000]],
+        device=device,
+        dtype=torch.float16,
+    )
+
+    assert torch.allclose(y, expected)
+
+
+@pytest.mark.linux_only
+def test_local_kernel(local_kernel, device):
+    x = torch.arange(1, 10, dtype=torch.float16, device=device).view(3, 3)
+    y = torch.empty_like(x)
+
+    local_kernel.gelu_fast(y, x)
 
     expected = torch.tensor(
         [[0.8408, 1.9551, 2.9961], [4.0000, 5.0000, 6.0000], [7.0000, 8.0000, 9.0000]],


### PR DESCRIPTION
This function loads a kernel from a local repository (e.g. the output of kernel-builder), which can be handy for testing.