### PR TITLE
feat: include benchmark dir in bundle

### DIFF
--- a/builder/lib/build.nix
+++ b/builder/lib/build.nix
@@ -224,9 +224,11 @@ rec {
       # Include benchmarks directory if it exists in the source
       benchmarksPath = path + "/benchmarks";
       hasBenchmarks = builtins.pathExists benchmarksPath;
-      allPaths = namePaths // lib.optionalAttrs hasBenchmarks {
-        benchmarks = benchmarksPath;
-      };
+      allPaths =
+        namePaths
+        // lib.optionalAttrs hasBenchmarks {
+          benchmarks = benchmarksPath;
+        };
     in
     import ./join-paths {
       inherit pkgs;


### PR DESCRIPTION
This PR simply includes the benchmark directory in the bundle so they will be uploaded in release builds


tested locally on mbp

```bash
cd kernels-community/relu
nix run .#build-and-copy -L
```

```bash
tree build -L 2
```
output
```
build
├── benchmarks
│   └── benchmark.py
├── torch210-metal-aarch64-darwin
│   ├── __init__.py
│   ├── _ops.py
│   ├── _relu_26740b1_dirty.abi3.so
│   ├── metadata.json
│   └── relu
└── torch29-metal-aarch64-darwin
    ├── __init__.py
    ├── _ops.py
    ├── _relu_26740b1_dirty.abi3.so
    ├── metadata.json
    └── relu

6 directories, 9 files
```