### PR TITLE
Add cli kernel init

### DIFF
--- a/src/kernels/cli.py
+++ b/src/kernels/cli.py
@@ -463,7 +463,9 @@ def init_kernel_project(args):
             f.write(content)
 
     # Print success message
-    print(f"✅ Kernel project '{kernel_name}' initialized successfully at: {output_dir}")
+    print(
+        f"✅ Kernel project '{kernel_name}' initialized successfully at: {output_dir}"
+    )
     print()
     print("Project structure:")
     _print_tree(output_dir, prefix="")


### PR DESCRIPTION
This should init a kernel project with default templates to simplify a bit the copy/pasting. 

Example:
```
/dev/kernels$ kernels init example-kernel

✅ Kernel project 'example-kernel' initialized successfully at: /dev/kernels/example-kernel

Project structure:
├── example_kernel_cuda
├── example_kernel_metal
├── example_kernel_rocm
├── example_kernel_xpu
├── torch-ext
│   ├── example_kernel
│   │   └── __init__.py
│   ├── torch_binding.cpp
│   └── torch_binding.h
├── .gitattributes
├── README.md
├── build.toml
└── flake.nix

Next steps:
  1. cd /dev/kernels/example-kernel
  2. Add your kernel implementation in example_kernel/
  3. Update torch-ext/example_kernel/__init__.py to export your functions
  4. Build with: nix run .#build-and-copy 
  5. Upload with: kernels upload . --repo-id your-username/example-kernel
```