### PR TITLE
Move all kernel component handling to CMake functions

### DIFF
--- a/build2cmake/src/templates/cpu/kernel.cmake
+++ b/build2cmake/src/templates/cpu/kernel.cmake
@@ -1,24 +1,5 @@
-set({{kernel_name}}_SRC
-  {{ sources }}
+cpu_kernel_component(SRC
+  SOURCES {{ sources }}
+  {% if includes %}INCLUDES "{{ includes }}"{% endif %}
+  {% if cxx_flags %}CXX_FLAGS "{{ cxx_flags }}"{% endif %}
 )
-
-{% if includes %}
-# TODO: check if CLion support this:
-# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
-set_source_files_properties(
-  {{'${' + kernel_name + '_SRC}'}}
-  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
-{% endif %}
-
-{% if cxx_flags %}
-foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-  set_property(
-    SOURCE ${_KERNEL_SRC}
-    APPEND PROPERTY
-    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:{{ cxx_flags }}>"
-  )
-endforeach()
-{% endif %}
-
-# Add C++ sources to main source list
-list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})

--- a/build2cmake/src/templates/cpu/preamble.cmake
+++ b/build2cmake/src/templates/cpu/preamble.cmake
@@ -10,6 +10,7 @@ file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
 message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/kernel.cmake)
 
 if(DEFINED Python3_EXECUTABLE)
   # Allow passing through the interpreter (e.g. from setup.py).
@@ -42,3 +43,6 @@ endif()
 {% endif %}
 
 add_compile_definitions(CPU_KERNEL)
+
+# Initialize SRC list for kernel and binding sources
+set(SRC "")

--- a/build2cmake/src/templates/cuda/kernel.cmake
+++ b/build2cmake/src/templates/cuda/kernel.cmake
@@ -1,93 +1,11 @@
-{% if cuda_minver %}
-if (CUDA_VERSION VERSION_GREATER_EQUAL {{ cuda_minver }})
-{% endif %}
-
-set({{kernel_name}}_SRC
-  {{ sources }}
+cuda_kernel_component(SRC
+  SOURCES {{ sources }}
+  {% if cuda_minver %}CUDA_MINVER {{ cuda_minver }}{% endif %}
+  {% if includes %}INCLUDES "{{ includes }}"{% endif %}
+  {% if cuda_capabilities %}CUDA_CAPABILITIES {{ cuda_capabilities|join(" ") }}{% endif %}
+  {% if cuda_flags %}CUDA_FLAGS "{{ cuda_flags }}"{% endif %}
+  {% if cxx_flags %}CXX_FLAGS "{{ cxx_flags }}"{% endif %}
+  {% if supports_hipify %}SUPPORTS_HIPIFY{% endif %}
+  {% if hip_flags %}HIP_FLAGS "{{ hip_flags }}"{% endif %}
+  {% if rocm_archs %}ROCM_ARCHS {{ rocm_archs|join(" ") }}{% endif %}
 )
-
-{% if includes %}
-# TODO: check if CLion support this:
-# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
-set_source_files_properties(
-  {{'${' + kernel_name + '_SRC}'}}
-  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
-{% endif %}
-
-if(GPU_LANG STREQUAL "CUDA")
-  {% if cuda_capabilities %}
-    cuda_archs_loose_intersection({{kernel_name}}_ARCHS "{{ cuda_capabilities|join(";") }}" "${CUDA_ARCHS}")
-  {% else %}
-    set({{kernel_name}}_ARCHS "${CUDA_KERNEL_ARCHS}")
-  {% endif %}
-  message(STATUS "Capabilities for kernel {{kernel_name}}: {{ '${' + kernel_name + '_ARCHS}'}}")
-  set_gencode_flags_for_srcs(SRCS {{'"${' + kernel_name + '_SRC}"'}} CUDA_ARCHS "{{ '${' + kernel_name + '_ARCHS}'}}")
-
-  {% if cuda_flags %}
-
-  set(_CUDA_FLAGS "{{ cuda_flags }}")
-  # -static-global-template-stub is not supported on CUDA < 12.8. Remove this
-  # once we don't support CUDA 12.6 anymore.
-  if(CUDA_VERSION VERSION_LESS 12.8)
-    string(REGEX REPLACE "-static-global-template-stub=(true|false)" "" _CUDA_FLAGS "${_CUDA_FLAGS}")
-  endif()
-
-  foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-    if(_KERNEL_SRC MATCHES ".*\\.cu$")
-      set_property(
-        SOURCE ${_KERNEL_SRC}
-        APPEND PROPERTY
-        COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:${_CUDA_FLAGS}>"
-      )
-    endif()
-  endforeach()
-  {% endif %}
-
-  {% if cxx_flags %}
-  foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-    set_property(
-      SOURCE ${_KERNEL_SRC}
-      APPEND PROPERTY
-      COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:{{ cxx_flags }}>"
-    )
-  endforeach()
-  {% endif %}
-
-  list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})
-{% if supports_hipify %}
-elseif(GPU_LANG STREQUAL "HIP")
-  {% if hip_flags %}
-
-  foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-    if(_KERNEL_SRC MATCHES ".*\\.(cu|hip)$")
-      set_property(
-        SOURCE ${_KERNEL_SRC}
-        APPEND PROPERTY
-        COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:{{ hip_flags }}>"
-      )
-    endif()
-  endforeach()
-  {% endif %}
-
-  hip_archs_loose_intersection({{kernel_name}}_ARCHS "{{ rocm_archs|join(";") }}" "${ROCM_ARCHS}")
-  message(STATUS "Archs for kernel {{kernel_name}}: {{ '${' + kernel_name + '_ARCHS}'}}")
-
-  foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-    if(_KERNEL_SRC MATCHES ".*\\.(cu|hip)$")
-      foreach(_ROCM_ARCH {{ '${' + kernel_name + '_ARCHS}'}})
-        set_property(
-          SOURCE ${_KERNEL_SRC}
-          APPEND PROPERTY
-          COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_ROCM_ARCH}>"
-        )
-      endforeach()
-    endif()
-  endforeach()
-
-  list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})
-{% endif %}
-endif()
-
-{% if cuda_minver %}
-endif()
-{% endif %}

