### PR TITLE
fix: avoid leading separator in user_agent when no caller-supplied agent is provided

### DIFF
--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -627,33 +627,41 @@ def _get_hf_api(user_agent: str | dict | None = None) -> HfApi:
 
     user_agent_str = ""
     if not constants.HF_HUB_DISABLE_TELEMETRY:
+        parts: list[str] = []
+
         # User-defined info
         if isinstance(user_agent, dict):
-            user_agent_str = "; ".join(f"{k}/{v}" for k, v in user_agent.items())
-        if isinstance(user_agent, str):
-            user_agent_str = user_agent
+            parts.extend(f"{k}/{v}" for k, v in user_agent.items())
+        elif isinstance(user_agent, str) and user_agent:
+            parts.append(user_agent)
 
         # System info
         python = ".".join(platform.python_version_tuple()[:2])
         backend = _select_backend(None).variant_str
-        sys_info = (
-            f"kernels/{__version__}; python/{python}; backend/{backend}; platform/{_platform()}; file_type/kernel"
+        parts.extend(
+            [
+                f"kernels/{__version__}",
+                f"python/{python}",
+                f"backend/{backend}",
+                f"platform/{_platform()}",
+                "file_type/kernel",
+            ]
         )
 
         if has_torch:
             import torch
 
-            sys_info += f"; torch/{torch.__version__}"
+            parts.append(f"torch/{torch.__version__}")
         if has_tvm_ffi:
             import tvm_ffi
 
-            sys_info += f"; tvm-ffi/{tvm_ffi.__version__}"
+            parts.append(f"tvm-ffi/{tvm_ffi.__version__}")
 
         # Add glibc version if available
         glibc = glibc_version()
         if glibc is not None:
-            sys_info += f"; glibc/{glibc}"
+            parts.append(f"glibc/{glibc}")
 
-        user_agent_str = f"{user_agent_str}; {sys_info}" if user_agent_str else sys_info
+        user_agent_str = "; ".join(parts)
 
     return HfApi(library_name="kernels", library_version=__version__, user_agent=user_agent_str)

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -636,22 +636,24 @@ def _get_hf_api(user_agent: str | dict | None = None) -> HfApi:
         # System info
         python = ".".join(platform.python_version_tuple()[:2])
         backend = _select_backend(None).variant_str
-        user_agent_str += (
-            f"; kernels/{__version__}; python/{python}; backend/{backend}; platform/{_platform()}; file_type/kernel"
+        sys_info = (
+            f"kernels/{__version__}; python/{python}; backend/{backend}; platform/{_platform()}; file_type/kernel"
         )
 
         if has_torch:
             import torch
 
-            user_agent_str += f"; torch/{torch.__version__}"
+            sys_info += f"; torch/{torch.__version__}"
         if has_tvm_ffi:
             import tvm_ffi
 
-            user_agent_str += f"; tvm-ffi/{tvm_ffi.__version__}"
+            sys_info += f"; tvm-ffi/{tvm_ffi.__version__}"
 
         # Add glibc version if available
         glibc = glibc_version()
         if glibc is not None:
-            user_agent_str += f"; glibc/{glibc}"
+            sys_info += f"; glibc/{glibc}"
+
+        user_agent_str = f"{user_agent_str}; {sys_info}" if user_agent_str else sys_info
 
     return HfApi(library_name="kernels", library_version=__version__, user_agent=user_agent_str)

--- a/kernels/tests/test_user_agent.py
+++ b/kernels/tests/test_user_agent.py
@@ -69,3 +69,16 @@ def test_platform_format():
     parts = plat.split("-")
     assert len(parts) == 2
     assert parts[1] in ("linux", "darwin", "windows")
+
+
+def test_user_agent_no_leading_or_empty_segment():
+    # Regression: when no caller-supplied user_agent is passed, the resulting
+    # string must not start with a separator and must not contain empty
+    # segments. Empty segments downstream produce malformed User-Agent headers
+    # (e.g. trailing "; ") which strict HTTP clients reject.
+    for ua_input in (None, "", {}):
+        api = _get_hf_api(user_agent=ua_input)
+        ua = api.user_agent
+        assert not ua.startswith(";"), f"user_agent must not start with ';': {ua!r}"
+        for segment in ua.split(";"):
+            assert segment.strip() != "", f"empty segment found in user_agent: {ua!r}"


### PR DESCRIPTION
## Summary

`_get_hf_api()` in `kernels/src/kernels/utils.py` produces a malformed user-agent when no `user_agent` argument is passed. The empty `user_agent_str` is appended to with `+= "; kernels/..."`, leaving a leading `; `. When the resulting string is forwarded to `HfApi(...)`, `huggingface_hub` joins its own fields with another `; `, producing an empty token in the middle of the User-Agent header.

After the dedup/format step in `huggingface_hub`, this leaves a trailing `; ` in the final header, which strict HTTP clients (httpx ≥ 0.25) reject with `LocalProtocolError: Illegal header value`.

This breaks any flow that triggers `_get_hf_api()` without supplying a `user_agent` — most notably `_get_available_versions()`, which is hit when `transformers` loads `finegrained-fp8` / `deep-gemm` kernels.

## Repro

```python
from kernels._versions import _get_available_versions
_get_available_versions("kernels-community/finegrained-fp8")
# httpx.LocalProtocolError: Illegal header value
# b'kernels/0.13.0; hf_hub/1.12.2; python/3.12.3; '
```

End-to-end, the same bug surfaces as a crash when running a `transformers` `Qwen3-VL-*-FP8` model — the FP8 kernel fetch never completes.

## Fix

Build the system info as a separate `sys_info` string with no leading separator, then concatenate it onto any caller-supplied `user_agent` with a single `; ` only when the caller-supplied part is non-empty.

## Tests

Added `test_user_agent_no_leading_or_empty_segment` to `kernels/tests/test_user_agent.py` covering the three input shapes that previously triggered the bug (`None`, `""`, `{}`).