### PR TITLE
Fix reference to repo in get_layer function

### DIFF
--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -380,7 +380,7 @@ def _get_kernel_layer(
 ) -> Type["nn.Module"]:
     """Get a layer from a kernel."""
 
-    if getattr(kernel, "layers", None) is None:
+    if getattr(repo, "layers", None) is None:
         raise ValueError(f"Kernel repo {repo} does not define any layers.")
 
     layer = getattr(kernel.layers, repo.layer_name, None)


### PR DESCRIPTION
There is a bug that breaks the ability to use custom layer repos since it checks for `kernel.layers` rather than `repo.layers`