### PR TITLE
trigger documentation builds on release branches.

### DIFF
--- a/.github/workflows/build_documentation.yaml
+++ b/.github/workflows/build_documentation.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - doc-builder*
       - v*-release
+      - release-*
     tags:
       - v*
   workflow_dispatch:


### PR DESCRIPTION
We need to add a filter for the release branches to our documentation building workflow so that it correctly triggers on the release branches.

We didn't have the docs tagged to v0.13.0 on https://huggingface.co/docs/kernels. I manually triggered it https://github.com/huggingface/kernels/actions/runs/24324197693.