### PR TITLE
kernels: remove the version warning until we have the Hub UX

### DIFF
--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -28,6 +28,9 @@ get the latest kernel build from the `v1` branch.
 Kernels within a version branch must never break the API or remove builds
 for older PyTorch versions. This ensures that your code will continue to work.
 
+Some kernels have not yet been updated to use versioning yet. In these cases,
+you can use `get_kernel` without the `version` argument.
+
 ## Checking Kernel Availability
 
 You can check if a particular version of a kernel supports the environment

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -170,7 +170,18 @@ kernel_layer_mapping = {
 }
 ```
 
-You can register such a mapping using `register_kernel_mapping`:
+This uses version `1` of the `SiluAndMul` kernel layer from
+`kernels-community/activation` for the `cuda` and `rocm` backends. Kernel
+layers are versioned using a major version number. Using `version=1`
+will get the latest kernel build from the `v1` branch. Kernel layers
+within a version branch must never break the API or remove builds for
+older PyTorch versions. This ensures that your code will continue to
+work.
+
+Some kernels have not yet been updated to use versioning yet. In these cases,
+you can use `LayerRepository` without the `version` argument.
+
+You can register a mapping, like the one above, using `register_kernel_mapping`:
 
 ```python
 register_kernel_mapping(kernel_layer_mapping)

--- a/kernels/src/kernels/_versions.py
+++ b/kernels/src/kernels/_versions.py
@@ -84,9 +84,12 @@ def select_revision_or_version(
     elif version is not None:
         return resolve_version_spec_as_ref(repo_id, version).target_commit
 
-    warnings.warn(
-        "Future versions of `kernels` (>=0.14) will require specifying a kernel version or revision."
-        "See: https://huggingface.co/docs/kernels/migration"
-    )
+    # Re-enable once we have proper UX on the hub for showing the
+    # kernel versions.
+    #
+    # warnings.warn(
+    #    "Future versions of `kernels` (>=0.14) will require specifying a kernel version or revision."
+    #    "See: https://huggingface.co/docs/kernels/migration"
+    # )
 
     return "main"


### PR DESCRIPTION
Also extend the documentation a bit on versioning.