### PR TITLE
Support registering inference/training-specific layers

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -164,9 +164,9 @@ kernel_layer_mapping = {
 }
 ```
 
-The kernels will matched exactly on the mode. So, for instance, no kernel
-layer is used when the `mode` passed to `kernelized` is
-`Mode.INFERENCE | Mode.TORCH_COMPILE` or `Mode.TRAINING`. If you want to
+The kernels will match exactly on the mode. So, for instance in the example above, no kernel
+layer is used when the `mode` passed to `kernelize` is
+`Mode.INFERENCE | Mode.TORCH_COMPILE` or `Mode.TRAINING`. However, if you want to
 register a kernel to be used when the mode does not match any of the
 modes in the mapping, you can use the special `Mode.DEFAULT` mode to do
 so. For example:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta"
 
 [dependency-groups]
 dev = [
-  "mypy == 1.14.1",
+  "mypy >= 1.15.0",
   "pytest >=8",
   # Whatever version is compatible with pytest.
   "pytest-benchmark",

--- a/src/kernels/__init__.py
+++ b/src/kernels/__init__.py
@@ -1,6 +1,7 @@
 from kernels.layer import (
     Device,
     LayerRepository,
+    Mode,
     kernelize,
     register_kernel_mapping,
     replace_kernel_forward_from_hub,
@@ -17,17 +18,18 @@ from kernels.utils import (
 )
 
 __all__ = [
+    "Device",
+    "LayerRepository",
+    "Mode",
     "get_kernel",
     "get_local_kernel",
     "get_locked_kernel",
     "has_kernel",
-    "load_kernel",
     "install_kernel",
-    "use_kernel_forward_from_hub",
-    "use_kernel_mapping",
+    "kernelize",
+    "load_kernel",
     "register_kernel_mapping",
     "replace_kernel_forward_from_hub",
-    "LayerRepository",
-    "Device",
-    "kernelize",
+    "use_kernel_forward_from_hub",
+    "use_kernel_mapping",
 ]

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -56,6 +56,9 @@ class Mode(Flag):
         if Mode.INFERENCE in union and Mode.TRAINING in union:
             raise ValueError("Mode.INFERENCE and Mode.TRAINING are mutually exclusive.")
 
+        if len(union) > 1 and Mode.DEFAULT in union:
+            raise ValueError("Mode.DEFAULT cannot be combined with other modes.")
+
         return union
 
 
@@ -242,6 +245,9 @@ def kernelize(
 
     if mode == Mode.DEFAULT:
         raise ValueError("Mode.DEFAULT can only be used to register kernel mappings.")
+
+    if Mode.INFERENCE not in mode and Mode.TRAINING not in mode:
+        raise ValueError("kernelize mode must contain Mode.INFERENCE or Mode.TRAINING.")
 
     if device is None:
         device_type = _find_device(model)

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -411,8 +411,11 @@ def _conditionally_replace_forward(
 ):
     module_class = type(module)
 
-    # Switch to fallback if the mode is not supported
-    # by the given layer.
+    # Switch to fallback if the mode is not supported by the layer.
+    # Note that this is useful even after _validate_layer_has_mode because
+    # layers registered with the DEFAULT mode never get rejected by
+    # _validate_layer_has_mode. For such layers, we want to fall back in
+    # case the layer does not support the given mode.
     needs_fallback = Mode.TORCH_COMPILE in mode and not getattr(
         layer, "can_torch_compile", False
     )

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
 import inspect
 import os
 import warnings
 from contextvars import ContextVar
 from copy import deepcopy
 from dataclasses import dataclass, field
+from enum import Flag, auto
 from types import MethodType
-from typing import TYPE_CHECKING, Dict, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from .utils import get_kernel
 
@@ -15,6 +25,38 @@ if TYPE_CHECKING:
 
 
 _DISABLE_KERNEL_MAPPING: bool = bool(int(os.environ.get("DISABLE_KERNEL_MAPPING", "0")))
+
+
+class Mode(Flag):
+    """
+    Kernelize mode
+
+    The `Mode` flag is used by `kernelize` to select kernels for the given
+    mode. Mappings can be registered for specific modes.
+
+    * `INFERENCE`: The kernel is used for inference.
+    * `TRAINING`: The kernel is used for training.
+    * `TORCH_COMPILE`: The kernel is used with `torch.compile`.
+    * `DEFAULT`: In a kernel mapping, this kernel that is used when no other mode
+       matches.
+
+    Different modes can be combined. For instance, `INFERENCE | TORCH_COMPILE`
+    should be used for layers that are used for inference *with* `torch.compile`.
+    """
+
+    _NONE = 0
+    DEFAULT = auto()
+    TRAINING = auto()
+    INFERENCE = auto()
+    TORCH_COMPILE = auto()
+
+    def __or__(self, other: Mode) -> Mode:
+        union = super().__or__(other)
+
+        if Mode.INFERENCE in union and Mode.TRAINING in union:
+            raise ValueError("Mode.INFERENCE and Mode.TRAINING are mutually exclusive.")
+
+        return union
 
 
 @dataclass(frozen=True)
@@ -59,13 +101,16 @@ class LayerRepository:
 _CACHED_LAYER: Dict[LayerRepository, Type["nn.Module"]] = {}
 
 
-_KERNEL_MAPPING: ContextVar[Dict[str, Dict[Device, LayerRepository]]] = ContextVar(
-    "_KERNEL_MAPPING", default={}
+_KERNEL_MAPPING: ContextVar[Dict[str, Dict[Device, Dict[Mode, LayerRepository]]]] = (
+    ContextVar("_KERNEL_MAPPING", default={})
 )
 
 
 def use_kernel_mapping(
-    mapping: Dict[str, Dict[Union[Device, str], LayerRepository]],
+    mapping: Dict[
+        str,
+        Dict[Union[Device, str], Union[LayerRepository, Dict[Mode, LayerRepository]]],
+    ],
     *,
     inherit_mapping: bool = True,
 ):
@@ -93,14 +138,17 @@ def use_kernel_mapping(
 
 
 def register_kernel_mapping(
-    mapping: Dict[str, Dict[Union[Device, str], LayerRepository]],
+    mapping: Dict[
+        str,
+        Dict[Union[Device, str], Union[LayerRepository, Dict[Mode, LayerRepository]]],
+    ],
 ):
     """
-    Allows one to register a mapping between a layer name the corresponding
-    kernel to use, depending on the device. This should be use in conjunction
+    Allows one to register a mapping between a layer name and the corresponding
+    kernel(s) to use, depending on the device. This should be used in conjunction
     with `kernelize`.
 
-    Exemple usage:
+    Example usage:
 
     ```python
     from kernels import LayerRepository, register_kernel_mapping
