### PR TITLE
fix: update template and init to use new repo and format

### DIFF
--- a/.github/workflows/publish_template.yml
+++ b/.github/workflows/publish_template.yml
@@ -1,6 +1,7 @@
 name: Publish Template to kernels-community/template
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/kernels/src/kernels/cli/__init__.py
+++ b/kernels/src/kernels/cli/__init__.py
@@ -229,7 +229,7 @@ def main():
     init_parser.add_argument(
         "--template-repo",
         type=str,
-        default="drbh/template",
+        default="kernels-community/template",
         help="HuggingFace repo ID for the template",
     )
     init_parser.add_argument(

--- a/kernels/src/kernels/cli/skills.py
+++ b/kernels/src/kernels/cli/skills.py
@@ -8,13 +8,10 @@ from huggingface_hub.utils import get_session
 
 DEFAULT_SKILL_ID = "cuda-kernels"
 _GITHUB_RAW_BASE = (
-    "https://raw.githubusercontent.com/huggingface/kernels/main/"
-    "skills/cuda-kernels"
+    "https://raw.githubusercontent.com/huggingface/kernels/main/" "skills/cuda-kernels"
 )
 _MANIFEST_URL = f"{_GITHUB_RAW_BASE}/manifest.txt"
-_LOCAL_SKILLS_ROOT = (
-    Path(__file__).resolve().parents[4] / "skills" / "cuda-kernels"
-)
+_LOCAL_SKILLS_ROOT = Path(__file__).resolve().parents[4] / "skills" / "cuda-kernels"
 
 GLOBAL_TARGETS = {
     "codex": Path("~/.codex/skills"),
@@ -79,8 +76,7 @@ def _install_to(target: Path, force: bool) -> Path:
     if dest.exists():
         if not force:
             raise SystemExit(
-                f"Skill already exists at {dest}.\n"
-                "Re-run with --force to overwrite."
+                f"Skill already exists at {dest}.\n" "Re-run with --force to overwrite."
             )
         _remove_existing(dest)
 

--- a/kernels/tests/test_init.py
+++ b/kernels/tests/test_init.py
@@ -9,7 +9,7 @@ from kernels.utils import KNOWN_BACKENDS
 
 def e2e_init(backends: list[str]) -> None:
     kernel_name = "testuser/test-kernel"
-    template_repo = "drbh/template"
+    template_repo = "kernels-community/template"
     args = argparse.Namespace(
         kernel_name=parse_kernel_name(kernel_name),
         template_repo=template_repo,

--- a/template/__KERNEL_NAME_NORMALIZED___metal/__KERNEL_NAME_NORMALIZED__.metal
+++ b/template/__KERNEL_NAME_NORMALIZED___metal/__KERNEL_NAME_NORMALIZED__.metal
@@ -1,14 +1,8 @@
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void __KERNEL_NAME_NORMALIZED___forward_kernel_float(device const float *input [[buffer(0)]],
-                                device float *output [[buffer(1)]],
-                                uint index [[thread_position_in_grid]]) {
+kernel void __KERNEL_NAME_NORMALIZED___kernel(device const float *input [[buffer(0)]],
+                                              device float *output [[buffer(1)]],
+                                              uint index [[thread_position_in_grid]]) {
     output[index] = input[index] + 1.0f;
-}
-
-kernel void __KERNEL_NAME_NORMALIZED___forward_kernel_half(device const half *input [[buffer(0)]],
-                                device half *output [[buffer(1)]],
-                                uint index [[thread_position_in_grid]]) {
-    output[index] = input[index] + static_cast<half>(1.0);
 }


### PR DESCRIPTION
This PR
- update the template to use the one on https://huggingface.co/kernels-community/template
- runs the formatter for the skills file
- allows the template workflow to be manually triggered
- removes the half example from the metal template