### PR TITLE
Update `CARD.md` to include install tip when benchmarking

### DIFF
--- a/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
+++ b/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/cutlass-gemm/CARD.md
+++ b/examples/kernels/cutlass-gemm/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/extra-data/CARD.md
+++ b/examples/kernels/extra-data/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-backprop-compile/CARD.md
+++ b/examples/kernels/relu-backprop-compile/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-compiler-flags/CARD.md
+++ b/examples/kernels/relu-compiler-flags/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-metal-cpp/CARD.md
+++ b/examples/kernels/relu-metal-cpp/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-nki/CARD.md
+++ b/examples/kernels/relu-nki/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-specific-torch/CARD.md
+++ b/examples/kernels/relu-specific-torch/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-torch-bounds/CARD.md
+++ b/examples/kernels/relu-torch-bounds/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu-tvm-ffi/CARD.md
+++ b/examples/kernels/relu-tvm-ffi/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/relu/CARD.md
+++ b/examples/kernels/relu/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/examples/kernels/silu-and-mul/CARD.md
+++ b/examples/kernels/silu-and-mul/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.

--- a/kernel-builder/src/init/templates/CARD.md
+++ b/kernel-builder/src/init/templates/CARD.md
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Install as `pip install -U "kernels[benchmark]"` and run `kernels benchmark {{ repo_id }}`.
 {% else %}
 
 No benchmark available yet.


### PR DESCRIPTION
## Description

This PR updates the `CARD.md` content that goes into the Hugging Face Hub for the benchmarking section to include the installation instruction with `pip` including the `benchmark` extra.

Note that this might be opinionated, so feel free to close if not relevant, I just found that useful when running the benchmarks as I had to `pip install kernels` -> `kernels benchmark ...` -> `Error: Missing dependencies for benchmark: tabulate\nInstall with: pip install 'kernels[benchmark]'` -> `pip install "kernels[benchmark]"`.

Thanks in advance! cc @sayakpaul @danieldk