### PR TITLE
Improve mode handling

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -174,14 +174,14 @@ The kernels will match exactly on the mode. So, for instance in the example abov
 layer is used when the `mode` passed to `kernelize` is
 `Mode.INFERENCE | Mode.TORCH_COMPILE` or `Mode.TRAINING`. However, if you want to
 register a kernel to be used when the mode does not match any of the
-modes in the mapping, you can use the special `Mode.DEFAULT` mode to do
+modes in the mapping, you can use the special `Mode.FALLBACK` mode to do
 so. For example:
 
 ```python
 kernel_layer_mapping = {
     "SiluAndMul": {
         "cuda": {
-            Mode.DEFAULT: LayerRepository(
+            Mode.FALLBACK: LayerRepository(
                 repo_id="kernels-community/activation",
                 layer_name="SiluAndMul",
             ),
@@ -205,13 +205,13 @@ In this case, modes other than `Mode.INFERENCE` and
 ### Mode fallback behavior
 
 As described above, if there is no exact match for the mode given to
-`kernelize`, it will try to use the kernel registered for `Mode.DEFAULT`.
-If the `Mode.DEFAULT` kernel does not support the `kernelize` mode, the
+`kernelize`, it will try to use the kernel registered for `Mode.FALLBACK`.
+If the `Mode.FALLBACK` kernel does not support the `kernelize` mode, the
 original layer's `forward` method will be used instead.
 
 As an example, suppose that two kernels were registered for a layer:
 
-1. Kernel `A` is registered for `Mode.DEFAULT`. This kernel supports training
+1. Kernel `A` is registered for `Mode.FALLBACK`. This kernel supports training
    (backward), but not `torch.compile`.
 2. Kernel `B` is registered for `Mode.INFERENCE | Mode.COMPILE` and supports
    `torch.compile`.
@@ -220,11 +220,11 @@ As an example, suppose that two kernels were registered for a layer:
 
 - `Mode.INFERENCE | Mode.COMPILE`` uses kernel `B`: exact match.
 - `Mode.INFERENCE` uses kernel `A`: no exact match, so fall back to
-  `Mode.DEFAULT`.
+  `Mode.FALLBACK`.
 - `Mode.TRAIN` uses kernel `A`: no exact match, so fall back to
-  `Mode.DEFAULT`, which supports training.
+  `Mode.FALLBACK`, which supports training.
 - `Mode.TRAIN | Mode.COMPILE`: uses the original layer's
