### PR TITLE
nix-builder: key CI tests by arch variant

### DIFF
--- a/nix-builder/lib/build.nix
+++ b/nix-builder/lib/build.nix
@@ -336,7 +336,7 @@ rec {
             );
         in
         {
-          name = extension.variant;
+          name = extension.archVariant;
           value =
             with pkgs;
             pkgs.writeShellScriptBin "ci-test" ''


### PR DESCRIPTION
`ciTests` should be keyed by the arch variant name. This allows us to run the tests on specific Torch/CUDA versions. It also fixes the best variant selection for `ci-test` for noarch kernels.