### PR TITLE
Rename cutlass-sycl to sycl-tla

### DIFF
--- a/build2cmake/src/config/deps.rs
+++ b/build2cmake/src/config/deps.rs
@@ -25,8 +25,8 @@ pub enum Dependency {
     Cutlass3_9,
     #[serde(rename = "cutlass_4_0")]
     Cutlass4_0,
-    #[serde(rename = "cutlass_sycl")]
-    CutlassSycl,
+    #[serde(rename = "sycl_tla")]
+    SyclTla,
     #[serde(rename = "metal-cpp")]
     MetalCpp,
     Torch,

--- a/build2cmake/src/templates/xpu/dep-sycl-tla.cmake
+++ b/build2cmake/src/templates/xpu/dep-sycl-tla.cmake
@@ -1,38 +1,38 @@
 if(GPU_LANG STREQUAL "SYCL")
 
-find_package(CutlassSycl)
+find_package(SyclTla)
 
 if(DPCPP_VERSION STREQUAL "2025.3")
-  set(CUTLASS_SYCL_REVISION "14055e78510b8776ba739755eb57e592fdceefdb" CACHE STRING "CUTLASS revision to use")
+  set(SYCL_TLA_REVISION "14055e78510b8776ba739755eb57e592fdceefdb" CACHE STRING "CUTLASS revision to use")
 elseif(DPCPP_VERSION STREQUAL "2025.2")
-  set(CUTLASS_SYCL_REVISION "14055e78510b8776ba739755eb57e592fdceefdb" CACHE STRING "CUTLASS revision to use")
+  set(SYCL_TLA_REVISION "14055e78510b8776ba739755eb57e592fdceefdb" CACHE STRING "CUTLASS revision to use")
 elseif(DPCPP_VERSION STREQUAL "2025.1")
-  set(CUTLASS_SYCL_REVISION "v3.9-0.3" CACHE STRING "CUTLASS revision to use")
+  set(SYCL_TLA_REVISION "v3.9-0.3" CACHE STRING "CUTLASS revision to use")
 elseif(DPCPP_VERSION STREQUAL "2025.0")
-  set(CUTLASS_SYCL_REVISION "v3.9-0.2" CACHE STRING "CUTLASS revision to use")
+  set(SYCL_TLA_REVISION "v3.9-0.2" CACHE STRING "CUTLASS revision to use")
 else()
   message(FATAL_ERROR "Unknown DPCPP_VERSION: ${DPCPP_VERSION}")
 endif()
 
-if (NOT CutlassSycl_FOUND)
+if (NOT SyclTla_FOUND)
   set(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
   set(CUTLASS_ENABLE_BENCHMARKS OFF CACHE BOOL "Disable CUTLASS Benchmarks")
-# Use the specified CUTLASS source directory for compilation if CUTLASS_SYCL_SRC_DIR is provided
-  if (DEFINED ENV{CUTLASS_SYCL_SRC_DIR})
-    set(CUTLASS_SYCL_SRC_DIR $ENV{CUTLASS_SYCL_SRC_DIR})
+# Use the specified CUTLASS source directory for compilation if SYCL_TLA_SRC_DIR is provided
+  if (DEFINED ENV{SYCL_TLA_SRC_DIR})
+    set(SYCL_TLA_SRC_DIR $ENV{SYCL_TLA_SRC_DIR})
   endif()
 
-  if(CUTLASS_SYCL_SRC_DIR)
-    if(NOT IS_ABSOLUTE CUTLASS_SYCL_SRC_DIR)
-      get_filename_component(CUTLASS_SYCL_SRC_DIR "${CUTLASS_SYCL_SRC_DIR}" ABSOLUTE)
+  if(SYCL_TLA_SRC_DIR)
+    if(NOT IS_ABSOLUTE SYCL_TLA_SRC_DIR)
+      get_filename_component(SYCL_TLA_SRC_DIR "${SYCL_TLA_SRC_DIR}" ABSOLUTE)
     endif()
-    message(STATUS "The CUTLASS_SYCL_SRC_DIR is set, using ${CUTLASS_SYCL_SRC_DIR} for compilation")
-    FetchContent_Declare(cutlass SOURCE_DIR ${CUTLASS_SYCL_SRC_DIR})
+    message(STATUS "The SYCL_TLA_SRC_DIR is set, using ${SYCL_TLA_SRC_DIR} for compilation")
+    FetchContent_Declare(cutlass SOURCE_DIR ${SYCL_TLA_SRC_DIR})
   else()
     # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.
     # Important: If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags.
     # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
-    if(CUTLASS_SYCL_REVISION MATCHES "^v")
+    if(SYCL_TLA_REVISION MATCHES "^v")
       set(CUTLASS_GIT_SHALLOW TRUE)
     else()
       set(CUTLASS_GIT_SHALLOW FALSE)
@@ -40,14 +40,14 @@ if (NOT CutlassSycl_FOUND)
     FetchContent_Declare(
         cutlass
         GIT_REPOSITORY https://github.com/intel/sycl-tla.git
-        GIT_TAG ${CUTLASS_SYCL_REVISION}
+        GIT_TAG ${SYCL_TLA_REVISION}
         GIT_PROGRESS TRUE
         GIT_SHALLOW ${CUTLASS_GIT_SHALLOW}
     )
   endif()
 
   # Set Intel backend env
-  message(STATUS "Setting Intel GPU optimization env vars for Cutlass-SYCL")
+  message(STATUS "Setting Intel GPU optimization env vars for sycl-tla")
   set(CUTLASS_ENABLE_SYCL ON CACHE BOOL "Enable SYCL for CUTLASS")
   add_compile_definitions(CUTLASS_ENABLE_SYCL=1)
   set(DPCPP_SYCL_TARGET "intel_gpu_bmg_g21,intel_gpu_pvc" CACHE STRING "SYCL target for Intel GPU")
@@ -67,15 +67,15 @@ if (NOT CutlassSycl_FOUND)
 else()
   include_directories(${CUTLASS_INCLUDE_DIR})
   include_directories(${CUTLASS_TOOLS_UTIL_INCLUDE_DIR})
-endif(NOT CutlassSycl_FOUND)
-if(CUTLASS_SYCL_REVISION MATCHES "^v3\\.9")
+endif(NOT SyclTla_FOUND)
+if(SYCL_TLA_REVISION MATCHES "^v3\\.9")
   add_compile_definitions(OLD_API=1)
 endif()
 
 string(REPLACE "-fsycl-targets=spir64_gen,spir64" "-fsycl-targets=spir64" sycl_link_flags "${sycl_link_flags}")
 string(REPLACE "-device pvc,xe-lpg,ats-m150" "-device bmg_g21,pvc" sycl_link_flags "${sycl_link_flags}")
 string(APPEND sycl_link_flags "-Xspirv-translator;-spirv-ext=+SPV_INTEL_split_barrier")
-if(DPCPP_VERSION STREQUAL "2025.2" OR DPCPP_VERSION STREQUAL "2025.3" OR CUTLASS_SYCL_REVISION STREQUAL "v0.5")
+if(DPCPP_VERSION STREQUAL "2025.2" OR DPCPP_VERSION STREQUAL "2025.3" OR SYCL_TLA_REVISION STREQUAL "v0.5")
   string(APPEND sycl_link_flags ",+SPV_INTEL_2d_block_io,+SPV_INTEL_subgroup_matrix_multiply_accumulate")
 endif()
 string(REPLACE "-fsycl-targets=spir64_gen,spir64" "-fsycl-targets=spir64" sycl_flags "${sycl_flags}")

--- a/build2cmake/src/torch/deps.rs
+++ b/build2cmake/src/torch/deps.rs
@@ -81,8 +81,8 @@ pub fn render_deps(env: &Environment, build: &Build, write: &mut impl Write) -> 
                     )
                     .wrap_err("Cannot render CUTLASS dependency template")?;
             }
