### PR TITLE
Bump huggingface_hub upper bound <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">= 3.9"
 dependencies = [
-  "huggingface_hub>=0.26.0,<1.0",
+  "huggingface_hub>=0.26.0,<2.0",
   "packaging>=20.0",
   "pyyaml>=6",
   "tomli>=2.0; python_version<'3.11'",


### PR DESCRIPTION
Related to huggingface_hub v1.0 release (https://github.com/huggingface/huggingface_hub/issues/3340)

I've checked all occurrences of `huggingface_hub` in this repo and none of them will be affected by the v1.0 breaking changes. So let's accept both 0.x and 1.x versions :) 

Same as what we did for tokenizers: https://github.com/huggingface/tokenizers/pull/1866