### PR TITLE
Fix link to terraform directory in writing-kernels.md

### DIFF
--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -37,7 +37,7 @@ support.
 
 ## Setting up environment
 
-In the [`terraform`](../../../terraform/) directory, we provide an
+In the [`terraform`](https://github.com/huggingface/kernels/tree/main/terraform) directory, we provide an
 example of programatically spinning up an EC2 instance that is ready
 with everything needed for you to start developing and building
 kernels.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Updated link to the terraform directory

## Details
The current link points to this HF user: https://huggingface.co/Terraform
I recognize that this fix won't work nicely locally, but I reckon it either works on https://huggingface.co/docs/kernels/builder/writing-kernels or it works locally, and then perhaps the preference is to get it looking correctly on the Hub docs.

- Tom Aarsen