### PR TITLE
fix: add get local tests

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -144,7 +144,9 @@ def test_version():
         get_kernel("kernels-test/versions", version=">0.2.0")
 
     with pytest.raises(ValueError, match=r"Either a revision or a version.*not both"):
-        kernel = get_kernel("kernels-test/versions", revision="v0.1.0", version="<1.0.0")
+        kernel = get_kernel(
+            "kernels-test/versions", revision="v0.1.0", version="<1.0.0"
+        )
 
 
 @pytest.mark.cuda_only

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,7 +77,7 @@ def test_local_kernel_path_types(local_kernel_path, device):
     package_name, path = local_kernel_path
 
     # Top-level repo path
-    print(path.parent.parent)
+    # ie: /home/ubuntu/.cache/huggingface/hub/models--kernels-community--activation/snapshots/2fafa6a3a38ccb57a1a98419047cf7816ecbc071
     kernel = get_local_kernel(path.parent.parent, package_name)
     x = torch.arange(1, 10, dtype=torch.float16, device=device).view(3, 3)
     y = torch.empty_like(x)
@@ -91,20 +91,18 @@ def test_local_kernel_path_types(local_kernel_path, device):
     assert torch.allclose(y, expected)
 
     # Build directory path
-    print(path.parent.parent / "build")
+    # ie: /home/ubuntu/.cache/huggingface/hub/models--kernels-community--activation/snapshots/2fafa6a3a38ccb57a1a98419047cf7816ecbc071/build
     kernel = get_local_kernel(path.parent.parent / "build", package_name)
     y = torch.empty_like(x)
     kernel.gelu_fast(y, x)
     assert torch.allclose(y, expected)
 
     # Explicit package path
-    print(path.parent)
-    kernel = get_local_kernel(path.parent, package_name)
+    # ie: /home/ubuntu/.cache/huggingface/hub/models--kernels-community--activation/snapshots/2fafa6a3a38ccb57a1a98419047cf7816ecbc071/build/torch28-cxx11-cu128-x86_64-linux
+    kernel = get_local_kernel(path, package_name)
     y = torch.empty_like(x)
     kernel.gelu_fast(y, x)
     assert torch.allclose(y, expected)
-
-    assert False  # TODO: remove
 
 
 @pytest.mark.darwin_only


### PR DESCRIPTION
This PR adds tests for the recent update to `get_local_kernel` to test the various paths