### PR TITLE
misc(upload): specifically define what folder to allow uploading

### DIFF
--- a/src/kernels/cli.py
+++ b/src/kernels/cli.py
@@ -244,7 +244,7 @@ def upload_kernels(args):
         path_in_repo="build",
         delete_patterns=list(delete_patterns),
         commit_message="Build uploaded using `kernels`.",
-        allow_patterns=["torch*"],
+        allow_patterns=["torch-*"],
     )
     print(f"✅ Kernel upload successful. Find the kernel in https://hf.co/{repo_id}.")
 


### PR DESCRIPTION
Especially as Windows build have a lot of other folders around `torch**`