### PR TITLE
nix-builder: nvidia-cutlass-dsl requires Linux

### DIFF
--- a/nix-builder/pkgs/python-modules/nvidia-cutlass-dsl-libs/default.nix
+++ b/nix-builder/pkgs/python-modules/nvidia-cutlass-dsl-libs/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     description = "NVIDIA CUTLASS Python DSL native libraries";
     homepage = "https://github.com/NVIDIA/cutlass";
     license = lib.licenses.unfree;
-    broken = !(cudaPackages.cudaAtLeast "12.8");
+    broken = !(stdenv.hostPlatform.isLinux && cudaPackages.cudaAtLeast "12.8");
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/nix-builder/pkgs/python-modules/nvidia-cutlass-dsl/default.nix
+++ b/nix-builder/pkgs/python-modules/nvidia-cutlass-dsl/default.nix
@@ -13,7 +13,6 @@
 
 let
   format = "wheel";
-  pyShortVersion = "cp" + builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
 in
 buildPythonPackage rec {
   pname = "nvidia-cutlass-dsl";


### PR DESCRIPTION
Fixes macOS cache build.