### PR TITLE
layer: make _CACHED_LAYER context-local to match _KERNEL_MAPPING

### DIFF
--- a/kernels/src/kernels/layer/globals.py
+++ b/kernels/src/kernels/layer/globals.py
@@ -1,8 +1,15 @@
 import os
 from contextvars import ContextVar
+from typing import TYPE_CHECKING, Type
 
 from .repos import DeviceRepos
+
+if TYPE_CHECKING:
+    from torch import nn
+    from .repos import RepositoryProtocol
 
 _DISABLE_KERNEL_MAPPING: bool = bool(int(os.environ.get("DISABLE_KERNEL_MAPPING", "0")))
 
 _KERNEL_MAPPING: ContextVar[dict[str, dict[str, DeviceRepos]]] = ContextVar("_KERNEL_MAPPING", default={})
+
+_CACHED_LAYER: ContextVar[dict["RepositoryProtocol", Type["nn.Module"]]] = ContextVar("_CACHED_LAYER", default={})

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -16,7 +16,7 @@ from ..utils import (
     get_local_kernel,
 )
 from .device import Device
-from .globals import _DISABLE_KERNEL_MAPPING, _KERNEL_MAPPING
+from .globals import _CACHED_LAYER, _DISABLE_KERNEL_MAPPING, _KERNEL_MAPPING
 from .mode import Mode
 from .repos import RepositoryProtocol, _select_repository
 
@@ -215,9 +215,6 @@ class LockedLayerRepository:
 
     def __str__(self) -> str:
         return f"`{self._repo_id}` (revision: {self._revision}), layer `{self.layer_name}`"
-
-
-_CACHED_LAYER: dict[RepositoryProtocol, Type["nn.Module"]] = {}
 
 
 def replace_kernel_forward_from_hub(
@@ -473,12 +470,13 @@ def _validate_layer_has_mode(
 
 
 def _get_layer_memoize(repo: RepositoryProtocol, module_class: Type["nn.Module"]) -> Type["nn.Module"]:
-    layer = _CACHED_LAYER.get(repo, None)
+    cache = _CACHED_LAYER.get()
+    layer = cache.get(repo, None)
     if layer is not None:
         return layer
 
     layer = repo.load()
     _validate_layer(check_cls=module_class, cls=layer, repo=repo)
-    _CACHED_LAYER[repo] = layer
+    cache[repo] = layer
 
     return layer


### PR DESCRIPTION
`_CACHED_LAYER` is a plain module-level `dict`, but `_KERNEL_MAPPING` is a
`ContextVar`. This mismatch means that when `use_kernel_mapping()` is used
concurrently (e.g. multiple threads or async tasks with different mappings),
the layer cache is incorrectly shared across contexts — a repo resolved in
one context can be returned for a different repo selected in another context.

Fix by moving `_CACHED_LAYER` into a `ContextVar` in `globals.py`, alongside
`_KERNEL_MAPPING`. `_get_layer_memoize` is updated to read/write from the
context-local dict. Since `use_kernel_mapping.__enter__` already deep-copies
the mapping context, the layer cache is automatically scoped and invalidated
per-context with no additional logic required.

Changes:
- `globals.py`: add `_CACHED_LAYER` as a `ContextVar`
- `layer.py`: remove module-level `_CACHED_LAYER` dict; update
  `_get_layer_memoize` to use the context-local instance