### PR TITLE
Add support for backend dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,22 @@ jobs:
         run: |
           uv run black --check src
           uv run black --check tests
+
+  validate-dependencies:
+    name: Validate python_depends.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate python_depends.json is up-to-date
+        run: |
+          python update_python_depends.py --validate || {
+            echo "Error: python_depends.json is out of date."
+            echo "Please run: python update_python_depends.py"
+            exit 1
+          }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,9 @@ jobs:
         run: |
           uv run pytest tests
 
-      - name: Run dependency test with dependency installed
+      - name: Re-run dependency test with dependencies installed
         run: |
-          uv pip install nvidia-cutlass-dsl
+          uv pip install einops nvidia-cutlass-dsl
           uv run pytest tests/test_deps.py
 
       - name: Run staging tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ kernels = "kernels.cli:main"
 [project.entry-points."egg_info.writers"]
 "kernels.lock" = "kernels.lockfile:write_egg_lockfile"
 
+[tool.setuptools.package-data]
+kernels = ["python_depends.json"]
+
 [tool.isort]
 profile = "black"
 line_length = 119

--- a/src/kernels/deps.py
+++ b/src/kernels/deps.py
@@ -1,27 +1,44 @@
 import importlib.util
-from typing import List, Set
+import json
+from pathlib import Path
+from typing import Dict, List
 
-allowed_dependencies: Set[str] = {
-    "einops",
-    "nvidia-cutlass-dsl",
-}
+try:
+    with open(Path(__file__).parent / "python_depends.json", "r") as f:
+        DEPENDENCY_DATA: Dict = json.load(f)
+except FileNotFoundError:
+    raise FileNotFoundError(
+        "Cannot load dependency data, is `kernels` correctly installed?"
+    )
 
 
-def validate_dependencies(dependencies: List[str]):
+def validate_dependencies(dependencies: List[str], backend: str):
     """
     Validate a list of dependencies to ensure they are installed.
 
     Args:
-        dependencies (`List[str]`): A list of dependency strings.
+        dependencies (`List[str]`): A list of dependency strings to validate.
+        backend (`str`): The backend to validate dependencies for.
     """
-    for dependency in dependencies:
-        if dependency not in allowed_dependencies:
-            allowed = ", ".join(sorted(allowed_dependencies))
-            raise ValueError(
-                f"Invalid dependency: {dependency}, allowed dependencies: {allowed}"
-            )
+    general_deps = DEPENDENCY_DATA.get("general", {})
+    backend_deps = DEPENDENCY_DATA.get("backends", {}).get(backend, {})
 
-        if importlib.util.find_spec(dependency.replace("-", "_")) is None:
-            raise ImportError(
-                f"Kernel requires dependency `{dependency}`. Please install with: pip install {dependency}"
-            )
+    # Validate each dependency
+    for dependency in dependencies:
+        # Look up dependency in general dependencies first, then backend-specific
+        if dependency in general_deps:
+            python_packages = general_deps[dependency].get("python", [])
+        elif dependency in backend_deps:
+            python_packages = backend_deps[dependency].get("python", [])
+        else:
+            # Dependency not found in general or backend-specific dependencies
+            raise ValueError(f"Invalid dependency: {dependency}")
+
+        # Check if each python package is installed
+        for python_package in python_packages:
+            # Convert package name to module name (replace - with _)
+            module_name = python_package.replace("-", "_")
+            if importlib.util.find_spec(module_name) is None:
+                raise ImportError(
+                    f"Kernel requires Python dependency `{python_package}`. Please install with: pip install {python_package}"
+                )

--- a/src/kernels/python_depends.json
+++ b/src/kernels/python_depends.json
@@ -1,0 +1,35 @@
+{
+  "general": {
+    "einops": {
+      "nix": [
+        "einops"
+      ],
+      "python": [
+        "einops"
+      ]
+    }
+  },
+  "backends": {
+    "cpu": {},
+    "cuda": {
+      "nvidia-cutlass-dsl": {
+        "nix": [
+          "nvidia-cutlass-dsl"
+        ],
+        "python": [
+          "nvidia-cutlass-dsl"
+        ]
+      }
+    },
+    "metal": {},
+    "rocm": {},
+    "xpu": {
+      "onednn": {
+        "nix": [],
+        "python": [
+          "onednn-devel"
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -5,11 +5,13 @@ import pytest
 from kernels import get_kernel
 
 
-def test_python_deps():
-    must_raise = find_spec("nvidia_cutlass_dsl") is None
+@pytest.mark.parametrize("dependency", ["einops", "nvidia-cutlass-dsl"])
+def test_python_deps(dependency):
+    must_raise = find_spec(dependency.replace("-", "_")) is None
     if must_raise:
         with pytest.raises(
-            ImportError, match=r"Kernel requires dependency `nvidia-cutlass-dsl`"
+            ImportError,
+            match=r"Kernel requires Python dependency `(einops|nvidia-cutlass-dsl)`",
         ):
             get_kernel("kernels-test/python-dep")
     else:

--- a/update_python_depends.py
+++ b/update_python_depends.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Download python_depends.json from the kernel-builder repository.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+from urllib.request import Request, urlopen
+
+URL = "https://raw.githubusercontent.com/huggingface/kernel-builder/refs/heads/backend-deps/build2cmake/src/python_dependencies.json"
+TARGET_DIR = Path(__file__).parent / "src" / "kernels"
+TARGET_FILE = TARGET_DIR / "python_depends.json"
+
+
+def download_json(url: str) -> Dict:
+    """Download JSON from URL and return parsed dict."""
+    request = Request(url)
+
+    with urlopen(request, timeout=30) as response:
+        content = response.read()
+
+    return json.loads(content)
+
+
+def download_file(url: str, target_path: Path) -> None:
+    """Download file from URL and save to target path."""
+    data = download_json(url)
+
+    with open(target_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def validate_file(url: str, target_path: Path):
+    """Check if local file is up-to-date with remote version.
+
+    Returns True if up-to-date, False otherwise.
+    """
+    if not target_path.exists():
+        return False
+
+    remote_json = download_json(url)
+
+    with open(target_path, "r") as f:
+        local_json = json.load(f)
+
+    if local_json != remote_json:
+        raise ValueError(f"Local Python dependencies at {target_path} are out of date.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download or validate python_depends.json")
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate that local file is up-to-date instead of downloading",
+    )
+    args = parser.parse_args()
+
+    if args.validate:
+        validate_file(URL, TARGET_FILE)
+    else:
+        download_file(URL, TARGET_FILE)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds support for backend-specific dependencies. We use the dependencies from `kernel-builder` and validate upon loading that all dependencies are permitted dependencies.