### PR TITLE
feat: improve get local kernel importing

### DIFF
--- a/src/kernels/utils.py
+++ b/src/kernels/utils.py
@@ -259,7 +259,7 @@ def get_local_kernel(repo_path: Path, package_name: str) -> ModuleType:
             if package_path.exists():
                 return import_from_path(package_name, package_path)
 
-    # If we didn't find the package in the repo we may have a explicit 
+    # If we didn't find the package in the repo we may have a explicit
     # package path.
     package_path = repo_path / package_name / "__init__.py"
     if package_path.exists():


### PR DESCRIPTION
This PR update the `get_local_kernel` function to handle more paths and infer the variant if needed.

These changes handle specifying the top level of the kernel repo or a specific variant directory as shown in the example below 

```bash
git clone https://huggingface.co/kernels-community/activation
uv run get-local.py
```

```python
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "numpy",
#     "torch==2.7.0",
#     "kernels",
# ]
#
# [tool.uv.sources]
# kernels = { git = "https://github.com/huggingface/kernels.git", branch = "improve-get-local-kernel" }
# ///
import torch
from kernels import get_local_kernel
from pathlib import Path

# set seed for reproducibility
torch.manual_seed(0)

activation = get_local_kernel(
    repo_path=Path("./activation"),
    # repo_path=Path("/home/ubuntu/.cache/huggingface/hub/models--kernels-community--activation/snapshots/2fafa6a3a38ccb57a1a98419047cf7816ecbc071/"),
    # repo_path=Path("activation/build/torch27-cxx11-cu126-x86_64-linux"),
    package_name="activation",
)

print(activation)

# Random tensor
x = torch.randn((10, 10), dtype=torch.float16, device="cuda")

# Run the kernel
y = torch.empty_like(x)
activation.gelu_fast(y, x)

# print(y)
sum_of_y = y.sum().item()
print(f"Sum of y: {sum_of_y}")
```