### PR TITLE
to avoid load_kernel failure in non-xpu env

### DIFF
--- a/src/kernels/utils.py
+++ b/src/kernels/utils.py
@@ -46,8 +46,9 @@ def build_variant() -> str:
         compute_framework = f"rocm{rocm_version.major}{rocm_version.minor}"
     elif torch.backends.mps.is_available():
         compute_framework = "metal"
-    elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        compute_framework = "xpu"
+    elif torch.version.xpu is not None:
+        version = torch.version.xpu
+        compute_framework = f"xpu{version[0:4]}{version[5:6]}"
     else:
         raise AssertionError(
             "Torch was not compiled with CUDA, Metal, XPU, or ROCm enabled."


### PR DESCRIPTION
load kernel may be used in kernel compile env without xpu card.