### PR TITLE
Make all kernel-builder subcommands take a directory

### DIFF
--- a/docs/source/builder/local-dev.md
+++ b/docs/source/builder/local-dev.md
@@ -25,11 +25,12 @@ $ cargo install hf-kernel-builder
 
 ## Generating a Python project with `kernel-builder`
 
-`kernel-builder` generates a CMake/Python project from a [`build.toml`](./writing-kernels.md)
-file. The invocation is as follows:
+`kernel-builder` can create CMake/Python project files for a kernel with
+a [`build.toml`](./writing-kernels.md) file. The `create-pyproject`
+command will create the files for the kernel in the current directory:
 
 ```bash
-$ kernel-builder create-pyproject build.toml -f
+$ kernel-builder create-pyproject -f
 ```
 
 The `-f` flag is optional and instructs `kernel-builder` to overwrite
@@ -41,6 +42,12 @@ your Python virtual environment for development:
 ```bash
 $ pip install wheel # Needed once to enable bdist_wheel.
 $ pip install --no-build-isolation -e .
+```
+
+You can also create a Python project for a kernel in another directory:
+
+```bash
+$ kernel-builder create-pyproject -f path/to/kernel
 ```
 
 **Warnings:**

--- a/docs/source/builder/nix.md
+++ b/docs/source/builder/nix.md
@@ -62,7 +62,7 @@ project files. For example:
 
 ```bash
 $ nix develop
-$ kernel-builder create-pyproject build.toml
+$ kernel-builder create-pyproject
 $ cmake -B build-ext
 $ cmake --build build-ext
 ```
@@ -74,7 +74,7 @@ Python package in this virtual environment:
 
 ```bash
 $ nix develop
-$ kernel-builder create-pyproject build.toml
+$ kernel-builder create-pyproject
 $ pip install --no-build-isolation -e .
 ```
 

--- a/kernel-builder/src/main.rs
+++ b/kernel-builder/src/main.rs
@@ -12,7 +12,7 @@ mod config;
 use config::{v3, Build, BuildCompat};
 
 mod util;
-use util::parse_and_validate;
+use util::{check_or_infer_kernel_dir, parse_and_validate};
 
 mod version;
 
