### PR TITLE
update Dockerfile override with monorepo 

### DIFF
--- a/builder/dockerfiles/Dockerfile
+++ b/builder/dockerfiles/Dockerfile
@@ -105,7 +105,7 @@ function build_extension {
   # check if using a local path for kernel-builder
   is_using_path=$(grep -q 'kernel-builder.url *= *"path:' flake.nix && echo "yes" || echo "no")
   if [ "$is_using_path" = "yes" ]; then
-    override="--override-input kernel-builder github:huggingface/kernel-builder"
+    override="--override-input kernel-builder github:huggingface/kernels"
     echo "Detected local path for kernel-builder in flake.nix, overriding to use GitHub source."
   else
     echo "No local path for kernel-builder detected in flake.nix."


### PR DESCRIPTION
this PR simply updates the override input path for the monorepo github repo so the relu example builds.

tested locally via a rebuild of the docker image 
```bash
cd builder/dockerfiles && \
  docker build -t kernel-builder:local -f Dockerfile .
```

and ran with
```bash
cd ../../builder/examples/relu
docker run --rm \
  -v $(pwd):/app \
  -w /app \
  kernel-builder:local build --jobs 1 --cores 8
```

note this took 23m37s and output
```bash
tree build -L 1
# build
# ├── torch210-cxx11-cpu-x86_64-linux
# ├── torch210-cxx11-cu126-x86_64-linux
# ├── torch210-cxx11-cu128-x86_64-linux
# ├── torch210-cxx11-cu130-x86_64-linux
# ├── torch210-cxx11-rocm70-x86_64-linux
# ├── torch210-cxx11-rocm71-x86_64-linux
# ├── torch210-cxx11-xpu20253-x86_64-linux
# ├── torch29-cxx11-cpu-x86_64-linux
# ├── torch29-cxx11-cu126-x86_64-linux
# ├── torch29-cxx11-cu128-x86_64-linux
# ├── torch29-cxx11-cu130-x86_64-linux
# ├── torch29-cxx11-rocm63-x86_64-linux
# ├── torch29-cxx11-rocm64-x86_64-linux
# └── torch29-cxx11-xpu20252-x86_64-linux
```