### PR TITLE
pass revision to to cmake template

### DIFF
--- a/build2cmake/src/torch/common.rs
+++ b/build2cmake/src/torch/common.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use eyre::{bail, Context, Result};
 use itertools::Itertools;
@@ -227,12 +227,11 @@ pub fn render_preamble(
     env: &Environment,
     general: &General,
     torch: &Torch,
-    target_dir: impl AsRef<Path>,
+    revision: &str,
     write: &mut impl Write,
 ) -> Result<()> {
     let cuda_minver = general.cuda.as_ref().and_then(|c| c.minver.as_ref());
     let cuda_maxver = general.cuda.as_ref().and_then(|c| c.maxver.as_ref());
-    let revision = git_identifier(&target_dir).unwrap_or_else(|_| random_identifier());
 
     env.get_template("preamble.cmake")
         .wrap_err("Cannot get CMake prelude template")?
@@ -258,16 +257,16 @@ pub fn render_preamble(
 pub fn write_cmake(
     env: &Environment,
     build: &Build,
-    target_dir: impl AsRef<Path>,
     torch: &Torch,
     name: &str,
+    revision: &str,
     file_set: &mut FileSet,
 ) -> Result<()> {
     write_cmake_helpers(file_set);
 
     let cmake_writer = file_set.entry("CMakeLists.txt");
 
-    render_preamble(env, &build.general, torch, &target_dir, cmake_writer)?;
+    render_preamble(env, &build.general, torch, revision, cmake_writer)?;
 
     render_deps(env, build, cmake_writer)?;
 
@@ -299,9 +298,9 @@ pub fn write_torch_ext(
     write_cmake(
         env,
         build,
-        &target_dir,
         torch_ext,
         build.general.name.as_str(),
+        &revision,
         &mut file_set,
     )?;
 

--- a/builder/lib/torch-extension/arch.nix
+++ b/builder/lib/torch-extension/arch.nix
@@ -244,7 +244,7 @@ stdenv.mkDerivation (prevAttrs: {
       buildVariant = torch.variant;
     in
     ''
-      rm -rf $out/_${moduleName}_${rev}
+      rm -rf $out/_${moduleName}_*_${rev}
     ''
     + (lib.optionalString (stripRPath && stdenv.hostPlatform.isLinux)) ''
       find $out/ -name '*.so' \


### PR DESCRIPTION
This PR fixes a bug where the ops id was not passed to render_preamble, causing it to fall back to a different identifier in Nix builds. This made the cmake extension name diverge from the expected name. 

Additionally, the postInstall cleanup pattern was missing the backend segment, so stale build artifacts were not removed. Together these caused build-and-copy to fail with Permission denied when bundling multiple variants.

error when using the builder on main
```bash
nix flake update
nix run .#build-and-copy -L --cores 2 --max-jobs 8
# torch-ext-bundle> cp: cannot create regular file '/nix/store/i0lf882dgvi9ffgc1sq92s0n330w3ynl-torch-ext-bundle/_flash_mla_cuda_ghzc76n4to3fq/_flash_mla_cuda_ghzc76n4to3fq.abi3.so': Permission denied
# error: Cannot build '/nix/store/ijd011d4pz5jy56m2c2q21fmrhnyjml9-torch-ext-bundle.drv'.
#        Reason: builder failed with exit code 1.
#        Output paths:
#          /nix/store/i0lf882dgvi9ffgc1sq92s0n330w3ynl-torch-ext-bundle
#        Last 1 log lines:
#        > cp: cannot create regular file '/nix/store/i0lf882dgvi9ffgc1sq92s0n330w3ynl-torch-ext-bundle/_flash_mla_cuda_ghzc76n4to3fq/_flash_mla_cuda_ghzc76n4to3fq.abi3.so': Permission denied
#        For full logs, run:
#          nix log /nix/store/ijd011d4pz5jy56m2c2q21fmrhnyjml9-torch-ext-bundle.drv
# error: Cannot build '/nix/store/dmwahvzhw1vsy2kqvz39sipv81x3iws0-build-and-copy.drv'.
#        Reason: 1 dependency failed.
#        Output paths:
#          /nix/store/pwsp646ri9y2c61azk9smqm4n8j37fa9-build-and-copy
# ❌ /nix/store/dmwahvzhw1vsy2kqvz39sipv81x3iws0-build-and-copy.drv^out
# error: Build failed due to failed dependency
```

example of build output when using an older version of the builder that didnt cause the collision but didnt clean up the build artifacts
```bash
# set kernel-builder.url = "github:huggingface/kernels/2c436beccd9adf962f1634c45e825e69909768c6";
tree -L 1 build
# build
# ├── _flash_mla_cuda_ffxujicuwi76y
# ├── _flash_mla_cuda_hu5pgjzy2nejw
# ├── _flash_mla_cuda_lsxvehlvaijjo
# ├── _flash_mla_cuda_syrdugbz4gcrc
# ├── torch210-cxx11-cu128-x86_64-linux
# ├── torch210-cxx11-cu130-x86_64-linux
# ├── torch29-cxx11-cu128-x86_64-linux
# └── torch29-cxx11-cu130-x86_64-linux
```

example build after changes
```bash
# set kernel-builder.url = "path:/home/drbh/Projects/kernels";
nix run .#build-and-copy -L --cores 2 --max-jobs 8
tree -L 1 build
# build
# ├── torch210-cxx11-cu128-x86_64-linux
# ├── torch210-cxx11-cu130-x86_64-linux
# ├── torch29-cxx11-cu128-x86_64-linux
# └── torch29-cxx11-cu130-x86_64-linux
```

note: upon further investigation the collision seems to happen after https://github.com/huggingface/kernels/pull/281 which seemed to result in the same identifier being used in multiple variants which resulted in a conflict in the join-paths merge. the changes in this PR avoid this bug and result in a reliable build output