### PR TITLE
Tighten up build variant check

### DIFF
--- a/src/kernels/cli.py
+++ b/src/kernels/cli.py
@@ -13,7 +13,7 @@ from kernels.utils import install_kernel, install_kernel_all_variants
 
 from .doc import generate_readme_for_kernel
 
-BUILD_VARIANT_REGEX = re.compile(r"^(torch\d+\d+|torch-)")
+BUILD_VARIANT_REGEX = re.compile(r"^(torch\d+\d+|torch-(cpu|cuda|metal|rocm|xpu))")
 
 
 def main():


### PR DESCRIPTION
To avoid that we use the source directory containing `torch-ext` to be uploaded.