### PR TITLE
feat: enable bundling cutlass in build

### DIFF
--- a/build2cmake/src/config/mod.rs
+++ b/build2cmake/src/config/mod.rs
@@ -117,6 +117,7 @@ pub struct Torch {
     pub maxver: Option<Version>,
     pub pyext: Option<Vec<String>>,
     pub src: Vec<PathBuf>,
+    pub bundle_dep_includes: Option<Vec<Dependency>>,
 }
 
 impl Torch {

--- a/build2cmake/src/config/v1.rs
+++ b/build2cmake/src/config/v1.rs
@@ -161,6 +161,7 @@ impl From<Torch> for super::Torch {
             maxver: None,
             pyext: torch.pyext,
             src: torch.src,
+            bundle_dep_includes: None,
         }
     }
 }

--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -191,6 +191,7 @@ impl From<Torch> for super::Torch {
             maxver: torch.maxver,
             pyext: torch.pyext,
             src: torch.src,
+            bundle_dep_includes: None,
         }
     }
 }

--- a/build2cmake/src/config/v3.rs
+++ b/build2cmake/src/config/v3.rs
@@ -67,6 +67,9 @@ pub struct Torch {
 
     #[serde(default)]
     pub src: Vec<PathBuf>,
+
+    #[serde(default, rename = "bundle-dep-includes")]
+    pub bundle_dep_includes: Option<Vec<super::Dependency>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -191,6 +194,7 @@ impl From<Torch> for super::Torch {
             maxver: torch.maxver,
             pyext: torch.pyext,
             src: torch.src,
+            bundle_dep_includes: torch.bundle_dep_includes,
         }
     }
 }
@@ -345,6 +349,7 @@ impl From<super::Torch> for Torch {
             maxver: torch.maxver,
             pyext: torch.pyext,
             src: torch.src,
+            bundle_dep_includes: torch.bundle_dep_includes,
         }
     }
 }


### PR DESCRIPTION
This is an experimental feature that adds a `bundle-dep-includes` attribute to the build toml that enables the inclusion of cutlass headers in the build artifacts. 

This feature enables the deep-gemm kernel to be built, since the kernel does JIT compilation using the cutlass and cute library at runtime. 

Initially I opted to vendor the dependencies in the kernel source but that adds hundreds of files that we already have available within the builder itself, this approach reuses the existing files and writes them into the build as shown below

```bash
└── torch29-cxx11-cu130-x86_64-linux
    ├── deep_gemm
    │   └── __init__.py
    ├── _deep_gemm_cuda_7f1079e_dirty.abi3.so
    ├── include
    │   ├── cute
    │   ├── cutlass
    │   └── deep_gemm
    ├── __init__.py
    ├── metadata.json
    ├── _ops.py
    └── utils
        ├── __init__.py
        └── math.py
```
