### PR TITLE
Update the docs to use `kernel-builder` in place of `nix`

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -25,8 +25,8 @@
 - sections:
     - local: builder/writing-kernels
       title: Writing Kernels
-    - local: builder/nix
-      title: Building with Nix
+    - local: builder/build
+      title: Building kernels
     - local: builder/local-dev
       title: Local Development
     - local: kernel-requirements

--- a/docs/source/builder/build.md
+++ b/docs/source/builder/build.md
@@ -1,9 +1,13 @@
 # Using the kernel builder with Nix
 
-> [!NOTE] 
+## Installation
+
+> [!NOTE]
 > The [install script](writing-kernels.md#quick-install) automates
 > the Nix and kernel-builder setup described below. Use these manual
 > instructions if you prefer step-by-step control.
+
+### Installing Nix
 
 The kernel builder uses Nix for building kernels. You can build or
 run the kernels directly if you have Nix installed on your system.
@@ -13,16 +17,7 @@ We recommend installing Nix in the following way:
 - macOS: use the [Determinate Nix installer](https://docs.determinate.systems/determinate-nix/).
   In addition, Xcode 16.x is currently required to build kernels.
 
-## Getting started
-
-The easiest way get all the Nix functionality is by putting a
-`flake.nix` in your kernel repository. To do so, copy
-[`examples/relu/flake.nix`](https://github.com/huggingface/kernels/blob/main/examples/kernels/relu/flake.nix) into the
-same directory as your `build.toml` file. Then run `nix flake update`.
-This generates a `flake.lock` file that pins the kernel builder
-and _all_ its transitive dependencies. Commit both `flake.nix`
-and `flake.lock` to your repository, this will ensure that kernel
-builds are reproducible.
+### Using the Hugging Face binary cache
 
 Since the kernel builder depends on many packages (e.g. every supported
 PyTorch version), it is recommended to enable the huggingface cache
@@ -42,22 +37,37 @@ Or run it once without installing cachix permanently:
 nix run nixpkgs#cachix -- use huggingface
 ```
 
+### GPU library configuration
+
 The kernel builder also provides Nix development shells with all Torch
 and CUDA/ROCm dependencies needed to develop kernels (see below). If
 you want to test your kernels inside a Nix development shell and you
 are not using NixOS, [make sure that the CUDA driver is visible](https://danieldk.eu/Nix-CUDA-on-non-NixOS-systems#make-runopengl-driverlib-and-symlink-the-driver-library) to Torch.
 
-## Building kernels with Nix
+## Getting started
 
-A kernel that has a `flake.nix` file can be built with the `build-and-copy`
-command. For example:
+The easiest way to get all the Nix functionality is by putting a
+`flake.nix` in your kernel repository. To do so, copy
+[`examples/relu/flake.nix`](https://github.com/huggingface/kernels/blob/main/examples/kernels/relu/flake.nix) into the
+same directory as your `build.toml` file. Then run `nix flake update`.
+This generates a `flake.lock` file that pins the kernel builder
+and _all_ its transitive dependencies. Commit both `flake.nix`
+and `flake.lock` to your repository, this will ensure that kernel
+builds are reproducible.
+
+## Building a kernel
+
+A kernel can be built with the `kernel-builder build-and-copy` command.
+For example:
 
 ```bash
 cd examples/relu
-nix run .#build-and-copy -L
+kernel-builder build-and-copy -L
 ```
 
-The compiled kernel will then be in the local `build/` directory.
+The `-L` option prints out build logs in the terminal, which can be handy
+for monitoring the build. The compiled kernel will then be in the local
+`build/` directory.
 
 ## Shell for local development
 
@@ -66,43 +76,69 @@ all required dependencies are available, as well as `kernel-builder` for generat
 project files. For example:
 
 ```bash
-$ nix develop
+$ kernel-builder devshell
+# A devshell is opened in which you can run the following commands:
 $ kernel-builder create-pyproject
 $ cmake -B build-ext
 $ cmake --build build-ext
 ```
 
 If you want to test the kernel as a Python package, you can do so.
-`nix develop` will automatically create a virtual environment in the
-`.venv` and activate it. You can install the kernel as a regular
+`kernel-builder devshell` will automatically create a virtual environment in
+the `.venv` and activate it. You can install the kernel as a regular
 Python package in this virtual environment:
 
 ```bash
-$ nix develop
+$ kernel-builder devshell
 $ kernel-builder create-pyproject
 $ pip install --no-build-isolation -e .
 ```
 
 Development shells are available for every build configuration. For
-instance, you can get a Torch 2.7 development shell for ROCm extensions
+instance, you can get a Torch 2.11 development shell for ROCm kernels
 using:
 
 ```bash
 $ rm -rf .venv  # Remove existing venv if any.
-$ nix develop .#devShells.torch29-cxx11-rocm64-x86_64-linux
+$ kernel-builder devshell --variant torch211-cxx11-rocm71-x86_64-linux
+```
+
+You can list the variants that the kernel supports with the `list-variants`
+subcommand:
+
+```bash
+$ kernel-builder list-variants
+torch29-cxx11-cu129-x86_64-linux
+torch210-cxx11-cu126-x86_64-linux
+torch210-cxx11-cu128-x86_64-linux
+torch210-cxx11-cu130-x86_64-linux
+torch210-cxx11-rocm70-x86_64-linux
+torch210-cxx11-rocm71-x86_64-linux
+torch210-cxx11-cpu-x86_64-linux
+torch210-cxx11-xpu20253-x86_64-linux
+torch211-cxx11-cpu-x86_64-linux
+torch211-cxx11-cu126-x86_64-linux
+torch211-cxx11-cu128-x86_64-linux
+torch211-cxx11-cu130-x86_64-linux
+torch211-cxx11-rocm71-x86_64-linux
+torch211-cxx11-rocm72-x86_64-linux
+torch211-cxx11-xpu20253-x86_64-linux
 ```
 
 ## Shell for testing a kernel
 
-You can also start a development shell. This will give you a Python interpreter
+You can also start a test shell. This will give you a Python interpreter
 with the kernel in Python's search path. This makes it more convenient to run
 tests:
 
 ```bash
 cd examples/relu
-nix develop -L .#test
+kernel-builder testshell
 python -m pytest tests
 ```
+
+`testshell` also supports the `--variant` option, so you can test a particular
+kernel variant.
 
 ## Adding test dependencies to development shells
 
@@ -127,7 +163,7 @@ the kernel's `flake.nix` to use the `pythonCheckInputs` option:
       path = ./.;
 
       # The einops and numpy test dependencies are added here:
-      pythonCheckInputs = pkgs: with pkgs; [ einops numpy ];
+      pythonCheckInputs = pkgs: with pkgs; [ numpy ];
     };
 }
 ```
@@ -136,6 +172,33 @@ The available packages can be found on [search.nixos.org](https://search.nixos.o
 
 Keep in mind that these additional dependencies will only be available to
 the Nix shells, not the final kernel uploaded to the Hub.
+
+## Uploading your kernel to the Hub
+
+Finally, when you are ready to make a kernel release, you can build and
+upload a kernel to the Hub:
+
+```bash
+$ cd mykernel
+$ kernel-builder build-and-upload
+```
+
+The repository to upload to is determined by the `repo-id` and `version`
+fields in `build.toml`. For example, with the following `build.toml`, the
+kernel will be uploaded to the repository `kernels-community/flash-attn4`
+in the `v1` version branch:
+
+```toml
+[general]
+# ...
+version = 1
+
+[general.hub]
+repo-id = "kernels-community/flash-attn4"
+```
+
+See [Writing Kernels](writing-kernels.md) for more details on the `build.toml`
+format.
 
 ## Skipping the `get_kernel` check
 

--- a/docs/source/builder/build.md
+++ b/docs/source/builder/build.md
@@ -46,14 +46,10 @@ are not using NixOS, [make sure that the CUDA driver is visible](https://danield
 
 ## Getting started
 
-The easiest way to get all the Nix functionality is by putting a
-`flake.nix` in your kernel repository. To do so, copy
-[`examples/relu/flake.nix`](https://github.com/huggingface/kernels/blob/main/examples/kernels/relu/flake.nix) into the
-same directory as your `build.toml` file. Then run `nix flake update`.
-This generates a `flake.lock` file that pins the kernel builder
-and _all_ its transitive dependencies. Commit both `flake.nix`
-and `flake.lock` to your repository, this will ensure that kernel
-builds are reproducible.
+The easiest way to start a new kernel is using the `kernel-builder init`
+subcommand, which is discussed in [Writing Kernels](writing-kernels.md).
+The commands discussed in the following sections will also work on
+existing kernel sources that have `build.toml`/`flake.nix`.
 
 ## Building a kernel
 
@@ -183,6 +179,10 @@ $ cd mykernel
 $ kernel-builder build-and-upload
 ```
 
+Aside from building and uploading the kernel itself, this will also fill
+the card template and upload it as `README.md` to the Hub if the card
+template is provided in the source repository as `CARD.md`.
+
 The repository to upload to is determined by the `repo-id` and `version`
 fields in `build.toml`. For example, with the following `build.toml`, the
 kernel will be uploaded to the repository `kernels-community/flash-attn4`
@@ -199,6 +199,32 @@ repo-id = "kernels-community/flash-attn4"
 
 See [Writing Kernels](writing-kernels.md) for more details on the `build.toml`
 format.
+
+## Updating the kernel build toolchain
+
+The kernel's dependencies are fully pinned down in the `flake.lock` that
+is shipped with the kernel. We periodically release new versions of the
+build toolchain that includes bug fixes and supports newer Torch and compute backend
+versions. To update the kernel build toolchain, run `nix flake update`
+in the kernel directory:
+
+```bash
+❯ nix flake update
+• Added input 'kernel-builder':
+    'github:huggingface/kernels/8ad8a5094f1b3c425f70900699ed690d65d878c3?narHash=sha256-m8tBntCIlH/rY4BcIv5X5%2BdtgSS1yQi883Co%2Bj5cudI%3D' (2026-04-09)
+• Added input 'kernel-builder/flake-compat':
+    'github:edolstra/flake-compat/5edf11c44bc78a0d334f6334cdaf7d60d732daab?narHash=sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns%3D' (2025-12-29)
+• Added input 'kernel-builder/flake-utils':
+    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
+• Added input 'kernel-builder/flake-utils/systems':
+    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e?narHash=sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768%3D' (2023-04-09)
+• Added input 'kernel-builder/nixpkgs':
+    'github:NixOS/nixpkgs/2f4fd5e1abf9bac8c1d22750c701a7a5e6b524c6?narHash=sha256-Mh6bLcYAcENBAZk3RoMPMFCGGMZmfaGMERE4siZOgP4%3D' (2026-03-31)
+• Added input 'kernel-builder/rust-overlay':
+    'github:oxalica/rust-overlay/962a0934d0e32f42d1b5e49186f9595f9b178d2d?narHash=sha256-JMdDYn0F%2BswYBILlpCeHDbCSyzqkeSGNxZ/Q5J584jM%3D' (2026-03-31)
+• Added input 'kernel-builder/rust-overlay/nixpkgs':
+    follows 'kernel-builder/nixpkgs'
+```
 
 ## Skipping the `get_kernel` check
 

--- a/docs/source/builder/local-dev.md
+++ b/docs/source/builder/local-dev.md
@@ -14,15 +14,6 @@ setuptools files for building the kernel as a regular Python package.
 Since CMake and setuptools are widely supported by IDEs, this provides
 a much-improved development experience.
 
-## Installing `kernel-builder`
-
-`kernel-builder` is available as a Rust crate. After [installing Rust](https://rustup.rs),
-it can be built and installed as follows:
-
-```bash
-$ cargo install hf-kernel-builder
-```
-
 ## Generating a Python project with `kernel-builder`
 
 `kernel-builder` can create CMake/Python project files for a kernel with

--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -73,63 +73,104 @@ kernels.
 If you use a different provider, the Terraform bridges should be
 similar and straightforward to modify.
 
+## Starting a new kernel
+
+The easiest way to start a new kernel is by using the `init` subcommand
+of `kernel-builder`. This creates a minimal, compilable kernel:
+
+```bash
+$ kernel-builder init --name myorg/mykernel
+Initialized `myorg/mykernel` at /home/daniel/git/kernels/examples/kernels/mykernel
+```
+
+This creates a kernel named `mykernel` in the directory `mykernel`. The
+kernel is configured to upload to the `myorg/mykernel` Hub
+repository when an upload command is used.
+
+By default, the `init` subcommand creates a CUDA kernel. You can specify
+different or additional backends with the `--backends` option:
+
+```bash
+$ kernel-builder init --name myorg/mykernel --backends cuda xpu
+Initialized `myorg/mykernel` at /home/daniel/git/kernels/examples/kernels/mykernel
+```
+
+If you want to create a kernel for all supported backends, you can
+use `--backends all`.
+
 ## Kernel project layout
 
 Kernel projects follow this general directory layout:
 
 ```text
-relu
+mykernel
+├── benchmarks
+│   └── benchmark.py
 ├── build.toml
-├── relu_kernel
-│   └── relu.cu
+├── CARD.md
+├── example.py
+├── flake.nix
+├── mykernel_cuda
+│   └── mykernel.cu
+├── tests
+│   ├── __init__.py
+│   └── test_mykernel.py
 └── torch-ext
-    └── torch_binding.cpp
-    └── torch_binding.h
-    └── relu
-        └── __init__.py
-└── tests
-    └── __init__.py
-    └── test_relu.py
+├── mykernel
+│   └── __init__.py
+├── torch_binding.cpp
+└── torch_binding.h
 ```
 
 In this example we can find:
 
 - The build configuration in `build.toml`.
-- One or more top-level directories containing kernels (`relu_kernel`).
+- One or more top-level directories containing kernels (`mykernel_cuda`).
 - The `torch-ext` directory, which contains:
   - `torch_binding.h`: contains declarations for kernel entry points
     (from `kernel_a` and `kernel_b`).
   - `torch_binding.cpp`: registers the entry points as Torch ops.
-  - `torch_ext/relu`: contains any Python wrapping the kernel needs. At the
+  - `torch_ext/mykernel`: contains any Python wrapping the kernel needs. At the
     bare minimum, it should contain an `__init__.py` file.
 - Kernel tests in the directory `tests`.
+- Benchmarks in the directory `benchmarks`.
+- A kernel card template in `CARD.md`.
+- The Nix flake configuration in `flake.nix`.
+- An example script that uses the kernel in `example.py`.
 
 ## `build.toml`
 
 `build.toml` tells `kernel-builder` what to build and how. It looks as
-follows for the `relu` kernel:
+follows for the `mykernel` kernel:
 
 ```toml
 [general]
-name = "relu"
+backends = [
+  "cuda",
+]
+name = "mykernel"
+version = 1
+
+[general.hub]
+repo-id = "myorg/mykernel"
 
 [torch]
 src = [
   "torch-ext/torch_binding.cpp",
-  "torch-ext/torch_binding.h"
+  "torch-ext/torch_binding.h",
 ]
 
-[kernel.relu]
+[kernel.mykernel]
 backend = "cuda"
-src = [
-  "relu_kernel/relu.cu",
-]
-depends = [ "torch" ]
+depends = ["torch"]
+src = ["mykernel_cuda/mykernel.cu"]
 # If the kernel is only supported on specific capabilities, set the
 # cuda-capabilities option:
 #
 # cuda-capabilities = [ "9.0", "10.0", "12.0" ]
 ```
+
+The following sections enumerate all supported options for `build.toml`.
 
 ### `general`
 
@@ -144,6 +185,11 @@ depends = [ "torch" ]
 - `python-depends` (**experimental**): a list of additional Python dependencies
   that the kernel requires. The only supported dependencies are `einops`
   and `nvidia-cutlass-dsl`.
+
+### `general.hub`
+
+- `repo-id`: the Hub repository to upload the kernel to when the `upload` or
+  `build-and-upload` subcommands of `kernel-builder` are used.
 
 ### `general.cuda`
 
@@ -227,52 +273,15 @@ Torch bindings are defined in C++, kernels commonly use two files:
 - `torch_binding.h` containing function declarations.
 - `torch_binding.cpp` registering the functions as Torch ops.
 
-For instance, the `relu` kernel has the following declaration in
-`torch_binding.h`:
+For instance, the `mykernel` kernel discussed above has the following
+declaration in `torch_binding.h`:
 
 ```cpp
 #pragma once
 
 #include <torch/torch.h>
 
-void relu(torch::Tensor &out, torch::Tensor const &input);
-```
-
-This is a declaration for the actual kernel, which is in `relu_kernel/relu.cu`:
-
-```cpp
-#include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <torch/all.h>
-
-#include <cmath>
-
-__global__ void relu_kernel(float *__restrict__ out,
-                            float const *__restrict__ input,
-                            const int d) {
-  const int64_t token_idx = blockIdx.x;
-  for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
-    auto x = input[token_idx * d + idx];
-    out[token_idx * d + idx] = x > 0.0f ? x : 0.0f;
-  }
-}
-
-void relu(torch::Tensor &out,
-          torch::Tensor const &input)
-{
-  TORCH_CHECK(input.scalar_type() == at::ScalarType::Float &&
-                  input.scalar_type() == at::ScalarType::Float,
-              "relu_kernel only supports float32");
-
-  int d = input.size(-1);
-  int64_t num_tokens = input.numel() / d;
-  dim3 grid(num_tokens);
-  dim3 block(std::min(d, 1024));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  relu_kernel<<<grid, block, 0, stream>>>(out.data_ptr<float>(),
-                                          input.data_ptr<float>(), d);
-}
+void mykernel(torch::Tensor &out, torch::Tensor const &input);
 ```
 
 This function is then registered as a Torch op in `torch_binding.cpp`:
@@ -284,8 +293,10 @@ This function is then registered as a Torch op in `torch_binding.cpp`:
 #include "torch_binding.h"
 
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
-  ops.def("relu(Tensor! out, Tensor input) -> ()");
-  ops.impl("relu", torch::kCUDA, &relu);
+  ops.def("mykernel(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL) || defined(ROCM_KERNEL)
+  ops.impl("mykernel", torch::kCUDA, &mykernel);
+#endif
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)
@@ -313,13 +324,16 @@ refer to the correct `torch.ops` module. For example:
 
 ```python
 from typing import Optional
+
 import torch
+
 from ._ops import ops
 
-def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+def mykernel(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
     if out is None:
         out = torch.empty_like(x)
-    ops.relu(out, x)
+    ops.mykernel(out, x)
     return out
 ```
 
@@ -334,7 +348,7 @@ PyTest marker that can be used as follows:
 import pytest
 
 @pytest.mark.kernels_ci
-def test_relu():
+def test_mykernel():
   ...
 ```
 
@@ -366,7 +380,7 @@ information from its `build.toml` and metadata. This system card provides a
 reasonable starting point and is meant to be edited afterward by the kernel
 developer.
 
-The template card is generated as a part of [`kernels init`](../cli-init.md)
+The template card is generated as a part of `kernel-builder init`
 command and is serialized in the root directory of the kernel.
 
 The card will be filled automatically by the builder when using the

--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -88,15 +88,22 @@ kernel is configured to upload to the `myorg/mykernel` Hub
 repository when an upload command is used.
 
 By default, the `init` subcommand creates a CUDA kernel. You can specify
-different or additional backends with the `--backends` option:
+another backend with the `--backends` option:
+
+```bash
+$ kernel-builder init --name myorg/mykernel --backends xpu
+```
+
+You can also make a multi-backend kernel by adding all the backends
+that you would like to support as arguments to `--backends`:
 
 ```bash
 $ kernel-builder init --name myorg/mykernel --backends cuda xpu
 Initialized `myorg/mykernel` at /home/daniel/git/kernels/examples/kernels/mykernel
 ```
 
-If you want to create a kernel for all supported backends, you can
-use `--backends all`.
+Finally, if you want to create a kernel for all supported backends, you
+can use `--backends all`.
 
 ## Kernel project layout
 
@@ -134,7 +141,8 @@ In this example we can find:
     bare minimum, it should contain an `__init__.py` file.
 - Kernel tests in the directory `tests`.
 - Benchmarks in the directory `benchmarks`.
-- A kernel card template in `CARD.md`.
+- A kernel card template in `CARD.md`. This placeholders in the card are filled
+  during the kernel build.
 - The Nix flake configuration in `flake.nix`.
 - An example script that uses the kernel in `example.py`.
 


### PR DESCRIPTION
* Replace `nix` by `kernel-builder` in examples (where relevant).
* Replace the examples on the kernel writing page work from `kernel-builder` init as a starting point.