### PR TITLE
chore: fix minor markdown backtick mistake

### DIFF
--- a/skills/cuda-kernels/references/kernel-templates.md
+++ b/skills/cuda-kernels/references/kernel-templates.md
@@ -322,7 +322,6 @@ void rmsnorm_forward_bf16(
         );
     }
 }
-```
 
 // C++ entry points
 extern "C" {


### PR DESCRIPTION
I know this is very trivial and minor change.

But I just couldn't stand only this codeblock having the wrong code block :P

I thought it was awkward mentioning this on issues, so just opened the PR.