### PR TITLE
nix-builder: wire up get-kernel-check in tvm-ffi builds

### DIFF
--- a/kernels/tests/test_tvm_ffi.py
+++ b/kernels/tests/test_tvm_ffi.py
@@ -1,6 +1,7 @@
 import pytest
 
-from kernels import get_kernel
+from kernels import get_kernel, install_kernel, get_local_kernel
+
 
 relu_supported_devices = ["cpu", "cuda", "xpu"]
 
@@ -23,3 +24,11 @@ def test_relu_torch(device):
     out = kernel.relu(x, torch.empty_like(x))
 
     torch.testing.assert_close(out, torch.relu(x))
+
+
+def test_local_load(device):
+    if device not in relu_supported_devices:
+        pytest.skip(f"Device is not one of: {','.join(relu_supported_devices)}")
+
+    package_name, path = install_kernel("kernels-test/relu-tvm-ffi", "v1")
+    get_local_kernel(path.parent.parent, package_name)

--- a/nix-builder/lib/extension/tvm-ffi/arch.nix
+++ b/nix-builder/lib/extension/tvm-ffi/arch.nix
@@ -82,7 +82,10 @@ let
   dependencies =
     resolvePythonDeps pythonDeps
     ++ resolveBackendPythonDeps buildConfig.backend backendPythonDeps
-    ++ [ torch ];
+    ++ [
+      torch
+      python3.pkgs.tvm-ffi
+    ];
 
   moduleName = builtins.replaceStrings [ "-" ] [ "_" ] kernelName;
 
@@ -149,10 +152,9 @@ stdenv.mkDerivation (prevAttrs: {
     kernel-layout-check
     remove-bytecode-hook
   ]
-  # TODO: renenable
-  #++ lib.optionals doGetKernelCheck [
-  #  (get-kernel-check.override { python3 = python3.withPackages (ps: dependencies); })
-  #]
+  ++ lib.optionals doGetKernelCheck [
+    (get-kernel-check.override { python3 = python3.withPackages (ps: dependencies); })
+  ]
   ++ lib.optionals cudaSupport [
     cmakeNvccThreadsHook
     cuda_nvcc


### PR DESCRIPTION
Also test loading of local kernels.