### PR TITLE
fix: pin version specifier and add warning to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import torch
 from kernels import get_kernel
 
 # Download optimized kernels from the Hugging Face hub
-activation = get_kernel("kernels-community/activation")
+activation = get_kernel("kernels-community/activation", version=">=0.1.0,<0.2.0")
 
 # Random tensor
 x = torch.randn((10, 10), dtype=torch.float16, device="cuda")
@@ -50,6 +50,11 @@ activation.gelu_fast(y, x)
 
 print(y)
 ```
+
+> [!WARNING] Strongly recommended to specify version bounds
+> Loading kernels without specifying a version will fetch from the `main` branch.
+> The `main` branch may contain breaking changes or incompatible updates at any time.
+> Always specify version bounds to ensure reproducible builds and avoid unexpected issues.
 
 You can [search for kernels](https://huggingface.co/models?other=kernels) on
 the Hub.

--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -9,7 +9,7 @@ import torch
 from kernels import get_kernel
 
 # Download optimized kernels from the Hugging Face hub
-activation = get_kernel("kernels-community/activation")
+activation = get_kernel("kernels-community/activation", version=">=0.1.0,<0.2.0")
 
 # Create a random tensor
 x = torch.randn((10, 10), dtype=torch.float16, device="cuda")
@@ -21,6 +21,11 @@ activation.gelu_fast(y, x)
 print(y)
 ```
 
+> [!WARNING] Strongly recommended to specify version bounds
+> Loading kernels without specifying a version will fetch from the `main` branch.
+> The `main` branch may contain breaking changes or incompatible updates at any time.
+> Always specify version bounds to ensure reproducible builds and avoid unexpected issues.
+
 ### Using version bounds
 
 Kernels are versioned using tags of the form `v<major>.<minor>.<patch>`.
@@ -30,10 +35,10 @@ You can specify which version to download using Python version specifiers:
 import torch
 from kernels import get_kernel
 
-activation = get_kernel("kernels-community/activation", version=">=0.0.4,<0.1.0")
+activation = get_kernel("kernels-community/activation", version=">=0.1.0,<0.2.0")
 ```
 
-This will get the latest kernel tagged `v0.0.z` where `z` is at least 4. It
+This will get the latest kernel tagged `v0.1.z` where `z` is at least 0. It
 is strongly recommended to specify a version bound, since a kernel author
 might push incompatible changes to the `main` branch.
 

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -159,14 +159,21 @@ kernel_layer_mapping = {
         "cuda": LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
+            version=">=0.1.0,<0.2.0",
         ),
         "rocm": LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
+            version=">=0.1.0,<0.2.0",
         )
     }
 }
 ```
+
+> [!WARNING] Strongly recommended to specify version bounds
+> Loading kernels without specifying a version will fetch from the `main` branch.
+> The `main` branch may contain breaking changes or incompatible updates at any time.
+> Always specify version bounds to ensure reproducible builds and avoid unexpected issues.
 
 You can register such a mapping using `register_kernel_mapping`:
 
@@ -197,6 +204,7 @@ kernel_layer_mapping = {
         "cuda": FuncRepository(
             repo_id="kernels-community/activation",
             func_name="silu_and_mul",
+            version=">=0.1.0,<0.2.0",
         ),
     }
 }
@@ -214,19 +222,19 @@ kernel_layer_mapping = {
         "cuda": LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
-            version=">=0.0.4,<0.1.0",
+            version=">=0.1.0,<0.2.0",
         ),
         "rocm": LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
-            version=">=0.0.4,<0.1.0",
+            version=">=0.1.0,<0.2.0",
         )
     }
 }
 ```
 
-This will get the layer from latest kernel tagged `v0.0.z` where `z` is at
-least 4. It is strongly recommended to specify a version bound, since a
+This will get the layer from the latest kernel tagged `v0.1.z` where `z` is at
+least 0. It is strongly recommended to specify a version bound, since a
 kernel author might push incompatible changes to the `main` branch.
 
 ### Registering kernels for specific modes


### PR DESCRIPTION
This PR adds a version specifier to the readme examples and warnings to the docs to recommend using a version specifier in all cases. 


**just triple checked that the readme example works with the provided specifier/readme example

`readme.py`
```python
import torch

from kernels import get_kernel

# Download optimized kernels from the Hugging Face hub
activation = get_kernel("kernels-community/activation", version=">=0.1.0,<0.2.0")

# Random tensor
x = torch.randn((10, 10), dtype=torch.float16, device="cuda")

# Run the kernel
y = torch.empty_like(x)
activation.gelu_fast(y, x)

print(y)
```

output

```bash
uv run readme.py                                                                                               drbh@drbh-gpu
Fetching 7 files: 100%|██████████████████████████████████████████████████████████████████████████| 7/7 [00:01<00:00,  6.16it/s]
Download complete: : 4.14MB [00:01, 4.06MB/s]              tensor([[ 9.6252e-02, -6.5857e-02,  9.7754e-01,  6.5674e-01,  2.0215e-01,
          2.2534e-01,  3.1982e-01,  3.2178e-01,  9.0088e-01, -1.3940e-01],
        [-1.2634e-01,  4.0527e-01,  3.2568e-01, -7.6637e-03,  1.7734e+00,
         -1.6199e-01,  9.7900e-01,  2.8271e-01,  5.7031e-01,  6.6895e-01],
        [ 1.1562e+00, -1.6992e-01, -7.9163e-02, -1.1395e-01,  1.1133e+00,
          3.2861e-01, -1.6516e-01, -1.5234e-01, -1.6431e-01,  2.5146e-01],
        [ 2.2969e+00, -1.6711e-01, -1.4429e-01,  2.0605e+00,  2.2229e-01,
          4.0527e-02, -1.0034e-01,  2.0740e-01, -1.6943e-01, -1.0809e-01],
        [-1.6040e-01,  4.9609e-01, -1.5002e-01, -1.4380e-01,  1.4697e+00,
          6.5820e-01, -9.4238e-02,  1.0957e+00, -1.6870e-01,  2.4941e+00],
        [-7.5256e-02,  4.4584e-04, -1.7258e-02,  3.3936e-01,  2.3652e+00,
          1.3306e-01, -1.1627e-01, -1.6418e-01,  2.9541e-01,  8.6117e-04],
        [-7.5378e-02,  8.7305e-01, -7.6904e-02, -1.3843e-01, -4.8187e-02,
         -9.1614e-02, -9.3201e-02,  3.0640e-01,  1.0907e-01,  6.6650e-01],
        [-1.2244e-01, -6.4270e-02, -1.6711e-01, -1.6943e-01, -4.6295e-02,
         -1.5125e-01,  1.5210e-01,  1.7939e+00,  9.7168e-01, -1.3171e-01],
        [ 1.5762e+00, -1.6980e-01,  1.3535e+00,  3.6469e-02,  1.6221e+00,
          1.1006e+00,  1.4941e+00, -1.5955e-01,  7.7148e-01, -1.4917e-01],
        [ 1.4043e+00,  1.5674e+00, -1.6980e-01,  1.9019e-01, -7.8796e-02,
          1.0908e+00,  2.6831e-01,  2.0215e+00, -8.2947e-02, -1.5833e-01]],
       device='cuda:0', dtype=torch.float16)
Download complete: : 4.14MB [00:01, 2.93MB/s]
```