### PR TITLE
Add support for XPU for kernel calls

### DIFF
--- a/src/kernels/layer.py
+++ b/src/kernels/layer.py
@@ -87,7 +87,7 @@ class Device:
 
     Args:
         type (`str`):
-            The device type (e.g., "cuda", "mps", "rocm").
+            The device type (e.g., "cuda", "mps", "rocm", "xpu").
         properties ([`CUDAProperties`], *optional*):
             Device-specific properties. Currently only [`CUDAProperties`] is supported for CUDA devices.
 
@@ -106,6 +106,9 @@ class Device:
 
         # MPS device for Apple Silicon
         mps_device = Device(type="mps")
+
+        # XPU device (e.g., Intel(R) Data Center GPU Max 1550)
+        xpu_device = Device(type="xpu")
         ```
     """
 
@@ -125,6 +128,8 @@ class Device:
             return _ROCMRepos()
         elif self.type == "mps":
             return _MPSRepos()
+        elif self.type == "xpu":
+            return _XPURepos()
         else:
             raise ValueError(f"Unknown device type: {self.type}")
 
@@ -447,6 +452,26 @@ class _DeviceRepos(ABC):
         ...
 
 
+class _XPURepos(_DeviceRepos):
+    _repos: Dict[Mode, LayerRepositoryProtocol]
+
+    def __init__(self):
+        super().__init__()
+        self._repos = {}
+
+    @property
+    def repos(
+        self,
+    ) -> Optional[Dict[Mode, LayerRepositoryProtocol]]:
+        return self._repos
+
+    def insert(self, device: Device, repos: Dict[Mode, LayerRepositoryProtocol]):
+        if device.type != "xpu":
+            raise ValueError(f"Device type must be 'xpu', got {device.type}")
+
+        self._repos = repos
+
+
 class _MPSRepos(_DeviceRepos):
     _repos: Dict[Mode, LayerRepositoryProtocol]
 
@@ -531,7 +556,7 @@ class _ROCMRepos(_DeviceRepos):
 
 def _validate_device_type(device_type: str) -> None:
     """Validate that the device type is supported."""
-    supported_devices = {"cuda", "rocm", "mps"}
+    supported_devices = {"cuda", "rocm", "mps", "xpu"}
     if device_type not in supported_devices:
         raise ValueError(
             f"Unsupported device type '{device_type}'. Supported device types are: {', '.join(sorted(supported_devices))}"
@@ -789,7 +814,7 @@ def kernelize(
             `Mode.TRAINING | Mode.TORCH_COMPILE` kernelizes the model for training with
             `torch.compile`.
         device (`Union[str, torch.device]`, *optional*):
-            The device type to load kernels for. Supported device types are: "cuda", "mps", "rocm".
+            The device type to load kernels for. Supported device types are: "cuda", "mps", "rocm", "xpu".
             The device type will be inferred from the model parameters when not provided.
         use_fallback (`bool`, *optional*, defaults to `True`):
             Whether to use the original forward method of modules when no compatible kernel could be found.


### PR DESCRIPTION
I wrote a simple script to test:
```
#!/usr/bin/env python

import torch
import torch.nn as nn

from kernels import (
    Mode,
    LayerRepository,
    use_kernel_mapping,
    kernelize,
    use_kernel_forward_from_hub,
)

def rms_norm_ref(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6):
    var = x.pow(2).mean(-1, keepdim=True)
    x_norm = x * torch.rsqrt(var + eps)
    return x_norm * weight


@use_kernel_forward_from_hub("LigerRMSNorm")
class MyRMSNorm(nn.Module):
    def __init__(self, hidden_size: int, eps: float = 1e-6):
        super().__init__()
        self.weight = nn.Parameter(torch.ones(hidden_size))
        self.variance_epsilon = eps

    def forward(self, x: torch.Tensor):
        return rms_norm_ref(x, self.weight, self.variance_epsilon)


def main():
    if not hasattr(torch, "xpu"):
        print("[SKIP] Current PyTorch does not include torch.xpu API.")
        return
    if not torch.xpu.is_available():
        print("[SKIP] No XPU device detected.")
        return

    device = torch.device("xpu")
    hidden = 1024
    batch = 4
    length = 16

    # Model and input
    torch.manual_seed(0)
    model = MyRMSNorm(hidden).to(device)
    x = torch.randn(batch, length, hidden, device=device, dtype=torch.float32)

    # Kernel mapping
    mapping = {
        "LigerRMSNorm": {
            "xpu": LayerRepository(
                repo_id="kernels-community/liger_kernels",
                layer_name="LigerRMSNorm",
            )
        }
    }

    print("Registering kernel mapping and performing kernelize...")
    with use_kernel_mapping(mapping):
        km = kernelize(model, mode=Mode.INFERENCE, device="xpu")

        # Forward
        y_kernel = km(x)

    # Reference implementation (reuse the same weight)
    ref = rms_norm_ref(x, model.weight)
    max_abs_diff = (y_kernel - ref).abs().max().item()
    print(f"Max absolute difference: {max_abs_diff:.3e}")

    # Tolerance based on experience (kernel may fuse ops / change precision)
    tol = 5e-4
    if max_abs_diff < tol:
        print("[PASS] Kernel output matches the reference implementation.")
    else:
        print("[WARN] Difference exceeds threshold; kernel may not be loaded correctly or precision differs.")

    # Print forward origin (debug only)
    print(f"Current forward callable: {km.forward} (type={type(km.forward)})")


if __name__ == "__main__":
    main()

```

The test results:
```
Registering kernel mapping and performing kernelize...
Fetching 17 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:00<00:00, 188135.01it/s]
Max absolute difference: 4.768e-07
[PASS] Kernel output matches the reference implementation.
Current forward callable: <bound method LigerRMSNorm.forward of MyRMSNorm()> (type=<class 'method'>)
```