--- a/build2cmake/src/templates/cuda/preamble.cmake
+++ b/build2cmake/src/templates/cuda/preamble.cmake
@@ -12,6 +12,7 @@ message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/kernel.cmake)
 
 if(DEFINED Python3_EXECUTABLE)
   # Allow passing through the interpreter (e.g. from setup.py).
@@ -128,6 +129,8 @@ else()
     "${${GPU_LANG}_SUPPORTED_ARCHS}")
 endif()
 
+# Initialize SRC list for kernel and binding sources
+set(SRC "")
 
 message(STATUS "Rendered for platform {{ platform }}")
 {% if platform == 'windows' %}

--- a/build2cmake/src/templates/cuda/torch-binding.cmake
+++ b/build2cmake/src/templates/cuda/torch-binding.cmake
@@ -14,4 +14,3 @@ set_source_files_properties(
 {% endif %}
 
 list(APPEND SRC {{'"${TORCH_' + name + '_SRC}"'}})
-

--- a/build2cmake/src/templates/kernel.cmake
+++ b/build2cmake/src/templates/kernel.cmake
@@ -1,0 +1,283 @@
+function(cuda_kernel_component SRC_VAR)
+    set(options SUPPORTS_HIPIFY)
+    set(oneValueArgs CUDA_MINVER)
+    set(multiValueArgs SOURCES INCLUDES CUDA_CAPABILITIES CUDA_FLAGS CXX_FLAGS HIP_FLAGS ROCM_ARCHS)
+    cmake_parse_arguments(KERNEL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT KERNEL_SOURCES)
+        message(FATAL_ERROR "cuda_kernel_component: SOURCES argument is required")
+    endif()
+
+    # Bail out if this component is not supported by the CUDA version.
+    if(KERNEL_CUDA_MINVER)
+        if(CUDA_VERSION VERSION_LESS ${KERNEL_CUDA_MINVER})
+            return()
+        endif()
+    endif()
+
+    set(_KERNEL_SRC ${KERNEL_SOURCES})
+
+    if(KERNEL_INCLUDES)
+        # TODO: check if CLion support this:
+        # https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
+        set_source_files_properties(
+      ${_KERNEL_SRC}
+      PROPERTIES INCLUDE_DIRECTORIES "${KERNEL_INCLUDES}")
+    endif()
+
+    if(GPU_LANG STREQUAL "CUDA")
+        # Determine CUDA architectures
+        if(KERNEL_CUDA_CAPABILITIES)
+            cuda_archs_loose_intersection(_KERNEL_ARCHS "${KERNEL_CUDA_CAPABILITIES}" "${CUDA_ARCHS}")
+        else()
+            set(_KERNEL_ARCHS "${CUDA_KERNEL_ARCHS}")
+        endif()
+        message(STATUS "CUDA kernel capabilities: ${_KERNEL_ARCHS}")
+        set_gencode_flags_for_srcs(SRCS "${_KERNEL_SRC}" CUDA_ARCHS "${_KERNEL_ARCHS}")
+
+        # Apply CUDA-specific compile flags
+        if(KERNEL_CUDA_FLAGS)
+            set(_CUDA_FLAGS "${KERNEL_CUDA_FLAGS}")
+            # -static-global-template-stub is not supported on CUDA < 12.8. Remove this
+            # once we don't support CUDA 12.6 anymore.
+            if(CUDA_VERSION VERSION_LESS 12.8)
+                string(REGEX REPLACE "-static-global-template-stub=(true|false)" "" _CUDA_FLAGS "${_CUDA_FLAGS}")
+            endif()
+
+            foreach(_SRC ${_KERNEL_SRC})
+                if(_SRC MATCHES ".*\\.cu$")
+                    set_property(
+            SOURCE ${_SRC}
+            APPEND PROPERTY
+            COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:${_CUDA_FLAGS}>"
+          )
+                endif()
+            endforeach()
+        endif()
+
+        # Apply CXX-specific compile flags
+        if(KERNEL_CXX_FLAGS)
+            foreach(_SRC ${_KERNEL_SRC})
+                set_property(
+          SOURCE ${_SRC}
+          APPEND PROPERTY
+          COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${KERNEL_CXX_FLAGS}>"
+        )
+            endforeach()
+        endif()
+
+        set(_TMP_SRC ${${SRC_VAR}})
+        list(APPEND _TMP_SRC ${_KERNEL_SRC})
+        set(${SRC_VAR} ${_TMP_SRC} PARENT_SCOPE)
+
+    elseif(GPU_LANG STREQUAL "HIP")
+        if(NOT KERNEL_SUPPORTS_HIPIFY)
+            message(WARNING "Kernel does not support HIP")
+            return()
+        endif()
+
+        # Apply HIP-specific compile flags
+        if(KERNEL_HIP_FLAGS)
+            foreach(_SRC ${_KERNEL_SRC})
+                if(_SRC MATCHES ".*\\.(cu|hip)$")
+                    set_property(
+            SOURCE ${_SRC}
+            APPEND PROPERTY
+            COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:${KERNEL_HIP_FLAGS}>"
+          )
+                endif()
+            endforeach()
+        endif()
+
+        # Determine ROCm architectures
+        if(KERNEL_ROCM_ARCHS)
+            hip_archs_loose_intersection(_KERNEL_ARCHS "${KERNEL_ROCM_ARCHS}" "${ROCM_ARCHS}")
+        else()
+            set(_KERNEL_ARCHS "${ROCM_ARCHS}")
+        endif()
+        message(STATUS "HIP kernel archs: ${_KERNEL_ARCHS}")
+
+        foreach(_SRC ${_KERNEL_SRC})
+            if(_SRC MATCHES ".*\\.(cu|hip)$")
+                foreach(_ARCH ${_KERNEL_ARCHS})
+                    set_property(
+            SOURCE ${_SRC}
+            APPEND PROPERTY
+            COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:HIP>:--offload-arch=${_ARCH}>"
+          )
+                endforeach()
+            endif()
+        endforeach()
+
+        set(_TMP_SRC ${${SRC_VAR}})
+        list(APPEND _TMP_SRC ${_KERNEL_SRC})
+        set(${SRC_VAR} ${_TMP_SRC} PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(xpu_kernel_component SRC_VAR)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs SOURCES INCLUDES CXX_FLAGS SYCL_FLAGS)
+    cmake_parse_arguments(KERNEL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT KERNEL_SOURCES)
+        message(FATAL_ERROR "xpu_kernel_component: SOURCES argument is required")
+    endif()
+
+    set(_KERNEL_SRC ${KERNEL_SOURCES})
+
+    # Handle per-file include directories if specified
+    if(KERNEL_INCLUDES)
+        # TODO: check if CLion support this:
+        # https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
+        set_source_files_properties(
+            ${_KERNEL_SRC}
+            PROPERTIES INCLUDE_DIRECTORIES "${KERNEL_INCLUDES}")
+    endif()
+
+    # Apply CXX-specific compile flags
+    if(KERNEL_CXX_FLAGS)
+        foreach(_SRC ${_KERNEL_SRC})
+            set_property(
+                SOURCE ${_SRC}
+                APPEND PROPERTY
+                COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${KERNEL_CXX_FLAGS}>"
+            )
+        endforeach()
+    endif()
+
+    # Add SYCL-specific compilation flags for XPU sources
+    if(KERNEL_SYCL_FLAGS)
+        # Use kernel-specific SYCL flags
+        foreach(_SRC ${_KERNEL_SRC})
+            if(_SRC MATCHES ".*\\.(cpp|cxx|cc)$")
+                set_property(
+                    SOURCE ${_SRC}
+                    APPEND PROPERTY
+                    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${KERNEL_SYCL_FLAGS}>"
+                )
+            endif()
+        endforeach()
+    else()
+        # Use default SYCL flags (from parent scope variable sycl_flags)
+        foreach(_SRC ${_KERNEL_SRC})
+            if(_SRC MATCHES ".*\\.(cpp|cxx|cc)$")
+                set_property(
+                    SOURCE ${_SRC}
+                    APPEND PROPERTY
+                    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${sycl_flags}>"
+                )
+            endif()
+        endforeach()
+    endif()
+
+    # Append to parent scope SRC variable
+    set(_TMP_SRC ${${SRC_VAR}})
+    list(APPEND _TMP_SRC ${_KERNEL_SRC})
+    set(${SRC_VAR} ${_TMP_SRC} PARENT_SCOPE)
+endfunction()
+
+function(cpu_kernel_component SRC_VAR)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs SOURCES INCLUDES CXX_FLAGS)
+    cmake_parse_arguments(KERNEL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT KERNEL_SOURCES)
+        message(FATAL_ERROR "cpu_kernel_component: SOURCES argument is required")
+    endif()
+
+    set(_KERNEL_SRC ${KERNEL_SOURCES})
+
+    # Handle per-file include directories if specified
+    if(KERNEL_INCLUDES)
+        # TODO: check if CLion support this:
+        # https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
+        set_source_files_properties(
+            ${_KERNEL_SRC}
+            PROPERTIES INCLUDE_DIRECTORIES "${KERNEL_INCLUDES}")
+    endif()
+
+    # Apply CXX-specific compile flags
+    if(KERNEL_CXX_FLAGS)
+        foreach(_SRC ${_KERNEL_SRC})
+            set_property(
+                SOURCE ${_SRC}
+                APPEND PROPERTY
+                COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${KERNEL_CXX_FLAGS}>"
+            )
+        endforeach()
+    endif()
+
+    # Append to parent scope SRC variable
+    set(_TMP_SRC ${${SRC_VAR}})
+    list(APPEND _TMP_SRC ${_KERNEL_SRC})
+    set(${SRC_VAR} ${_TMP_SRC} PARENT_SCOPE)
+endfunction()
+
+function(metal_kernel_component SRC_VAR)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs SOURCES INCLUDES CXX_FLAGS)
+    cmake_parse_arguments(KERNEL "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT KERNEL_SOURCES)
+        message(FATAL_ERROR "metal_kernel_component: SOURCES argument is required")
+    endif()
+
+    set(_KERNEL_SRC ${KERNEL_SOURCES})
+
+    # Separate Metal shader files from other sources
+    set(_METAL_SRC)
+    set(_CPP_SRC)
+
+    foreach(_SRC_FILE IN LISTS _KERNEL_SRC)
+        if(_SRC_FILE MATCHES "\\.(metal|h)$")
+            list(APPEND _METAL_SRC ${_SRC_FILE})
+        else()
+            list(APPEND _CPP_SRC ${_SRC_FILE})
+        endif()
+    endforeach()
+
+    # Handle per-file include directories if specified (for C++ sources only)
+    if(KERNEL_INCLUDES AND _CPP_SRC)
+        # TODO: check if CLion support this:
+        # https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
+        set_source_files_properties(
+            ${_CPP_SRC}
+            PROPERTIES INCLUDE_DIRECTORIES "${KERNEL_INCLUDES}")
+    endif()
+
+    # Apply CXX-specific compile flags
+    if(KERNEL_CXX_FLAGS AND _CPP_SRC)
+        foreach(_SRC ${_CPP_SRC})
+            set_property(
+                SOURCE ${_SRC}
+                APPEND PROPERTY
+                COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${KERNEL_CXX_FLAGS}>"
+            )
+        endforeach()
+    endif()
+
+    # Add C++ sources to main source list
+    if(_CPP_SRC)
+        set(_TMP_SRC ${${SRC_VAR}})
+        list(APPEND _TMP_SRC ${_CPP_SRC})
+        set(${SRC_VAR} ${_TMP_SRC} PARENT_SCOPE)
+    endif()
+
+    # Keep track of Metal sources for later compilation
+    if(_METAL_SRC)
+        set(_TMP_METAL ${ALL_METAL_SOURCES})
+        list(APPEND _TMP_METAL ${_METAL_SRC})
+        set(ALL_METAL_SOURCES ${_TMP_METAL} PARENT_SCOPE)
+    endif()
+
+    # Keep the includes directory for the Metal sources
+    if(KERNEL_INCLUDES AND _METAL_SRC)
+        set(_TMP_METAL_INCLUDES ${METAL_INCLUDE_DIRS})
+        list(APPEND _TMP_METAL_INCLUDES ${KERNEL_INCLUDES})
+        set(METAL_INCLUDE_DIRS ${_TMP_METAL_INCLUDES} PARENT_SCOPE)
+    endif()
+endfunction()

--- a/build2cmake/src/templates/metal/kernel.cmake
+++ b/build2cmake/src/templates/metal/kernel.cmake
@@ -1,48 +1,5 @@
-set({{kernel_name}}_SRC
-  {{ sources }}
+metal_kernel_component(SRC
+  SOURCES {{ sources }}
+  {% if includes %}INCLUDES "{{ includes }}"{% endif %}
+  {% if cxx_flags %}CXX_FLAGS "{{ cxx_flags }}"{% endif %}
 )
-
-# Separate Metal shader files from other sources
-set({{kernel_name}}_METAL_SRC)
-set({{kernel_name}}_CPP_SRC)
-
-foreach(src_file IN LISTS {{kernel_name}}_SRC)
-  if(src_file MATCHES "\\.(metal|h)$")
-    list(APPEND {{kernel_name}}_METAL_SRC ${src_file})
-  else()
-    list(APPEND {{kernel_name}}_CPP_SRC ${src_file})
-  endif()
-endforeach()
-
-{% if includes %}
-# TODO: check if CLion support this:
-# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
-set_source_files_properties(
-  {{'${' + kernel_name + '_CPP_SRC}'}}
-  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
-{% endif %}
-
-{% if cxx_flags %}
-foreach(_KERNEL_SRC {{'${' + kernel_name + '_CPP_SRC}'}})
-  set_property(
-    SOURCE ${_KERNEL_SRC}
-    APPEND PROPERTY
-    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:{{ cxx_flags }}>"
-  )
-endforeach()
-{% endif %}
-
-# Add C++ sources to main source list
-list(APPEND SRC {{'"${' + kernel_name + '_CPP_SRC}"'}})
-
-# Keep track of Metal sources for later compilation
-if({{kernel_name}}_METAL_SRC)
-  list(APPEND ALL_METAL_SOURCES {{'"${' + kernel_name + '_METAL_SRC}"'}})
-endif()
-
-{% if includes %}
-# Keep the includes directory for the Metal sources
-if({{kernel_name}}_METAL_SRC)
-  list(APPEND METAL_INCLUDE_DIRS {{ includes }})
-endif()
-{% endif %}

--- a/build2cmake/src/templates/metal/preamble.cmake
+++ b/build2cmake/src/templates/metal/preamble.cmake
@@ -10,6 +10,7 @@ file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
 message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/kernel.cmake)
 
 if(DEFINED Python3_EXECUTABLE)
   # Allow passing through the interpreter (e.g. from setup.py).
@@ -43,5 +44,9 @@ endif()
 
 add_compile_definitions(METAL_KERNEL)
 
-# Initialize list for Metal shader sources
+# Initialize SRC list for kernel and binding sources
+set(SRC "")
+
+# Initialize lists for Metal shader sources and their include directories
 set(ALL_METAL_SOURCES)
+set(METAL_INCLUDE_DIRS)

--- a/build2cmake/src/templates/xpu/kernel.cmake
+++ b/build2cmake/src/templates/xpu/kernel.cmake
@@ -1,48 +1,6 @@
-set({{kernel_name}}_SRC
-  {{ sources }}
+xpu_kernel_component(SRC
+  SOURCES {{ sources }}
+  {% if includes %}INCLUDES "{{ includes }}"{% endif %}
+  {% if cxx_flags %}CXX_FLAGS "{{ cxx_flags }}"{% endif %}
+  {% if sycl_flags %}SYCL_FLAGS "{{ sycl_flags }}"{% endif %}
 )
-
-{% if includes %}
-# TODO: check if CLion support this:
-# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
-set_source_files_properties(
-  {{'${' + kernel_name + '_SRC}'}}
-  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
-{% endif %}
-
-{% if cxx_flags %}
-foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-  set_property(
-    SOURCE ${_KERNEL_SRC}
-    APPEND PROPERTY
-    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:{{ cxx_flags }}>"
-  )
-endforeach()
-{% endif %}
-
-# Add SYCL-specific compilation flags for XPU sources
-{% if sycl_flags %}
-# Use kernel-specific SYCL flags
-foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-  if(_KERNEL_SRC MATCHES ".*\\.(cpp|cxx|cc)$")
-    set_property(
-      SOURCE ${_KERNEL_SRC}
-      APPEND PROPERTY
-      COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:{{ sycl_flags }}>"
-    )
-  endif()
-endforeach()
-{% else %}
-# Use default SYCL flags
-foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-  if(_KERNEL_SRC MATCHES ".*\\.(cpp|cxx|cc)$")
-    set_property(
-      SOURCE ${_KERNEL_SRC}
-      APPEND PROPERTY
-      COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:${sycl_flags}>"
-    )
-  endif()
-endforeach()
-{% endif %}
-
-list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})

--- a/build2cmake/src/templates/xpu/preamble.cmake
+++ b/build2cmake/src/templates/xpu/preamble.cmake
@@ -12,7 +12,7 @@ if(ICX_COMPILER AND ICPX_COMPILER)
     string(REGEX MATCH "[0-9]+\\.[0-9]+" DPCPP_VERSION "${ICPX_VERSION_OUTPUT}")
     set(DPCPP_VERSION "${DPCPP_VERSION}" CACHE STRING "DPCPP major.minor version")
     set(CMAKE_C_COMPILER ${ICX_COMPILER})
-    
+
     # On Windows, use icx (MSVC-compatible) for C++ to work with Ninja generator
     # On Linux, use icpx (GNU-compatible) for C++
     if(WIN32)
@@ -33,6 +33,7 @@ file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
 message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 
 include("cmake/utils.cmake")
+include("cmake/kernel.cmake")
 
 # Find Python with all necessary components for building extensions
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module Development.SABIModule)
@@ -88,3 +89,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/windows.cmake)
 # Generate build variant name for XPU (e.g., torch291-xpu-x86_64-windows)
 generate_build_name(BUILD_VARIANT_NAME "${TORCH_VERSION}" "xpu" "${DPCPP_VERSION}")
 {% endif %}
