### PR TITLE
Fix an issue with Windows ARM64 free threaded builds

### DIFF
--- a/.github/workflows/kernel_abi_python_release.yaml
+++ b/.github/workflows/kernel_abi_python_release.yaml
@@ -155,10 +155,12 @@ jobs:
           args: --release --out dist --manifest-path kernel-abi-check/bindings/python/Cargo.toml -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: matrix.platform.target != 'aarch64'
         with:
           python-version: 3.14t
           architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels (3.14t)
+        if: matrix.platform.target != 'aarch64'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/kernel_abi_python_release.yaml
+++ b/.github/workflows/kernel_abi_python_release.yaml
@@ -143,10 +143,12 @@ jobs:
           args: --release --out dist --manifest-path kernel-abi-check/bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: matrix.platform.target != 'aarch64'
         with:
           python-version: 3.13t
           architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels (3.13t)
+        if: matrix.platform.target != 'aarch64'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/kernels_data_python_release.yaml
+++ b/.github/workflows/kernels_data_python_release.yaml
@@ -148,10 +148,12 @@ jobs:
           args: --release --out dist --manifest-path kernels-data/bindings/python/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: matrix.platform.target != 'aarch64'
         with:
           python-version: 3.13t
           architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels (3.13t)
+        if: matrix.platform.target != 'aarch64'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/kernels_data_python_release.yaml
+++ b/.github/workflows/kernels_data_python_release.yaml
@@ -160,10 +160,12 @@ jobs:
           args: --release --out dist --manifest-path kernels-data/bindings/python/Cargo.toml -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: matrix.platform.target != 'aarch64'
         with:
           python-version: 3.14t
           architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels (3.14t)
+        if: matrix.platform.target != 'aarch64'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
See https://github.com/actions/setup-python/issues/1241 for a discussion of the issues. The binary naming seems to be incompatible with the Python setup action. This PR disables 3.13t and 3.14t for Windows ARM64, which is a niche of a niche of a niche anyway.