-            Dependency::CutlassSycl => {
-                env.get_template("xpu/dep-cutlass-sycl.cmake")?
+            Dependency::SyclTla => {
+                env.get_template("xpu/dep-sycl-tla.cmake")?
                     .render_to_write(context! {}, &mut *write)?;
             }
             Dependency::MetalCpp => {

--- a/builder/examples/cutlass-gemm/build.toml
+++ b/builder/examples/cutlass-gemm/build.toml
@@ -23,7 +23,7 @@ src = ["gemm.cu"]
 backend = "xpu"
 depends = [
     "torch",
-    "cutlass_sycl",
+    "sycl_tla",
 ]
 src = ["gemm_sycl.cpp"]
 

--- a/builder/lib/deps.nix
+++ b/builder/lib/deps.nix
@@ -27,7 +27,7 @@ let
     "torch" = [
       torch
     ];
-    "cutlass_sycl" = [ torch.xpuPackages.cutlass-sycl ];
+    "sycl_tla" = [ torch.xpuPackages.sycl-tla ];
     "metal-cpp" = [
       pkgs.metal-cpp.dev
     ];

--- a/nix/pkgs/xpu-packages/default.nix
+++ b/nix/pkgs/xpu-packages/default.nix
@@ -29,7 +29,7 @@ let
       ocloc = final.callPackage ./ocloc.nix { };
     })
     (final: prev: {
-      cutlass-sycl = final.callPackage ./cutlass-sycl.nix { };
+      sycl-tla = final.callPackage ./sycl-tla.nix { };
     })
   ];
 in

--- a/nix/pkgs/xpu-packages/sycl-tla.nix
+++ b/nix/pkgs/xpu-packages/sycl-tla.nix
@@ -34,7 +34,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  pname = "cutlass-sycl";
+  pname = "sycl-tla";
   inherit (cutlassVersion) version;
 
   src = fetchFromGitHub (
@@ -73,10 +73,10 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-        mkdir -p $out/lib $out/include $out/tools/util/include $out/lib/cmake/CutlassSycl
+        mkdir -p $out/lib $out/include $out/tools/util/include $out/lib/cmake/SyclTla
         cp -rn $src/include/* $out/include/
         cp -rn $src/tools/util/include/* $out/tools/util/include/
-        cat > $out/lib/cmake/CutlassSycl/CutlassSyclConfig.cmake <<EOF
+        cat > $out/lib/cmake/SyclTla/SyclTlaConfig.cmake <<EOF
     set(CUTLASS_INCLUDE_DIR  "$out/include")
     set(CUTLASS_TOOLS_UTIL_INCLUDE_DIR "$out/tools/util/include")
     add_compile_definitions(CUTLASS_ENABLE_SYCL)


### PR DESCRIPTION
The project `cutlass-sycl` has now been renamed to `sycl-tla`. This PR updates the relevant parameter names accordingly.