### PR TITLE
Fix build set issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,8 +92,7 @@
             || abort "`torchVersions` must be a function taking one argument (the default version set)";
           let
             buildSets = mkBuildSets (torchVersions torchVersions') systems;
-            buildSetPerSystem = partitionBuildSetsBySystem buildSets;
-            buildPerSystem = mkBuildPerSystem buildSetPerSystem;
+            buildSetsPerSystem = partitionBuildSetsBySystem buildSets;
           in
           flake-utils.lib.eachSystem systems (
             system:
@@ -108,11 +107,10 @@
                 pythonNativeCheckInputs
                 ;
               build = buildPerSystem.${system};
-              buildSets = buildSetPerSystem.${system};
+              buildSets = buildSetsPerSystem.${system} or [ ];
             }
           );
       };
-      #// defaultBuildPerSystem;
     in
     flake-utils.lib.eachSystem systems (
       system:


### PR DESCRIPTION
- Create `buildPerSystem` for all systems, not just the ones we have build sets for.
- When there is no build set for a system, use an empty list (so that trying to build a kernel flake does not error out).