### PR TITLE
kernels-data: allow unknown fields in `Metadata`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: style kernel-builder-cli-docs quality
 
 
-export check_dirs := kernels/src kernels/tests
+export check_dirs := kernels/src kernels/tests kernels-data/bindings/python
 
 all: src/kernels/python_depends.json
 

--- a/kernels-data/bindings/python/tests/test_kernels_data.py
+++ b/kernels-data/bindings/python/tests/test_kernels_data.py
@@ -108,9 +108,7 @@ def test_metadata_load_full(tmp_path):
 
 def test_metadata_load_minimal(tmp_path):
     path = tmp_path / "metadata.json"
-    path.write_text(
-        json.dumps({"python-depends": [], "backend": {"type": "cpu"}})
-    )
+    path.write_text(json.dumps({"python-depends": [], "backend": {"type": "cpu"}}))
     m = Metadata.load(path)
     assert m.version is None
     assert m.license is None
@@ -121,13 +119,11 @@ def test_metadata_load_minimal(tmp_path):
 
 def test_metadata_load_cann(tmp_path):
     path = tmp_path / "metadata.json"
-    path.write_text(
-        json.dumps({"python-depends": [], "backend": {"type": "cann"}})
-    )
+    path.write_text(json.dumps({"python-depends": [], "backend": {"type": "cann"}}))
     assert Metadata.load(path).backend == Backend.CANN
 
 
-def test_metadata_load_unknown_field_rejected(tmp_path):
+def test_metadata_load_unknown_field_accepted(tmp_path):
     path = tmp_path / "metadata.json"
     path.write_text(
         json.dumps(
@@ -138,8 +134,7 @@ def test_metadata_load_unknown_field_rejected(tmp_path):
             }
         )
     )
-    with pytest.raises(ValueError):
-        Metadata.load(path)
+    Metadata.load(path)
 
 
 def test_metadata_load_malformed(tmp_path):

--- a/kernels-data/src/metadata.rs
+++ b/kernels-data/src/metadata.rs
@@ -13,7 +13,7 @@ pub struct BackendInfo {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<usize>,


### PR DESCRIPTION
Now that we will use `kernels-data` inside `kernels`, we have to allow
unknown fields in metadata. Otherwise the following scenario will break:

1. We publish kernels 0.14.
2. We add a field `foo` to the metadata in kernel-builder 0.15.
3. `kernels` 0.14 will not load metadata from kernel-builder 0.15,
   since it contains an unknown (for 0.14) field `foo`.
