### PR TITLE
Add cxx_flags to docs

### DIFF
--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -257,7 +257,7 @@ are available:
   capabilities are the intersection of this list and the capabilities
   supported by the CUDA compiler. It is recommended to leave this option
   unspecified **unless** a kernel requires specific capabilities.
-- `cuda_flags` (optional): additional flags to be passed to `nvcc`.
+- `cuda-flags` (optional): additional flags to be passed to `nvcc`.
   **Warning**: this option should only be used in exceptional circumstances.
   Custom compile flags can interfere with the build process or break
   compatibility requirements.
@@ -269,7 +269,7 @@ are available:
 
 #### xpu
 
-- `sycl_flags`: a list of additional flags to be passed to the SYCL
+- `sycl-flags`: a list of additional flags to be passed to the SYCL
   compiler.
 
 ### cpu

--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -272,6 +272,12 @@ are available:
 - `sycl_flags`: a list of additional flags to be passed to the SYCL
   compiler.
 
+### cpu
+
+- `cxx-flags`: a list of additional flags to be passed to the C++
+  compiler.
+
+
 ## Torch bindings
 
 ### Defining bindings


### PR DESCRIPTION
Fixes https://github.com/huggingface/kernels/issues/454 (Opened the issue half an hour ago, found that it's already implemented, but missing in the docs).

When I tried to add cxx_flags with the underscore to the build.toml, I got the following error: `Unknown field cxx_flags. Expected one of cxx-flags, depends, include, src`, that means likely the `cuda_flags` and `sycl_flags` should also be `cuda-flags` `sycl-flags`, should I also update this in the docs?