### PR TITLE
fix: adjust token for upload to hub

### DIFF
--- a/.github/workflows/publish_template.yml
+++ b/.github/workflows/publish_template.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Upload template to Hugging Face Hub
         env:
-          HF_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           hf upload kernels-community/template template --repo-type model --delete "*"


### PR DESCRIPTION
This PR is a hotfix to use the correct token to push template updates to the hub