### PR TITLE
fix: adjust upload pattern

### DIFF
--- a/src/kernels/cli.py
+++ b/src/kernels/cli.py
@@ -206,7 +206,7 @@ def upload_kernels(args):
         path_in_repo="build",
         delete_patterns=list(delete_patterns),
         commit_message="Build uploaded using `kernels`.",
-        allow_patterns=["torch-*"],
+        allow_patterns=["torch*"],
     )
     print(f"✅ Kernel upload successful. Find the kernel in https://hf.co/{repo_id}.")
 


### PR DESCRIPTION
This PR fixes a syntax bug with the `allow_patterns` in the upload command. Currently the build produces files with names like

```
torch210-cxx11-cu126-x86_64-linux
torch210-cxx11-cu128-x86_64-linux
torch210-cxx11-cu130-x86_64-linux
torch28-cxx11-cu126-x86_64-linux
torch28-cxx11-cu128-x86_64-linux
torch28-cxx11-cu129-x86_64-linux
torch29-cxx11-cu126-x86_64-linux
torch29-cxx11-cu128-x86_64-linux
torch29-cxx11-cu130-x86_64-linux
```

however none of them are uploaded because only files with the pattern `allow_patterns=["torch-*"]` are allowed. This pr simply removed the trailing `-` and allows new builds to be uploaded