+
+# Initialize SRC list for kernel and binding sources
+set(SRC "")

--- a/build2cmake/src/torch/cpu.rs
+++ b/build2cmake/src/torch/cpu.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 static CMAKE_UTILS: &str = include_str!("../templates/utils.cmake");
+static CMAKE_KERNEL: &str = include_str!("../templates/kernel.cmake");
 static REGISTRATION_H: &str = include_str!("../templates/registration.h");
 
 pub fn write_torch_ext_cpu(
@@ -72,6 +73,13 @@ fn write_cmake(
     file_set
         .entry(utils_path.clone())
         .extend_from_slice(CMAKE_UTILS.as_bytes());
+
+    let mut kernel_path = PathBuf::new();
+    kernel_path.push("cmake");
+    kernel_path.push("kernel.cmake");
+    file_set
+        .entry(kernel_path.clone())
+        .extend_from_slice(CMAKE_KERNEL.as_bytes());
 
     let cmake_writer = file_set.entry("CMakeLists.txt");
 

--- a/build2cmake/src/torch/cuda.rs
+++ b/build2cmake/src/torch/cuda.rs
@@ -15,6 +15,7 @@ use crate::version::Version;
 use crate::FileSet;
 
 static CMAKE_UTILS: &str = include_str!("../templates/utils.cmake");
+static CMAKE_KERNEL: &str = include_str!("../templates/kernel.cmake");
 static WINDOWS_UTILS: &str = include_str!("../templates/windows.cmake");
 static REGISTRATION_H: &str = include_str!("../templates/registration.h");
 static HIPIFY: &str = include_str!("../templates/cuda/hipify.py");
@@ -142,6 +143,13 @@ fn write_cmake(
     file_set
         .entry(utils_path.clone())
         .extend_from_slice(CMAKE_UTILS.as_bytes());
+
+    let mut kernel_path = PathBuf::new();
+    kernel_path.push("cmake");
+    kernel_path.push("kernel.cmake");
+    file_set
+        .entry(kernel_path.clone())
+        .extend_from_slice(CMAKE_KERNEL.as_bytes());
 
     let mut windows_utils_path = PathBuf::new();
     windows_utils_path.push("cmake");

--- a/build2cmake/src/torch/metal.rs
+++ b/build2cmake/src/torch/metal.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 static CMAKE_UTILS: &str = include_str!("../templates/utils.cmake");
+static CMAKE_KERNEL: &str = include_str!("../templates/kernel.cmake");
 static REGISTRATION_H: &str = include_str!("../templates/registration.h");
 static COMPILE_METAL_CMAKE: &str = include_str!("../templates/metal/compile-metal.cmake");
 static METALLIB_TO_HEADER_PY: &str = include_str!("../templates/metal/metallib_to_header.py");
@@ -74,6 +75,13 @@ fn write_cmake(
     file_set
         .entry(utils_path.clone())
         .extend_from_slice(CMAKE_UTILS.as_bytes());
+
+    let mut kernel_path = PathBuf::new();
+    kernel_path.push("cmake");
+    kernel_path.push("kernel.cmake");
+    file_set
+        .entry(kernel_path.clone())
+        .extend_from_slice(CMAKE_KERNEL.as_bytes());
 
     let mut compile_metal_path = PathBuf::new();
     compile_metal_path.push("cmake");

--- a/build2cmake/src/torch/xpu.rs
+++ b/build2cmake/src/torch/xpu.rs
@@ -14,6 +14,7 @@ use crate::version::Version;
 use crate::FileSet;
 
 static CMAKE_UTILS: &str = include_str!("../templates/utils.cmake");
+static CMAKE_KERNEL: &str = include_str!("../templates/kernel.cmake");
 static REGISTRATION_H: &str = include_str!("../templates/registration.h");
 static WINDOWS_UTILS: &str = include_str!("../templates/windows.cmake");
 
@@ -145,6 +146,13 @@ fn write_cmake(
     file_set
         .entry(windows_utils_path.clone())
         .extend_from_slice(WINDOWS_UTILS.as_bytes());
+
+    let mut kernel_path = PathBuf::new();
+    kernel_path.push("cmake");
+    kernel_path.push("kernel.cmake");
+    file_set
+        .entry(kernel_path.clone())
+        .extend_from_slice(CMAKE_KERNEL.as_bytes());
 
     let cmake_writer = file_set.entry("CMakeLists.txt");
 


### PR DESCRIPTION
Our end goal is to generate a CMake file that works with all backends. This is a first step, handle the kernel components using functions, so that we can later generate the calls for every backend. The calls are still in backend-specific code for now.