### PR TITLE
feat: add custom type for kernel modules

### DIFF
--- a/src/kernels/utils.py
+++ b/src/kernels/utils.py
@@ -73,7 +73,7 @@ def universal_build_variant() -> str:
 
 # Custom module type to identify dynamically loaded kernel modules.
 # Using a subclass lets us distinguish these from regular imports.
-class _KernelModule(ModuleType):
+class _KernelModuleType(ModuleType):
     """Marker class for modules loaded dynamically from a path."""
     module_name: str
     is_kernel: bool = True
@@ -95,7 +95,7 @@ def import_from_path(module_name: str, file_path: Path) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     if module is None:
         raise ImportError(f"Cannot load module {module_name} from spec")
-    module.__class__ = _KernelModule
+    module.__class__ = _KernelModuleType
     module.module_name = module_name
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore


### PR DESCRIPTION
This PR includes a subclass of the `ModuleType` type to mark dynamically loaded kernels as `_KernelModuleType`


```bash
uv run typed-kernels.py
```

```python
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "accelerate",
#     "torch==2.7.0",
#     "transformers",
#     "kernels",
#     "ipdb",
# ]
#
# [tool.uv.sources]
# transformers = { git = "https://github.com/drbh/transformers.git", branch = "allow-kernel-rev" }
# kernels = { path = "../kernels", editable = true }
# ///
import torch

from kernels import get_kernel

# Download optimized kernels from the Hugging Face hub
activation = get_kernel("kernels-community/activation")

print(torch)
print(activation)
print(activation.is_kernel)
print(type(activation))
```

output

```txt
Fetching 7 files: 100%|████████████████████████████████████████████████████| 7/7 [00:00<00:00, 119350.11it/s]
<module 'torch' from '/home/ubuntu/.cache/uv/environments-v2/kern-type-b885b03600690c7b/lib/python3.13/site-packages/torch/__init__.py'>
<class 'module'>
<kernel_module 'activation_68e410966316795f' from '/home/ubuntu/.cache/huggingface/hub/models--kernels-community--activation/snapshots/2fafa6a3a38ccb57a1a98419047cf7816ecbc071/build/torch27-cxx11-cu126-x86_64-linux/activation/__init__.py'>
True
<class 'kernel_module'>
```