### PR TITLE
triton based kernel could also run in xpu

### DIFF
--- a/src/kernels/utils.py
+++ b/src/kernels/utils.py
@@ -46,9 +46,11 @@ def build_variant() -> str:
         compute_framework = f"rocm{rocm_version.major}{rocm_version.minor}"
     elif torch.backends.mps.is_available():
         compute_framework = "metal"
+    elif hasattr(torch, "xpu") and torch.xpu.is_available():
+        compute_framework = "xpu"
     else:
         raise AssertionError(
-            "Torch was not compiled with CUDA, Metal, or ROCm enabled."
+            "Torch was not compiled with CUDA, Metal, XPU, or ROCm enabled."
         )
 
     torch_version = parse(torch.__version__)


### PR DESCRIPTION
from kernels import get_kernel
import torch
universal_kernel = get_kernel("kernels-community/triton-scaled-mm")
torch.manual_seed(0)
A = torch.randint(-10, 10, (64, 128), dtype=torch.int8, device="xpu")
B = torch.randint(-10, 10, (128, 96), dtype=torch.int8, device="xpu")
scale_a = torch.tensor(0.4, dtype=torch.float16, device="xpu")
scale_b = torch.tensor(0.6, dtype=torch.float16, device="xpu")
out = universal_kernel.triton_scaled_mm(A, B, scale_a, scale_b, torch.float16)
print(out)