@@ -121,10 +169,16 @@ def register_kernel_mapping(
     for new_kernel, new_device_repos in mapping.items():
         device_repo = _KERNEL_MAPPING.get().setdefault(new_kernel, {})
         for new_device, new_repo in new_device_repos.items():
-            if isinstance(new_device, str):
-                device_repo[Device(type=new_device)] = new_repo
+            device = (
+                Device(type=new_device) if isinstance(new_device, str) else new_device
+            )
+
+            if isinstance(new_repo, LayerRepository):
+                kernel_options = {Mode.DEFAULT: new_repo}
             else:
-                device_repo[new_device] = new_repo
+                kernel_options = new_repo
+
+            device_repo[device] = kernel_options
 
 
 def replace_kernel_forward_from_hub(
@@ -145,10 +199,24 @@ def replace_kernel_forward_from_hub(
     cls.kernel_layer_name = layer_name
 
 
+def _select_repository(
+    repositories: Dict[Mode, LayerRepository],
+    *,
+    mode: Mode,
+) -> Optional[Tuple[LayerRepository, Mode]]:
+    if mode in repositories:
+        return (repositories[mode], mode)
+    elif Mode.DEFAULT in repositories:
+        return (repositories[Mode.DEFAULT], Mode.DEFAULT)
+    else:
+        return None
+
+
 def kernelize(
     model: "nn.Module",
+    *,
+    mode: Mode,
     device: Optional[Union[str, "torch.device"]] = None,
-    needs_torch_compile: bool = False,
     use_fallback: bool = True,
 ):
     """
@@ -158,10 +226,11 @@ def kernelize(
 
     Args:
         model: The PyTorch model to kernelize
+        mode: the mode that the kernel is going to be used in (e.g.
+            `Mode.TRAINING | Mode.TORCH_COMPILE` kernelizes the model for training
+            and `torch.compile`).
         device: The device type to load kernels for. The device type will be inferred
             from the parameters of the model when not provided.
-        needs_torch_compile: When set to `true`, only kernels that support
-            `torch.compile` will be loaded.
         use_fallback: Whether to use the original forward method of modules when no
             compatible kernel could be found. If set to `False`, an exception will
             be raised in such cases.
@@ -170,6 +239,9 @@ def kernelize(
         The kernelized model
     """
     import torch
+
+    if mode == Mode.DEFAULT:
+        raise ValueError("Mode.DEFAULT can only be used to register kernel mappings.")
 
     if device is None:
         device_type = _find_device(model)
@@ -203,10 +275,10 @@ def kernelize(
             _replace_forward(module, module_class)
             continue
 
-        # Use device type string directly instead of Device object
-        repo = kernel.get(device_type)
+        # Get kernel options for the device
+        repos = kernel.get(device_type)
 
-        if repo is None:
+        if repos is None:
             if not use_fallback:
                 raise ValueError(
                     f"No layer mapping for `{layer_name}` with device type `{device_type}`"
@@ -214,32 +286,35 @@ def kernelize(
             _replace_forward(module, module_class)
             continue
 
-        # Short-circuit if we already loaded the layer.
-        layer = _CACHED_LAYER.get(repo, None)
-        if layer is not None:
-            _conditionally_replace_forward(
-                module=module,
-                layer=layer,
-                needs_torch_compile=needs_torch_compile,
-                use_fallback=use_fallback,
-            )
-            continue
-
-        layer = _get_kernel_layer(
-            repo_id=repo.repo_id,
-            layer_name=repo.layer_name,
-            revision=repo.revision,
+        repo_with_mode = _select_repository(
+            repos,
+            mode=mode,
         )
 
-        # Validate the replacement layer against the class layer.
-        _validate_layer(check_cls=module_class, cls=layer)
+        if repo_with_mode is None:
+            if not use_fallback:
+                raise ValueError(
+                    f"No repository for `{layer_name}` for configuration mode={mode}"
+                )
+            _replace_forward(module, module_class)
+            continue
 
-        _CACHED_LAYER[repo] = layer
+        repo, repo_mode = repo_with_mode
+
+        layer = _get_layer_memoize(repo, module_class)
+
+        # Ideally we would do validation on the mapping where we check that
+        # e.g. if a repo class is registered for TRAINING | TORCH_COMPILE,
+        # the actual layer is compatible with that. Unfortunately, this would
+        # mean that we have to pre-download everything.
+        _validate_layer_has_mode(
+            layer_name=layer_name, module=layer, repo=repo, repo_mode=repo_mode
+        )
 
         _conditionally_replace_forward(
             module=module,
             layer=layer,
-            needs_torch_compile=needs_torch_compile,
+            mode=mode,
             use_fallback=use_fallback,
         )
 
@@ -331,45 +406,72 @@ def _conditionally_replace_forward(
     *,
     module: "nn.Module",
     layer: Type["nn.Module"],
-    needs_torch_compile: bool,
+    mode: Mode,
     use_fallback: bool,
 ):
     module_class = type(module)
 
-    # Switch to fallback when the layer does not support:
-    # compilation/compile when needed.
-    # backward when needed
-    needs_fallback = needs_torch_compile and not getattr(
+    # Switch to fallback if the mode is not supported
+    # by the given layer.
+    needs_fallback = Mode.TORCH_COMPILE in mode and not getattr(
         layer, "can_torch_compile", False
     )
+    needs_fallback |= Mode.TRAINING in mode and not getattr(layer, "has_backward", True)
+
     if needs_fallback:
         if use_fallback:
             _replace_forward(module, module_class)
         else:
-            raise ValueError(
-                f"Available kernel does not fulfill requirements: needs_torch_compile={needs_torch_compile}"
-            )
+            raise ValueError(f"Available kernel does not support mode: {mode}")
     else:
         _replace_forward(module, layer)
 
 
 def _replace_forward(module: "nn.Module", layer: Type["nn.Module"]):
-    import torch.nn as nn
+    module.forward = MethodType(layer.forward, module)  # type: ignore[method-assign]
 
-    module_class = type(module)
-    layer_with_backward = (
-        layer if getattr(layer, "has_backward", True) else module_class
+
+def _validate_layer_has_mode(
+    *,
+    layer_name: str,
+    module: Type["nn.Module"],
+    repo: LayerRepository,
+    repo_mode: Mode,
+):
+    """
+    Check that a repository supports the mode that it was registered for.
+    """
+
+    if Mode.TRAINING in repo_mode and not getattr(module, "has_backward", True):
+        raise ValueError(
+            f"Layer `{repo.layer_name}` ({repo.repo_id}, revision: {repo.revision}) does not support backward.\n"
+            f"Was registered for `{layer_name}` with mode `{repo_mode}`"
+        )
+
+    if Mode.TORCH_COMPILE in repo_mode and not getattr(
+        module, "can_torch_compile", False
+    ):
+        raise ValueError(
+            f"Layer `{repo.layer_name}` ({repo.repo_id}, revision: {repo.revision}) does not support torch.compile.\n"
+            f"Was registered for `{layer_name}` with mode `{repo_mode}`"
+        )
+
+    return True
+
+
+def _get_layer_memoize(
+    repo: LayerRepository, module_class: Type["nn.Module"]
+) -> Type["nn.Module"]:
+    layer = _CACHED_LAYER.get(repo, None)
+    if layer is not None:
+        return layer
+
+    layer = _get_kernel_layer(
+        repo_id=repo.repo_id,
+        layer_name=repo.layer_name,
+        revision=repo.revision,
     )
+    _validate_layer(check_cls=module_class, cls=layer)
+    _CACHED_LAYER[repo] = layer
 
-    def train(self, mode: bool = True) -> nn.Module:
-        super(type(self), self).train(mode)
-        if mode:
-            self.forward = MethodType(layer_with_backward.forward, self)
-        else:
-            self.forward = MethodType(layer.forward, self)
-        return self
-
-    module.train = MethodType(train, module)  # type: ignore[method-assign]
-
-    # Trigger setting correct forward for the current state.
-    module.train(module.training)
+    return layer

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -56,7 +56,7 @@ class Mode(Flag):
         if Mode.INFERENCE in union and Mode.TRAINING in union:
             raise ValueError("Mode.INFERENCE and Mode.TRAINING are mutually exclusive.")
 
-        if union != Mode.DEFAULT and Mode.DEFAULT in union:
+        if Mode.DEFAULT in union and union != Mode.DEFAULT:
             raise ValueError("Mode.DEFAULT cannot be combined with other modes.")
 
         return union

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -37,7 +37,7 @@ class Mode(Flag):
     * `INFERENCE`: The kernel is used for inference.
     * `TRAINING`: The kernel is used for training.
     * `TORCH_COMPILE`: The kernel is used with `torch.compile`.
-    * `DEFAULT`: In a kernel mapping, this kernel that is used when no other mode
+    * `DEFAULT`: In a kernel mapping, this kernel is used when no other mode
        matches.
 
     Different modes can be combined. For instance, `INFERENCE | TORCH_COMPILE`

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -246,7 +246,10 @@ def kernelize(
     if mode == Mode.DEFAULT:
         raise ValueError("Mode.DEFAULT can only be used to register kernel mappings.")
 
-    if Mode.INFERENCE not in mode and Mode.TRAINING not in mode:
+    # Type check ignored because this causes a false negative on Python < 3.11.
+    # Looks similar to: https://github.com/python/mypy/issues/9642
+    # Remove once we start doing typing checks on >= 3.11.
+    if Mode.INFERENCE not in mode and Mode.TRAINING not in mode:  # type: ignore[operator]
         raise ValueError("kernelize mode must contain Mode.INFERENCE or Mode.TRAINING.")
 
     if device is None:

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -56,7 +56,7 @@ class Mode(Flag):
         if Mode.INFERENCE in union and Mode.TRAINING in union:
             raise ValueError("Mode.INFERENCE and Mode.TRAINING are mutually exclusive.")
 
-        if len(union) > 1 and Mode.DEFAULT in union:
+        if union != Mode.DEFAULT and Mode.DEFAULT in union:
             raise ValueError("Mode.DEFAULT cannot be combined with other modes.")
 
         return union

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -494,10 +494,10 @@ def test_fallback_used_when_training():
 
 def test_invalid_mode_rejected():
     with pytest.raises(ValueError, match="mutually exclusive"):
-        Mode.INFERENCE | Mode.TRAINING
+        _ = Mode.INFERENCE | Mode.TRAINING
 
     with pytest.raises(ValueError, match="cannot be combined with other modes"):
-        Mode.DEFAULT | Mode.TORCH_COMPILE
+        _ = Mode.DEFAULT | Mode.TORCH_COMPILE
 
     with pytest.raises(
         ValueError, match="can only be used to register kernel mappings"

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -494,10 +494,10 @@ def test_fallback_used_when_training():
 
 def test_invalid_mode_rejected():
     with pytest.raises(ValueError, match="mutually exclusive"):
-        mode = Mode.INFERENCE | Mode.TRAINING
+        Mode.INFERENCE | Mode.TRAINING
 
     with pytest.raises(ValueError, match="cannot be combined with other modes"):
-        mode = Mode.DEFAULT | Mode.TORCH_COMPILE
+        Mode.DEFAULT | Mode.TORCH_COMPILE
 
     with pytest.raises(
         ValueError, match="can only be used to register kernel mappings"


### PR DESCRIPTION
This change makes it possible to register kernels specialized for inference, training, and/or `torch.compile`. To do so, the mapping notation is extended to support registering specialized kernels for a specific 'mode'. For instance, the following mapping,

```python
kernel_layer_mapping = {
    "SiluAndMul": {
        "cuda": {
          Mode.DEFAULT: LayerRepository(
              repo_id="kernels-community/activation",
              layer_name="SiluAndMul",
          ),
          Mode.TRAINING | Mode.TORCH_COMPILE: LayerRepository(
              repo_id="kernels-community/activation-training-optimized",
              layer_name="SiluAndMul",
          ),
      }
    }
}
```

uses `kernels-community/activation` by default, but will switch to using `kernels-community/activation-training-optimized` if a model is kernelized for training and `torch.compile`. The 'old' way of registering kernels is still supported and will register a kernel as `Mode.DEFAULT`.

To make it easier to add more modes in the future and to unify the `register_kernel_mapping` and `kernelize` signatures, the `training` and `needs_torch_compile` arguments of `kernelize` are replaced by a single `mode` argument:

```python
model = MyModel(...)
model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE)
```

This change also removes the automatic `forward` updates when switching a model from eval to training or vice versa (we prefer explicitness).