### PR TITLE
feat: `get_loaded_kernels()`

### DIFF
--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -23,6 +23,7 @@ from kernels.layer import (
 )
 from kernels.utils import (
     get_kernel,
+    get_loaded_kernels,
     get_local_kernel,
     get_locked_kernel,
     has_kernel,
@@ -45,6 +46,7 @@ __all__ = [
     "LockedLayerRepository",
     "Mode",
     "get_kernel",
+    "get_loaded_kernels",
     "get_local_kernel",
     "get_locked_kernel",
     "has_kernel",

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -119,8 +119,9 @@ def _import_from_path(module_name: str, variant_path: Path, _repo_infos: RepoInf
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
-    _loaded_kernels[module.op._namespace] = LoadedKernel(
-        op_namespace=module.op._namespace,
+    op_namespace = sys.modules[f"{module_name}._ops"].ops.name
+    _loaded_kernels[op_namespace] = LoadedKernel(
+        op_namespace=op_namespace,
         variant_path=variant_path,
         package_name=package_name,
         module_name=module_name,

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -36,7 +36,7 @@ KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
 
 class RepoInfos(NamedTuple):
     repo_id: str
-    revision: str | None
+    revision: str
     backend: str | None
 
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -12,6 +12,7 @@ import sys
 from importlib.metadata import Distribution
 from pathlib import Path
 from types import ModuleType
+from typing import NamedTuple
 
 from huggingface_hub import HfApi, constants
 
@@ -31,6 +32,30 @@ from kernels.variants import (
 )
 
 KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
+
+
+class RepoInfos(NamedTuple):
+    repo_id: str
+    revision: str | None
+    version: int | str | None
+    backend: str | None
+
+
+class LoadedKernel(NamedTuple):
+    op_namespace: str
+    variant_path: Path
+    package_name: str
+    module_name: str
+    repo_infos: RepoInfos | None
+
+
+_loaded_kernels: dict[str, LoadedKernel] = {}
+
+
+def get_loaded_kernels() -> dict[str, LoadedKernel]:
+    """Returns the `op_namespace -> LoadedKernel` mapping
+    """
+    return _loaded_kernels.copy()
 
 
 def _get_cache_dir() -> str | None:
@@ -71,7 +96,7 @@ def _parse_local_kernel_overrides(local_kernels: str) -> dict[str, Path]:
 CACHE_DIR: str | None = _get_cache_dir()
 
 
-def _import_from_path(module_name: str, variant_path: Path) -> ModuleType:
+def _import_from_path(module_name: str, variant_path: Path, _repo_infos: RepoInfos | None = None) -> ModuleType:
     metadata = Metadata.load_from_variant(variant_path)
     validate_dependencies(module_name, metadata.python_depends, _backend())
 
@@ -83,6 +108,7 @@ def _import_from_path(module_name: str, variant_path: Path) -> ModuleType:
     # it would also be used for other imports. So, we make a module name that
     # depends on the path for it to be unique using the hex-encoded hash of
     # the path.
+    package_name = module_name
     path_hash = "{:x}".format(ctypes.c_size_t(hash(file_path)).value)
     module_name = f"{module_name}_{path_hash}"
     spec = importlib.util.spec_from_file_location(module_name, file_path)
@@ -93,6 +119,13 @@ def _import_from_path(module_name: str, variant_path: Path) -> ModuleType:
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
+    _loaded_kernels[module.op._namespace] = LoadedKernel(
+        op_namespace=module.op._namespace,
+        variant_path=variant_path,
+        package_name=package_name,
+        module_name=module_name,
+        repo_infos=_repo_infos,
+    )
     return module
 
 
@@ -282,7 +315,13 @@ def get_kernel(
     package_name, variant_path = install_kernel(
         repo_id, revision=revision, backend=backend, user_agent=user_agent
     )
-    return _import_from_path(package_name, variant_path)
+    repo_infos = RepoInfos(
+        repo_id=repo_id,
+        revision=revision,
+        version=version,
+        backend=backend,
+    )
+    return _import_from_path(package_name, variant_path, _repo_infos=repo_infos)
 
 
 def get_local_kernel(

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -71,7 +71,7 @@ def _get_cache_dir() -> str | None:
 
 
 def _get_local_kernel_overrides() -> dict[str, Path]:
-    """Returns list local overrides for kernels."""
+    """Returns a copy of the loaded kernels registry (`op_namespace -> LoadedKernel` mapping)."""
     local_kerels = os.environ.get("LOCAL_KERNELS", None)
     if local_kerels is None:
         return dict()

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -296,6 +296,9 @@ def get_kernel(
             The backend will be detected automatically if not provided.
         user_agent (`Union[str, dict]`, *optional*):
             The `user_agent` info to pass to `snapshot_download()` for internal telemetry.
+        reload (`bool`, *optional*, defaults to `False`):
+            Whether to force reloading the kernel in case it is already loaded,
+            given: `repo_id`, (possibly inferred) `revision` and `backend`
 
     Returns:
         `ModuleType`: The imported kernel module.

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -42,10 +42,10 @@ class RepoInfos(NamedTuple):
 
 
 class LoadedKernel(NamedTuple):
-    op_namespace: str
     variant_path: Path
     package_name: str
     module_name: str
+    torch_namespace: str | None
     repo_infos: RepoInfos | None
 
 
@@ -53,7 +53,7 @@ _loaded_kernels: dict[str, LoadedKernel] = {}
 
 
 def get_loaded_kernels() -> dict[str, LoadedKernel]:
-    """Returns a copy of the loaded kernels registry (`op_namespace -> LoadedKernel` mapping)."""
+    """Returns a copy of the loaded kernels registry (`module_name -> LoadedKernel` mapping)."""
     return _loaded_kernels.copy()
 
 
@@ -120,16 +120,16 @@ def _import_from_path(
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
-    # Only track kernels that register custom torch ops
+    torch_namespace: str | None = None
     if (ops := sys.modules.get(f"{module_name}._ops")) is not None:
-        op_namespace = ops.ops.name
-        _loaded_kernels[op_namespace] = LoadedKernel(
-            op_namespace=op_namespace,
-            variant_path=variant_path,
-            package_name=package_name,
-            module_name=module_name,
-            repo_infos=_repo_infos,
-        )
+        torch_namespace = getattr(ops.ops, "name", None)
+    _loaded_kernels[module_name] = LoadedKernel(
+        torch_namespace=torch_namespace,
+        variant_path=variant_path,
+        package_name=package_name,
+        module_name=module_name,
+        repo_infos=_repo_infos,
+    )
     return module
 
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -53,8 +53,7 @@ _loaded_kernels: dict[str, LoadedKernel] = {}
 
 
 def get_loaded_kernels() -> dict[str, LoadedKernel]:
-    """Returns the `op_namespace -> LoadedKernel` mapping
-    """
+    """Returns a copy of the loaded kernels registry (`op_namespace -> LoadedKernel` mapping)."""
     return _loaded_kernels.copy()
 
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -37,7 +37,6 @@ KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
 class RepoInfos(NamedTuple):
     repo_id: str
     revision: str | None
-    version: int | str | None
     backend: str | None
 
 
@@ -52,9 +51,9 @@ class LoadedKernel(NamedTuple):
 _loaded_kernels: dict[str, LoadedKernel] = {}
 
 
-def get_loaded_kernels() -> dict[str, LoadedKernel]:
-    """Returns a copy of the loaded kernels registry (`module_name -> LoadedKernel` mapping)."""
-    return _loaded_kernels.copy()
+def get_loaded_kernels() -> list[LoadedKernel]:
+    """Returns a copy of the loaded kernels registry (see `kernels.utils.LoadedKernel` NamedTuple)."""
+    return list(_loaded_kernels.values())
 
 
 def _get_cache_dir() -> str | None:
@@ -276,6 +275,7 @@ def get_kernel(
     version: int | str | None = None,
     backend: str | None = None,
     user_agent: str | dict | None = None,
+    reload: bool = False,
 ) -> ModuleType:
     """
     Load a kernel from the kernel hub.
@@ -316,14 +316,18 @@ def get_kernel(
         return get_local_kernel(override, package_name_from_repo_id(repo_id))
 
     revision = select_revision_or_version(repo_id, revision=revision, version=version)
-    package_name, variant_path = install_kernel(
-        repo_id, revision=revision, backend=backend, user_agent=user_agent
-    )
     repo_infos = RepoInfos(
         repo_id=repo_id,
         revision=revision,
-        version=version,
         backend=backend,
+    )
+    if not reload:
+        for loaded_kernel in get_loaded_kernels():
+            if loaded_kernel.repo_infos == repo_infos:
+                if (module := sys.modules.get(loaded_kernel.module_name)) is not None:
+                    return module
+    package_name, variant_path = install_kernel(
+        repo_id, revision=revision, backend=backend, user_agent=user_agent
     )
     return _import_from_path(package_name, variant_path, _repo_infos=repo_infos)
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -71,7 +71,7 @@ def _get_cache_dir() -> str | None:
 
 
 def _get_local_kernel_overrides() -> dict[str, Path]:
-    """Returns a copy of the loaded kernels registry (`op_namespace -> LoadedKernel` mapping)."""
+    """Returns list local overrides for kernels."""
     local_kerels = os.environ.get("LOCAL_KERNELS", None)
     if local_kerels is None:
         return dict()

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -44,7 +44,7 @@ class LoadedKernel(NamedTuple):
     variant_path: Path
     package_name: str
     module_name: str
-    torch_namespace: str | None
+    op_namespace: str | None
     repo_infos: RepoInfos | None
 
 
@@ -119,14 +119,15 @@ def _import_from_path(
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
-    torch_namespace: str | None = None
-    if (ops := sys.modules.get(f"{module_name}._ops")) is not None:
-        torch_namespace = getattr(ops.ops, "name", None)
+    op_namespace: str | None = None
+    for so_path in file_path.parent.iterdir():
+        if so_path.is_file() and so_path.name.endswith('.so'):
+            op_namespace = so_path.name.split('.')[0]
     _loaded_kernels[module_name] = LoadedKernel(
-        torch_namespace=torch_namespace,
         variant_path=variant_path,
         package_name=package_name,
         module_name=module_name,
+        op_namespace=op_namespace,
         repo_infos=_repo_infos,
     )
     return module

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -119,14 +119,16 @@ def _import_from_path(module_name: str, variant_path: Path, _repo_infos: RepoInf
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
-    op_namespace = sys.modules[f"{module_name}._ops"].ops.name
-    _loaded_kernels[op_namespace] = LoadedKernel(
-        op_namespace=op_namespace,
-        variant_path=variant_path,
-        package_name=package_name,
-        module_name=module_name,
-        repo_infos=_repo_infos,
-    )
+    # Only track kernels that register custom torch ops
+    if (ops := sys.modules.get(f"{module_name}._ops")) is not None:
+        op_namespace = ops.ops.name
+        _loaded_kernels[op_namespace] = LoadedKernel(
+            op_namespace=op_namespace,
+            variant_path=variant_path,
+            package_name=package_name,
+            module_name=module_name,
+            repo_infos=_repo_infos,
+        )
     return module
 
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -95,7 +95,9 @@ def _parse_local_kernel_overrides(local_kernels: str) -> dict[str, Path]:
 CACHE_DIR: str | None = _get_cache_dir()
 
 
-def _import_from_path(module_name: str, variant_path: Path, _repo_infos: RepoInfos | None = None) -> ModuleType:
+def _import_from_path(
+    module_name: str, variant_path: Path, _repo_infos: RepoInfos | None = None
+) -> ModuleType:
     metadata = Metadata.load_from_variant(variant_path)
     validate_dependencies(module_name, metadata.python_depends, _backend())
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -41,14 +41,12 @@ class RepoInfos(NamedTuple):
 
 
 class LoadedKernel(NamedTuple):
-    variant_path: Path
+    module: ModuleType
     package_name: str
-    module_name: str
-    op_namespace: str | None
     repo_infos: RepoInfos | None
 
 
-_loaded_kernels: dict[str, LoadedKernel] = {}
+_loaded_kernels: dict[Path, LoadedKernel] = {}
 
 
 def get_loaded_kernels() -> list[LoadedKernel]:
@@ -97,6 +95,9 @@ CACHE_DIR: str | None = _get_cache_dir()
 def _import_from_path(
     module_name: str, variant_path: Path, _repo_infos: RepoInfos | None = None
 ) -> ModuleType:
+    if (loaded_kernel := _loaded_kernels.get(variant_path)) is not None:
+        return loaded_kernel.module
+
     metadata = Metadata.load_from_variant(variant_path)
     validate_dependencies(module_name, metadata.python_depends, _backend())
 
@@ -119,15 +120,10 @@ def _import_from_path(
         raise ImportError(f"Cannot load module {module_name} from spec")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)  # type: ignore
-    op_namespace: str | None = None
-    for so_path in file_path.parent.iterdir():
-        if so_path.is_file() and so_path.name.endswith('.so'):
-            op_namespace = so_path.name.split('.')[0]
-    _loaded_kernels[module_name] = LoadedKernel(
-        variant_path=variant_path,
+
+    _loaded_kernels[variant_path] = LoadedKernel(
+        module=module,
         package_name=package_name,
-        module_name=module_name,
-        op_namespace=op_namespace,
         repo_infos=_repo_infos,
     )
     return module
@@ -276,7 +272,6 @@ def get_kernel(
     version: int | str | None = None,
     backend: str | None = None,
     user_agent: str | dict | None = None,
-    reload: bool = False,
 ) -> ModuleType:
     """
     Load a kernel from the kernel hub.
@@ -297,9 +292,6 @@ def get_kernel(
             The backend will be detected automatically if not provided.
         user_agent (`Union[str, dict]`, *optional*):
             The `user_agent` info to pass to `snapshot_download()` for internal telemetry.
-        reload (`bool`, *optional*, defaults to `False`):
-            Whether to force reloading the kernel in case it is already loaded,
-            given: `repo_id`, (possibly inferred) `revision` and `backend`
 
     Returns:
         `ModuleType`: The imported kernel module.
@@ -325,11 +317,6 @@ def get_kernel(
         revision=revision,
         backend=backend,
     )
-    if not reload:
-        for loaded_kernel in get_loaded_kernels():
-            if loaded_kernel.repo_infos == repo_infos:
-                if (module := sys.modules.get(loaded_kernel.module_name)) is not None:
-                    return module
     package_name, variant_path = install_kernel(
         repo_id, revision=revision, backend=backend, user_agent=user_agent
     )


### PR DESCRIPTION
New `get_loaded_kernels()` API

Enables:
- `get_kernel` (internal) caching based on repo infos (done in this PR)
- kernels packaging (PyTorch ahead-of-time compilation context)

Example "kernels-included package" -> https://huggingface.co/cbensimon/FLUX.2-klein-4B-sm90-cu128-glibc235-r52/tree/main/package