-  `forward`: no exact match, falling back to `Mode.DEFAULT` is not possible
+  `forward`: no exact match, falling back to `Mode.FALLBACK` is not possible
   because kernel `A` does not support `torch.compile`.
 
 ### Registering kernels for specific CUDA capabilities

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -67,7 +67,8 @@ model = kernelize(model, mode=Mode.TRAINING)
 ```
 
 A model that is kernelized for training can also be used for inference, but
-not the other way around.
+not the other way around. If you want to change the mode of the kernelized
+model, you can just run `kernelize` on the model again with the new mode.
 
 If you want to compile a model with `torch.compile`, this should be indicated
 in the mode as well. You can do this by combining `Mode.INFERENCE` or

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -325,7 +325,7 @@ def _select_repository(
 def kernelize(
     model: "nn.Module",
     *,
-    mode: Mode,
+    mode: Mode = Mode.TRAINING | Mode.TORCH_COMPILE,
     device: Optional[Union[str, "torch.device"]] = None,
     use_fallback: bool = True,
 ):

--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -41,7 +41,7 @@ class Mode(Flag):
     * `INFERENCE`: The kernel is used for inference.
     * `TRAINING`: The kernel is used for training.
     * `TORCH_COMPILE`: The kernel is used with `torch.compile`.
-    * `DEFAULT`: In a kernel mapping, this kernel is used when no other mode
+    * `FALLBACK`: In a kernel mapping, this kernel is used when no other mode
        matches.
 
     Different modes can be combined. For instance, `INFERENCE | TORCH_COMPILE`
@@ -49,7 +49,7 @@ class Mode(Flag):
     """
 
     _NONE = 0
-    DEFAULT = auto()
+    FALLBACK = auto()
     TRAINING = auto()
     INFERENCE = auto()
     TORCH_COMPILE = auto()
@@ -60,8 +60,8 @@ class Mode(Flag):
         if Mode.INFERENCE in union and Mode.TRAINING in union:
             raise ValueError("Mode.INFERENCE and Mode.TRAINING are mutually exclusive.")
 
-        if Mode.DEFAULT in union and union != Mode.DEFAULT:
-            raise ValueError("Mode.DEFAULT cannot be combined with other modes.")
+        if Mode.FALLBACK in union and union != Mode.FALLBACK:
+            raise ValueError("Mode.FALLBACK cannot be combined with other modes.")
 
         return union
 
@@ -283,7 +283,7 @@ def register_kernel_mapping(
             )
 
             if isinstance(new_repo, LayerRepository):
-                kernel_options = {Mode.DEFAULT: new_repo}
+                kernel_options = {Mode.FALLBACK: new_repo}
             else:
                 kernel_options = new_repo
 
@@ -316,8 +316,8 @@ def _select_repository(
 ) -> Optional[Tuple[LayerRepository, Mode]]:
     if mode in repositories:
         return (repositories[mode], mode)
-    elif Mode.DEFAULT in repositories:
-        return (repositories[Mode.DEFAULT], Mode.DEFAULT)
+    elif Mode.FALLBACK in repositories:
+        return (repositories[Mode.FALLBACK], Mode.FALLBACK)
     else:
         return None
 
@@ -350,8 +350,8 @@ def kernelize(
     """
     import torch
 
-    if mode == Mode.DEFAULT:
-        raise ValueError("Mode.DEFAULT can only be used to register kernel mappings.")
+    if mode == Mode.FALLBACK:
+        raise ValueError("Mode.FALLBACK can only be used to register kernel mappings.")
 
     # Type check ignored because this causes a false negative on Python < 3.11.
     # Looks similar to: https://github.com/python/mypy/issues/9642
@@ -548,7 +548,7 @@ def _conditionally_replace_forward(
 
     # Switch to fallback if the mode is not supported by the layer.
     # Note that this is useful even after _validate_layer_has_mode because
-    # layers registered with the DEFAULT mode never get rejected by
+    # layers registered with the FALLBACK mode never get rejected by
     # _validate_layer_has_mode. For such layers, we want to fall back in
     # case the layer does not support the given mode.
     needs_fallback = Mode.TORCH_COMPILE in mode and not getattr(

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -281,7 +281,7 @@ def test_mapping_contexts():
                 "TestKernel",
             }
             assert (
-                _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.DEFAULT].repo_id
+                _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.FALLBACK].repo_id
                 == "kernels-community/non-existing"
             )
 
@@ -292,7 +292,7 @@ def test_mapping_contexts():
             "TestKernel",
         }
         assert (
-            _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.DEFAULT].repo_id
+            _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.FALLBACK].repo_id
             == "kernels-community/activation"
         )
 
@@ -301,7 +301,7 @@ def test_mapping_contexts():
                 "SiluAndMul",
             }
             assert (
-                _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.DEFAULT].repo_id
+                _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.FALLBACK].repo_id
                 == "kernels-community/non-existing"
             )
 
@@ -312,7 +312,7 @@ def test_mapping_contexts():
             "TestKernel",
         }
         assert (
-            _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.DEFAULT].repo_id
+            _KERNEL_MAPPING.get()["SiluAndMul"]["cuda"].repos[Mode.FALLBACK].repo_id
             == "kernels-community/activation"
         )
 
@@ -445,7 +445,7 @@ def test_kernel_modes():
         {
             "Linear": {
                 "cuda": {
-                    Mode.DEFAULT: LayerRepository(
+                    Mode.FALLBACK: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
                     ),
@@ -569,12 +569,12 @@ def test_invalid_mode_rejected():
         _ = Mode.INFERENCE | Mode.TRAINING
 
     with pytest.raises(ValueError, match="cannot be combined with other modes"):
-        _ = Mode.DEFAULT | Mode.TORCH_COMPILE
+        _ = Mode.FALLBACK | Mode.TORCH_COMPILE
 
     with pytest.raises(
         ValueError, match="can only be used to register kernel mappings"
     ):
-        kernelize(torch.nn.Linear(32, 32), mode=Mode.DEFAULT)
+        kernelize(torch.nn.Linear(32, 32), mode=Mode.FALLBACK)
 
     with pytest.raises(ValueError, match="mode must contain"):
         kernelize(torch.nn.Linear(32, 32), mode=Mode.TORCH_COMPILE)


### PR DESCRIPTION
This introduces a fallback chain when a `kernelize` mode cannot be matched exactly:

- `INFERENCE`: `INFERENCE` → `INFERENCE | TORCH_COMPILE` → `TRAINING` →
  `TRAINING | TORCH_COMPILE` → `FALLBACK`
- `INFERENCE | TORCH_COMPILE`: `INFERENCE | TORCH_COMPILE` →
  `TRAINING | TORCH_COMPILE` → `FALLBACK`
- `TRAINING`: `TRAINING` → `TRAINING | TORCH_COMPILE` → `FALLBACK`
- `TRAINING | TORCH_COMPILE`: `TRAINING | TORCH_COMPILE` → `FALLBACK`

Also set the default mode for `kernelize` to `TRAINING | TORCH_COMPILE`.