### PR TITLE
[Fix] Auto-detect Python executable in cmake utils

### DIFF
--- a/kernel-builder/src/pyproject/templates/utils.cmake
+++ b/kernel-builder/src/pyproject/templates/utils.cmake
@@ -30,7 +30,7 @@ endmacro()
 function (run_python OUT EXPR ERR_MSG)
   execute_process(
     COMMAND
-    "${Python_EXECUTABLE}" "-c" "${EXPR}"
+    "${Python3_EXECUTABLE}" "-c" "${EXPR}"
     OUTPUT_VARIABLE PYTHON_OUT
     RESULT_VARIABLE PYTHON_ERROR_CODE
     ERROR_VARIABLE PYTHON_STDERR
@@ -50,7 +50,7 @@ endfunction()
 function (run_python_script OUT SCRIPT_PATH ERR_MSG)
   execute_process(
     COMMAND
-    "${Python_EXECUTABLE}" "${SCRIPT_PATH}"
+    "${Python3_EXECUTABLE}" "${SCRIPT_PATH}"
     OUTPUT_VARIABLE PYTHON_OUT
     RESULT_VARIABLE PYTHON_ERROR_CODE
     ERROR_VARIABLE PYTHON_STDERR

--- a/kernel-builder/src/pyproject/templates/utils.cmake
+++ b/kernel-builder/src/pyproject/templates/utils.cmake
@@ -28,9 +28,16 @@ endmacro()
 # python, a fatal message `ERR_MSG` is issued.
 #
 function (run_python OUT EXPR ERR_MSG)
+  if(Python3_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+  elseif(Python_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+  else()
+    message(FATAL_ERROR "No Python executable found. Set Python3_EXECUTABLE or Python_EXECUTABLE.")
+  endif()
   execute_process(
     COMMAND
-    "${Python3_EXECUTABLE}" "-c" "${EXPR}"
+    "${_PYTHON_EXECUTABLE}" "-c" "${EXPR}"
     OUTPUT_VARIABLE PYTHON_OUT
     RESULT_VARIABLE PYTHON_ERROR_CODE
     ERROR_VARIABLE PYTHON_STDERR
@@ -48,9 +55,16 @@ endfunction()
 # non-zero code, a fatal message `ERR_MSG` is issued.
 #
 function (run_python_script OUT SCRIPT_PATH ERR_MSG)
+  if(Python3_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+  elseif(Python_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+  else()
+    message(FATAL_ERROR "No Python executable found. Set Python3_EXECUTABLE or Python_EXECUTABLE.")
+  endif()
   execute_process(
     COMMAND
-    "${Python3_EXECUTABLE}" "${SCRIPT_PATH}"
+    "${_PYTHON_EXECUTABLE}" "${SCRIPT_PATH}"
     OUTPUT_VARIABLE PYTHON_OUT
     RESULT_VARIABLE PYTHON_ERROR_CODE
     ERROR_VARIABLE PYTHON_STDERR
@@ -68,9 +82,16 @@ endfunction()
 # python, `SUCCESS` is set to FALSE. If successful, `SUCCESS` is set to TRUE.
 #
 function (try_run_python OUT SUCCESS EXPR)
+  if(Python3_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+  elseif(Python_EXECUTABLE)
+    set(_PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+  else()
+    message(FATAL_ERROR "No Python executable found. Set Python3_EXECUTABLE or Python_EXECUTABLE.")
+  endif()
   execute_process(
     COMMAND
-    "${Python3_EXECUTABLE}" "-c" "${EXPR}"
+    "${_PYTHON_EXECUTABLE}" "-c" "${EXPR}"
     OUTPUT_VARIABLE PYTHON_OUT
     RESULT_VARIABLE PYTHON_ERROR_CODE
     ERROR_QUIET


### PR DESCRIPTION
`run_python()`, `run_python_script()` and `try_run_python()` in `utils.cmake` previously hardcoded `Python_EXECUTABLE` or `Python3_EXECUTABLE`.

For example, this causes `get_gpu_lang.py` to fail with **"Cannot detect GPU language"** when building kernels locally via `pip install -e .`. 

The error message is as follows:
```
...
running build_py
      running build_ext
      -- The CXX compiler identification is IntelLLVM 2025.3.2
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /opt/intel/oneapi/compiler/2025.3/bin/icpx - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      -- FetchContent base directory: /tmp/tmp5jy45gzj.build-temp/flash_attn2._flash_attn2_xpu_37cbe71_dirty/_deps
      -- Found Python3: /opt/venv/bin/python (found version "3.12.3") found components: Development Development.SABIModule Interpreter Development.Module Development.Embed
      CMake Error at cmake/utils.cmake:60 (message):
        Cannot detect GPU language:
      Call Stack (most recent call first):
        cmake/get_gpu_lang.cmake:5 (run_python_script)
        CMakeLists.txt:41 (get_gpu_lang)
...
```

This PR makes all three functions auto-detect the available Python executable.