@@ -27,8 +27,8 @@ struct Cli {
 enum Commands {
     /// Generate CMake files for a kernel extension build.
     CreatePyproject {
-        #[arg(name = "BUILD_TOML")]
-        build_toml: PathBuf,
+        #[arg(name = "KERNEL_DIR")]
+        kernel_dir: Option<PathBuf>,
 
         /// The directory to write the generated files to
         /// (directory of `BUILD_TOML` when absent).
@@ -47,20 +47,20 @@ enum Commands {
 
     /// Update a `build.toml` to the current format.
     UpdateBuild {
-        #[arg(name = "BUILD_TOML")]
-        build_toml: PathBuf,
+        #[arg(name = "KERNEL_DIR")]
+        kernel_dir: Option<PathBuf>,
     },
 
     /// Validate the build.toml file.
     Validate {
-        #[arg(name = "BUILD_TOML")]
-        build_toml: PathBuf,
+        #[arg(name = "KERNEL_DIR")]
+        kernel_dir: Option<PathBuf>,
     },
 
     /// Clean generated artifacts.
     CleanPyproject {
-        #[arg(name = "BUILD_TOML")]
-        build_toml: PathBuf,
+        #[arg(name = "KERNEL_DIR")]
+        kernel_dir: Option<PathBuf>,
 
         /// The directory to clean from (directory of `BUILD_TOML` when absent).
         #[arg(name = "TARGET_DIR")]
@@ -85,28 +85,35 @@ fn main() -> Result<()> {
     let args = Cli::parse();
     match args.command {
         Commands::CreatePyproject {
-            build_toml,
+            kernel_dir,
             force,
             target_dir,
             ops_id,
-        } => create_pyproject(build_toml, target_dir, force, ops_id),
-        Commands::UpdateBuild { build_toml } => update_build(build_toml),
-        Commands::Validate { build_toml } => {
-            parse_and_validate(build_toml)?;
+        } => create_pyproject(kernel_dir, target_dir, force, ops_id),
+        Commands::UpdateBuild { kernel_dir } => update_build(kernel_dir),
+        Commands::Validate { kernel_dir } => {
+            validate(kernel_dir)?;
             Ok(())
         }
         Commands::CleanPyproject {
-            build_toml,
+            kernel_dir,
             target_dir,
             dry_run,
             force,
             ops_id,
-        } => clean_pyproject(build_toml, target_dir, dry_run, force, ops_id),
+        } => clean_pyproject(kernel_dir, target_dir, dry_run, force, ops_id),
     }
 }
 
-fn update_build(build_toml: PathBuf) -> Result<()> {
-    let build_compat: BuildCompat = parse_and_validate(&build_toml)?;
+fn validate(kernel_dir: Option<PathBuf>) -> Result<()> {
+    let kernel_dir = check_or_infer_kernel_dir(kernel_dir)?;
+    parse_and_validate(kernel_dir)?;
+    Ok(())
+}
+
+fn update_build(kernel_dir: Option<PathBuf>) -> Result<()> {
+    let kernel_dir = check_or_infer_kernel_dir(kernel_dir)?;
+    let build_compat: BuildCompat = parse_and_validate(&kernel_dir)?;
 
     if matches!(build_compat, BuildCompat::V3(_)) {
         return Ok(());
@@ -118,6 +125,7 @@ fn update_build(build_toml: PathBuf) -> Result<()> {
     let v3_build: v3::Build = build.into();
     let pretty_toml = toml::to_string_pretty(&v3_build)?;
 
+    let build_toml = kernel_dir.join("build.toml");
     let mut writer =
         BufWriter::new(File::create(&build_toml).wrap_err_with(|| {
             format!("Cannot open {} for writing", build_toml.to_string_lossy())

--- a/kernel-builder/src/pyproject/mod.rs
+++ b/kernel-builder/src/pyproject/mod.rs
@@ -7,8 +7,11 @@ use std::{
 use eyre::{bail, Result};
 use minijinja::Environment;
 
-use crate::config::{Build, Framework};
 use crate::util::{check_or_infer_target_dir, parse_build};
+use crate::{
+    config::{Build, Framework},
+    util::check_or_infer_kernel_dir,
+};
 
 pub(crate) mod common;
 pub mod deps;
@@ -42,13 +45,14 @@ pub fn create_pyproject_file_set(
 }
 
 pub fn create_pyproject(
-    build_toml: PathBuf,
+    kernel_dir: Option<PathBuf>,
     target_dir: Option<PathBuf>,
     force: bool,
     ops_id: Option<String>,
 ) -> Result<()> {
-    let target_dir = check_or_infer_target_dir(&build_toml, target_dir)?;
-    let build = parse_build(&build_toml)?;
+    let kernel_dir = check_or_infer_kernel_dir(kernel_dir)?;
+    let target_dir = check_or_infer_target_dir(&kernel_dir, target_dir)?;
+    let build = parse_build(&kernel_dir)?;
     let file_set = create_pyproject_file_set(build, &target_dir, ops_id)?;
     file_set.write(&target_dir, force)?;
 
@@ -56,15 +60,16 @@ pub fn create_pyproject(
 }
 
 pub fn clean_pyproject(
-    build_toml: PathBuf,
+    kernel_dir: Option<PathBuf>,
     target_dir: Option<PathBuf>,
     dry_run: bool,
     force: bool,
     ops_id: Option<String>,
 ) -> Result<()> {
-    let target_dir = check_or_infer_target_dir(&build_toml, target_dir)?;
+    let kernel_dir = check_or_infer_kernel_dir(kernel_dir)?;
+    let target_dir = check_or_infer_target_dir(&kernel_dir, target_dir)?;
 
-    let build = parse_build(&build_toml)?;
+    let build = parse_build(&kernel_dir)?;
     let generated_files =
         create_pyproject_file_set(build, target_dir.clone(), ops_id)?.into_names();
 

--- a/kernel-builder/src/util.rs
+++ b/kernel-builder/src/util.rs
@@ -1,15 +1,16 @@
 use std::{
+    env::current_dir,
     fs::File,
     io::Read,
     path::{Path, PathBuf},
 };
 
-use eyre::{bail, ensure, Context, Result};
+use eyre::{ensure, Context, Result};
 
 use crate::config::{Build, BuildCompat};
 
-pub(crate) fn parse_build(build_toml: impl AsRef<Path>) -> Result<Build> {
-    let build_compat = parse_and_validate(build_toml)?;
+pub(crate) fn parse_build(kernel_dir: impl AsRef<Path>) -> Result<Build> {
+    let build_compat = parse_and_validate(kernel_dir)?;
 
     if matches!(build_compat, BuildCompat::V1(_) | BuildCompat::V2(_)) {
         eprintln!(
@@ -24,11 +25,25 @@ pub(crate) fn parse_build(build_toml: impl AsRef<Path>) -> Result<Build> {
     Ok(build)
 }
 
+pub(crate) fn check_or_infer_kernel_dir(kernel_dir: Option<PathBuf>) -> Result<PathBuf> {
+    match kernel_dir {
+        Some(kernel_dir) => {
+            ensure!(
+                kernel_dir.is_dir(),
+                "`{}` is not a directory",
+                kernel_dir.to_string_lossy()
+            );
+            Ok(kernel_dir)
+        }
+        None => Ok(current_dir()?),
+    }
+}
+
 pub(crate) fn check_or_infer_target_dir(
-    build_toml: impl AsRef<Path>,
+    kernel_dir: impl AsRef<Path>,
     target_dir: Option<PathBuf>,
 ) -> Result<PathBuf> {
-    let build_toml = build_toml.as_ref();
+    let kernel_dir = kernel_dir.as_ref();
     match target_dir {
         Some(target_dir) => {
             ensure!(
@@ -38,23 +53,14 @@ pub(crate) fn check_or_infer_target_dir(
             );
             Ok(target_dir)
         }
-        None => {
-            let absolute = std::path::absolute(build_toml)?;
-            match absolute.parent() {
-                Some(parent) => Ok(parent.to_owned()),
-                None => bail!(
-                    "Cannot get parent path of `{}`",
-                    build_toml.to_string_lossy()
-                ),
-            }
-        }
+        None => Ok(std::path::absolute(kernel_dir)?),
     }
 }
 
-pub(crate) fn parse_and_validate(build_toml: impl AsRef<Path>) -> Result<BuildCompat> {
-    let build_toml = build_toml.as_ref();
+pub(crate) fn parse_and_validate(kernel_dir: impl AsRef<Path>) -> Result<BuildCompat> {
+    let build_toml = kernel_dir.as_ref().join("build.toml");
     let mut toml_data = String::new();
-    File::open(build_toml)
+    File::open(&build_toml)
         .wrap_err_with(|| format!("Cannot open {} for reading", build_toml.to_string_lossy()))?
         .read_to_string(&mut toml_data)
         .wrap_err_with(|| format!("Cannot read from {}", build_toml.to_string_lossy()))?;

--- a/nix-builder/lib/extension/torch/arch.nix
+++ b/nix-builder/lib/extension/torch/arch.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (prevAttrs: {
     mkdir -p $out
     cp -r --no-preserve=mode ${src}/* $out/
     ${pkgs.kernel-builder}/bin/kernel-builder create-pyproject \
-      --ops-id ${rev} $out/build.toml
+      --ops-id ${rev} $out
   '';
 
   preConfigure =

--- a/nix-builder/lib/extension/torch/no-arch.nix
+++ b/nix-builder/lib/extension/torch/no-arch.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (prevAttrs: {
     mkdir -p $out
     cp -r --no-preserve=mode ${src}/* $out/
     ${pkgs.kernel-builder}/bin/kernel-builder create-pyproject \
-      --ops-id ${rev} $out/build.toml
+      --ops-id ${rev} $out
   '';
 
   framework = "torch";

--- a/nix-builder/lib/extension/tvm-ffi/arch.nix
+++ b/nix-builder/lib/extension/tvm-ffi/arch.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (prevAttrs: {
   # Generate build files.
   postPatch = ''
     kernel-builder create-pyproject \
-      --ops-id ${rev} build.toml
+      --ops-id ${rev} .
   '';
 
   preConfigure =

--- a/nix-builder/scripts/windows/builder.ps1
+++ b/nix-builder/scripts/windows/builder.ps1
@@ -212,17 +212,7 @@ function Find-KernelBuilder {
     throw "kernel-builder executable not found. Please build it or specify -KernelBuilderPath"
 }
 
-function Get-BuildTomlPath {
-    param([string]$Folder)
 
-    $buildTomlPath = Join-Path $Folder 'build.toml'
-
-    if (!(Test-Path $buildTomlPath -PathType Leaf)) {
-        throw "build.toml not found in folder: $Folder"
-    }
-
-    return $buildTomlPath
-}
 
 function Invoke-KernelBuilder {
     param(
@@ -326,12 +316,12 @@ function Get-CMakeConfigureArgs {
     # For XPU backend, use Ninja generator with Intel compilers
     if ($Backend -and $Backend.ToLower() -eq 'xpu') {
         Write-Status "Using Ninja generator for XPU backend with Intel SYCL compilers" -Type Info
-        
+
         $kwargs = @("..", "-G", "Ninja", "-DCMAKE_BUILD_TYPE=Release")
-        
+
         # Verify Intel compilers are available (CMakeLists.txt will set them correctly)
         $icx = Get-Command icx -ErrorAction SilentlyContinue
-        
+
         if ($icx) {
             Write-Status "Found Intel compiler: $($icx.Source)" -Type Info
             Write-Status "CMakeLists.txt will configure icx for Windows (MSVC-compatible mode)" -Type Info
@@ -470,7 +460,7 @@ function Invoke-Backend {
     #>
     param(
         [string]$KernelBuilderExe,
-        [string]$BuildToml,
+        [string]$KernelDir,
         [string]$Target,
         [hashtable]$Options,
         [string]$Backend
@@ -479,7 +469,7 @@ function Invoke-Backend {
     $backendName = if ($Backend -eq 'universal') { 'Universal' } else { $Backend.ToUpper() }
     Write-Status "Generating $backendName backend..." -Type Info
 
-    $kwargs = @('create-pyproject', $BuildToml)
+    $kwargs = @('create-pyproject', $KernelDir)
 
     if ($Target) { $kwargs += $Target }
     if ($Options.Force) { $kwargs += '--force' }
@@ -523,13 +513,12 @@ function Set-BackendArchitecture {
 try {
     # Resolve paths
     $SourceFolder = Resolve-Path $SourceFolder -ErrorAction Stop
-    $buildTomlPath = Get-BuildTomlPath -Folder $SourceFolder
     $kernelBuilderExe = Find-KernelBuilder
 
     # Validate mode
     if ($Validate) {
-        Write-Status "Validating $buildTomlPath..." -Type Info
-        Invoke-KernelBuilder -KernelBuilderExe $kernelBuilderExe -Arguments @('validate', $buildTomlPath)
+        Write-Status "Validating $SourceFolder..." -Type Info
+        Invoke-KernelBuilder -KernelBuilderExe $kernelBuilderExe -Arguments @('validate', $SourceFolder)
         Write-Status "Validation successful!" -Type Success
         exit 0
     }
@@ -538,7 +527,7 @@ try {
     if ($Clean) {
         Write-Status "Cleaning generated artifacts..." -Type Warning
 
-        $kwargs = @('clean', $buildTomlPath)
+        $kwargs = @('clean', $SourceFolder)
         if ($TargetFolder) { $kwargs += $TargetFolder }
         if ($DryRun) { $kwargs += '--dry-run' }
         if ($Force) { $kwargs += '--force' }
@@ -569,12 +558,12 @@ try {
     if ($Backend) {
         # Explicit backend specified
         $targetPath = if ($TargetFolder) { Resolve-Path $TargetFolder } else { $null }
-        Invoke-Backend -KernelBuilderExe $kernelBuilderExe -BuildToml $buildTomlPath -Target $targetPath -Options $options -Backend $Backend.ToLower()
+        Invoke-Backend -KernelBuilderExe $kernelBuilderExe -KernelDir $SourceFolder -Target $targetPath -Options $options -Backend $Backend.ToLower()
     } else {
         # Auto-detect backend from build.toml
         Write-Status "Auto-detecting backend from build.toml..." -Type Info
 
-        $kwargs = @('create-pyproject', $buildTomlPath)
+        $kwargs = @('create-pyproject', $SourceFolder)
         if ($TargetFolder) { $kwargs += (Resolve-Path $TargetFolder) }
         if ($Force) { $kwargs += '--force' }
         if ($OpsId) { $kwargs += '--ops-id', $OpsId }


### PR DESCRIPTION
This change makes all `kernel-builder` subcommands take a directory rather than `build.toml`. The argument also becomes optional, the current directory is used when the argument is left out.

This aligns the subcommand with the upcoming `kernel-builder init` subcommand.

Also move the `{create,clean}_pyproject` functions to the `pyproject` module.