### PR TITLE
Fix too-aggressive layer caching

### DIFF
--- a/src/kernels/layer/func.py
+++ b/src/kernels/layer/func.py
@@ -244,8 +244,8 @@ class LockedFuncRepository:
         self._repo_id = repo_id
         self._lockfile = lockfile
         self.func_name = func_name
+        self._revision = self._resolve_revision()
 
-    @functools.lru_cache()
     def _resolve_revision(self) -> str:
         if self._lockfile is None:
             locked_sha = _get_caller_locked_kernel(self._repo_id)
@@ -259,7 +259,7 @@ class LockedFuncRepository:
         return locked_sha
 
     def load(self) -> Type["nn.Module"]:
-        kernel = get_kernel(repo_id=self._repo_id, revision=self._resolve_revision())
+        kernel = get_kernel(repo_id=self._repo_id, revision=self._revision)
         return _get_kernel_func(self, kernel)
 
     def __eq__(self, other):
@@ -267,13 +267,14 @@ class LockedFuncRepository:
             isinstance(other, LockedFuncRepository)
             and self.func_name == other.func_name
             and self._repo_id == other._repo_id
+            and self._revision == other._revision
         )
 
     def __hash__(self):
-        return hash((self.func_name, self._repo_id))
+        return hash((self.func_name, self._repo_id, self._revision))
 
     def __str__(self) -> str:
-        return f"`{self._repo_id}` (revision: {self._resolve_revision()}), function `{self.func_name}`"
+        return f"`{self._repo_id}` (revision: {self._revision}), function `{self.func_name}`"
 
 
 def _get_kernel_func(

--- a/tests/test_kernel_locking.py
+++ b/tests/test_kernel_locking.py
@@ -61,6 +61,22 @@ def test_layer_locked(device):
         version = kernelize(version, device=device, mode=Mode.INFERENCE)
         assert version() == "0.1.1"
 
+    with pytest.raises(ValueError, match="Kernel.* is not locked"):
+        # Must fail, because our project does not have a lock for it. However,
+        # if layer caching is too aggressive (i.e. does not take the revision into
+        # account), this may incorrectly pass.
+        with use_kernel_mapping(
+            {
+                "Version": {
+                    device: LockedLayerRepository(
+                        repo_id="kernels-test/versions",
+                        layer_name="Version",
+                    )
+                },
+            }
+        ):
+            kernelize(version, device=device, mode=Mode.INFERENCE)
+
 
 def test_func_locked(device):
     project_dir = Path(__file__).parent / "layer_locking"
@@ -79,8 +95,6 @@ def test_func_locked(device):
 
     model = Version()
 
-    print(model.version.forward)
-
     with use_kernel_mapping(
         {
             "version": {
@@ -96,11 +110,23 @@ def test_func_locked(device):
 
     assert version() == "0.1.1"
 
-    print(model.version.forward)
+    with pytest.raises(ValueError, match="Kernel.* is not locked"):
+        # Must fail, because our project does not have a lock for it. However,
+        # if layer caching is too aggressive (i.e. does not take the revision into
+        # account), this may incorrectly pass.
+        with use_kernel_mapping(
+            {
+                "version": {
+                    device: LockedFuncRepository(
+                        repo_id="kernels-test/versions",
+                        func_name="version",
+                    )
+                },
+            }
+        ):
+            kernelize(model, device=device, mode=Mode.INFERENCE)
 
     with use_kernel_mapping({"version": {}}):
         model = kernelize(model, mode=Mode.INFERENCE, device=device)
 
     assert version() == "0.0.0"
-
-    print(model.version.forward)


### PR DESCRIPTION
We did not store the kernel revision in the `LockedLayerRepository` and `LockedFuncRepository`. This results in cache hits when loading a kernel twice with different revisions. Fix this by storing the revision in instances as well and using them in `__eq__` and `__hash__`.