### PR TITLE
[Fix][XPU]: resolve executable stack (RWE) security issue in binaries and bump sycl-tla to v0.8

### DIFF
--- a/kernel-builder/src/pyproject/templates/torch/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/preamble.cmake
@@ -179,7 +179,7 @@ elseif(GPU_LANG STREQUAL "SYCL")
 
 
   set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
-  set(sycl_flags "-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
+  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
   set(GPU_FLAGS "${sycl_flags}")
   set(GPU_ARCHES "")
 

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
@@ -136,8 +136,8 @@ elseif(GPU_LANG STREQUAL "SYCL")
     message(STATUS "Using Intel SYCL C++ compiler: ${ICPX_COMPILER} and C compiler: ${ICX_COMPILER} Version: ${DPCPP_VERSION}")
   endif()
 
-  set(sycl_link_flags "-fsycl;--offload-compress;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
-  set(sycl_flags "-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
+  set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
+  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
   set(GPU_FLAGS "${sycl_flags}")
   set(GPU_ARCHES "")
 

--- a/kernel-builder/src/pyproject/templates/xpu/dep-sycl-tla.cmake
+++ b/kernel-builder/src/pyproject/templates/xpu/dep-sycl-tla.cmake
@@ -3,7 +3,7 @@ if(GPU_LANG STREQUAL "SYCL")
 find_package(SyclTla)
 
 if(DPCPP_VERSION STREQUAL "2025.3")
-  set(SYCL_TLA_REVISION "14055e78510b8776ba739755eb57e592fdceefdb" CACHE STRING "CUTLASS revision to use")
+  set(SYCL_TLA_REVISION "v0.8" CACHE STRING "CUTLASS revision to use")
 else()
   message(FATAL_ERROR "Unknown DPCPP_VERSION: ${DPCPP_VERSION}")
 endif()

--- a/nix-builder/pkgs/xpu-packages/sycl-tla.nix
+++ b/nix-builder/pkgs/xpu-packages/sycl-tla.nix
@@ -14,9 +14,8 @@ let
   dpcppVersion = oneapi-torch-dev.version;
   cutlassVersions = {
     "2025.3" = {
-      version = "0.6-dev";
-      rev = "14055e78510b8776ba739755eb57e592fdceefdb";
-      hash = "sha256-5KVvFdEYFQhvIjeauoEUSyhBdbSh6UYEwgsd+X7jcHA=";
+      version = "0.8";
+      hash = "sha256-xXAxIDBesjDDOIa6/YsGznyW+5+NpaO1L96lBuqRzrk=";
     };
   };
   cutlassVersion =


### PR DESCRIPTION
This PR:

1. Fixes a critical security/compatibility issue where XPU (SYCL) kernel shared libraries were generated with an executable stack (`GNU_STACK` flag set to `RWE / 0x07`).
2. Upgrades the sycl-tla dependency to the latest `v0.8` release.

For `.so` files, before the fix: 
```
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RWE    0x10
```
After the fix:
```
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
```
