### PR TITLE
Fix handling of noarch and tvm-ffi variants

### DIFF
--- a/nix-builder/lib/build.nix
+++ b/nix-builder/lib/build.nix
@@ -272,7 +272,7 @@ rec {
           buildToml = readBuildConfig path;
         in
         {
-          name = extension.variant;
+          name = extension.archVariant;
           value = mkShell {
             nativeBuildInputs = with pkgs; pythonNativeCheckInputs python3.pkgs;
 
@@ -336,7 +336,7 @@ rec {
             );
         in
         {
-          name = buildSet.torch.variant;
+          name = extension.variant;
           value =
             with pkgs;
             pkgs.writeShellScriptBin "ci-test" ''
@@ -384,7 +384,7 @@ rec {
           );
         in
         {
-          name = extension.variant;
+          name = extension.archVariant;
           value = mkShell rec {
             nativeBuildInputs =
               with pkgs;

--- a/nix-builder/lib/extension/torch/arch.nix
+++ b/nix-builder/lib/extension/torch/arch.nix
@@ -269,5 +269,6 @@ stdenv.mkDerivation (prevAttrs: {
   passthru = {
     inherit dependencies torch;
     inherit (torch) variant;
+    archVariant = torch.variant;
   };
 })

--- a/nix-builder/lib/extension/torch/no-arch.nix
+++ b/nix-builder/lib/extension/torch/no-arch.nix
@@ -100,5 +100,6 @@ stdenv.mkDerivation (prevAttrs: {
   passthru = {
     inherit dependencies;
     variant = torch.noarchVariant;
+    archVariant = torch.variant;
   };
 })

--- a/nix-builder/lib/extension/tvm-ffi/arch.nix
+++ b/nix-builder/lib/extension/tvm-ffi/arch.nix
@@ -274,5 +274,6 @@ stdenv.mkDerivation (prevAttrs: {
   passthru = {
     inherit dependencies;
     inherit (python3.pkgs.tvm-ffi) variant;
+    archVariant = python3.pkgs.tvm-ffi.variant;
   };
 })


### PR DESCRIPTION
- For development and test shells, we want the arch variant names, because we'd like to be able to test a noarch kernel with multiple Torch/CUDA versions. This change also fixes `nix develop` without specifying a variant.
- For kernel CI tests, make sure that we generate the tvm-ffi variant names for tvm-ffi kernels.

Fixes #356