### PR TITLE
feat: prefer using hf hub library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,8 +1131,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "1.0.0"
-source = "git+https://github.com/huggingface/hf-hub.git?rev=18dfe58f2d1ed3779428b670ab8e407bc336c168#18dfe58f2d1ed3779428b670ab8e407bc336c168"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92c57832843dcd7a502be7150a8df2b132e5fb3e8c30127b5b75fc5a92d554d"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hf-hub"
 version = "1.0.0"
-source = "git+https://github.com/huggingface/hf-hub.git?rev=670b3f489cc10e1c4a7325fb8632bffbe07f0c40#670b3f489cc10e1c4a7325fb8632bffbe07f0c40"
+source = "git+https://github.com/huggingface/hf-hub.git?rev=18dfe58f2d1ed3779428b670ab8e407bc336c168#18dfe58f2d1ed3779428b670ab8e407bc336c168"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hf-hub"
 version = "1.0.0"
-source = "git+https://github.com/huggingface/hf-hub.git?rev=54d70e8afc95dad00e7fcebf8e0d74a39c395856#54d70e8afc95dad00e7fcebf8e0d74a39c395856"
+source = "git+https://github.com/huggingface/hf-hub.git?rev=670b3f489cc10e1c4a7325fb8632bffbe07f0c40#670b3f489cc10e1c4a7325fb8632bffbe07f0c40"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -226,6 +226,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +397,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -421,6 +466,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -537,6 +588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,23 +634,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -610,7 +693,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -620,8 +703,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -653,7 +747,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -762,17 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix",
- "tokio",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +917,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -931,6 +1014,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -959,7 +1043,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1046,6 +1130,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hf-hub"
+version = "1.0.0"
+source = "git+https://github.com/huggingface/hf-hub.git?rev=54d70e8afc95dad00e7fcebf8e0d74a39c395856#54d70e8afc95dad00e7fcebf8e0d74a39c395856"
+dependencies = [
+ "base64",
+ "bon",
+ "bytes",
+ "futures",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hf-kernel-builder"
 version = "0.14.0-dev1"
 dependencies = [
@@ -1056,7 +1165,7 @@ dependencies = [
  "dirs",
  "eyre",
  "git2",
- "huggingface-hub",
+ "hf-hub",
  "itertools 0.13.0",
  "kernels-data",
  "minijinja",
@@ -1077,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51abe4fef614e6d944f451ceb9af154efa7e85dff8f2c35e2922cc789e0aa88"
+checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1090,7 +1199,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
+ "uuid",
  "xet-client",
  "xet-core-structures",
  "xet-data",
@@ -1137,38 +1246,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "huggingface-hub"
-version = "0.0.1"
-source = "git+https://github.com/huggingface/huggingface_hub_rust.git?rev=6084c0f911026b4fec2961742c611520d7eb3d27#6084c0f911026b4fec2961742c611520d7eb3d27"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "fs4",
- "futures",
- "globset",
- "hf-xet",
- "pathdiff",
- "reqwest",
- "reqwest-middleware",
- "reqwest-retry",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "typed-builder",
- "url",
- "xet-client",
-]
-
-[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1344,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,7 +1512,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1499,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1677,15 +1773,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -2018,29 +2105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2177,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2121,12 +2185,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2171,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2228,7 +2286,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2241,7 +2299,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2343,6 +2401,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,21 +2450,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redb"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2494,39 +2560,8 @@ dependencies = [
  "async-trait",
  "http",
  "reqwest",
- "serde",
  "thiserror 2.0.18",
  "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http",
- "hyper",
- "reqwest",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.3",
 ]
 
 [[package]]
@@ -2752,12 +2787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,7 +2852,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2847,7 +2876,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2879,8 +2908,19 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2988,17 +3028,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3025,7 +3054,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3108,7 +3137,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3119,7 +3148,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3219,7 +3248,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3373,7 +3402,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3461,26 +3490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
-name = "typed-builder"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,16 +3500,6 @@ name = "typewit"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc19094686c694eb41b3b99dcc2f2975d4b078512fa22ae6c63f7ca318bdcff7"
-
-[[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.3",
- "web-time",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -3775,7 +3774,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3833,20 +3832,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3975,7 +3960,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3986,7 +3971,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4048,15 +4033,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4313,7 +4289,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4329,7 +4305,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4379,9 +4355,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9164bc896ccd143b33fd08a8a2c8e3d769e5e0b2c853496694937fcce734bc1a"
+checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4389,17 +4365,15 @@ dependencies = [
  "bytes",
  "clap",
  "crc32fast",
- "derivative",
  "futures",
  "http",
  "hyper",
  "lazy_static",
  "more-asserts",
- "rand 0.9.3",
+ "rand 0.10.1",
  "redb",
  "reqwest",
  "reqwest-middleware",
- "reqwest-retry",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4419,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ddd10bc095bdb6539a9ace6bfd9f27c13c8604d2f18d25383169aa948c5c09"
+checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
 dependencies = [
  "async-trait",
  "base64",
@@ -4439,7 +4413,7 @@ dependencies = [
  "lazy_static",
  "lz4_flex",
  "more-asserts",
- "rand 0.9.3",
+ "rand 0.10.1",
  "regex",
  "safe-transmute",
  "serde",
@@ -4456,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00516b2aeea170fbed408adf519931f52db71b5fc7365bb6c63055caf5af113a"
+checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4470,17 +4444,17 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "more-asserts",
- "rand 0.9.3",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
  "url",
+ "uuid",
  "walkdir",
  "xet-client",
  "xet-core-structures",
@@ -4489,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc7acf5e0a8eb33bb6115376126b6776b7c82a043c661816ff070a6408832a"
+checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4510,7 +4484,7 @@ dependencies = [
  "more-asserts",
  "oneshot",
  "pin-project",
- "rand 0.9.3",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -4545,7 +4519,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4566,7 +4540,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4586,7 +4560,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4626,7 +4600,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/kernel-builder/Cargo.toml
+++ b/kernel-builder/Cargo.toml
@@ -16,7 +16,7 @@ clap-markdown = "0.1.5"
 clap_complete = "4"
 eyre = "0.6.12"
 git2 = "0.20"
-hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "54d70e8afc95dad00e7fcebf8e0d74a39c395856", features = ["blocking"] }
+hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "670b3f489cc10e1c4a7325fb8632bffbe07f0c40", features = ["blocking"] }
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"

--- a/kernel-builder/Cargo.toml
+++ b/kernel-builder/Cargo.toml
@@ -16,7 +16,7 @@ clap-markdown = "0.1.5"
 clap_complete = "4"
 eyre = "0.6.12"
 git2 = "0.20"
-hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "18dfe58f2d1ed3779428b670ab8e407bc336c168", features = ["blocking"] }
+hf-hub = { version = "1.0.0-rc.0", features = ["blocking"] }
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"

--- a/kernel-builder/Cargo.toml
+++ b/kernel-builder/Cargo.toml
@@ -16,7 +16,7 @@ clap-markdown = "0.1.5"
 clap_complete = "4"
 eyre = "0.6.12"
 git2 = "0.20"
-huggingface-hub = { git = "https://github.com/huggingface/huggingface_hub_rust.git", rev = "6084c0f911026b4fec2961742c611520d7eb3d27", package = "huggingface-hub", features = ["blocking", "xet"] }
+hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "54d70e8afc95dad00e7fcebf8e0d74a39c395856", features = ["blocking"] }
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"

--- a/kernel-builder/Cargo.toml
+++ b/kernel-builder/Cargo.toml
@@ -16,7 +16,7 @@ clap-markdown = "0.1.5"
 clap_complete = "4"
 eyre = "0.6.12"
 git2 = "0.20"
-hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "670b3f489cc10e1c4a7325fb8632bffbe07f0c40", features = ["blocking"] }
+hf-hub = { git = "https://github.com/huggingface/hf-hub.git", rev = "18dfe58f2d1ed3779428b670ab8e407bc336c168", features = ["blocking"] }
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"

--- a/kernel-builder/src/hf.rs
+++ b/kernel-builder/src/hf.rs
@@ -1,9 +1,9 @@
 use eyre::{Context, Result};
-use huggingface_hub::{HFClientSync, HFRepositorySync, RepoType};
+use hf_hub::{HFClientSync, HFRepositorySync, RepoType};
 
 /// Build a sync HF API client.
-pub fn api() -> Result<huggingface_hub::HFClientSync> {
-    huggingface_hub::HFClientSync::new().context("Cannot create Hugging Face API client")
+pub fn api() -> Result<hf_hub::HFClientSync> {
+    hf_hub::HFClientSync::new().context("Cannot create Hugging Face API client")
 }
 
 /// Get a repo handle.
@@ -19,10 +19,14 @@ pub fn repo_handle(api: &HFClientSync, repo_type: RepoType, repo_id: &str) -> HF
 /// Resolve the HF username of the currently logged-in user via `whoami`.
 /// Requires a valid HF token to be configured.
 pub fn whoami_username() -> Result<String> {
-    api()?.whoami().map(|user| user.username).map_err(|_| {
-        eyre::eyre!(
-            "Not logged in to Hugging Face. Run `hf auth login` first, \
-                 or use --name <owner/repo> to skip auto-detection."
-        )
-    })
+    api()?
+        .whoami()
+        .send()
+        .map(|user| user.username)
+        .map_err(|_| {
+            eyre::eyre!(
+                "Not logged in to Hugging Face. Run `hf auth login` first, \
+                     or use --name <owner/repo> to skip auto-detection."
+            )
+        })
 }

--- a/kernel-builder/src/hf.rs
+++ b/kernel-builder/src/hf.rs
@@ -7,12 +7,12 @@ pub fn api() -> Result<hf_hub::HFClientSync> {
 }
 
 /// Get a repo handle.
-pub fn repo_handle(api: &HFClientSync, repo_type: RepoType, repo_id: &str) -> HFRepositorySync {
+pub fn repo_handle<T: RepoType>(api: &HFClientSync, repo_id: &str) -> HFRepositorySync<T> {
     let parts: Vec<&str> = repo_id.splitn(2, '/').collect();
     if parts.len() == 2 {
-        api.repo(repo_type, parts[0], parts[1])
+        api.repository::<T>(parts[0], parts[1])
     } else {
-        api.repo(repo_type, "", repo_id)
+        api.repository::<T>("", repo_id)
     }
 }
 

--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -9,7 +9,7 @@ use clap::Args;
 use eyre::{bail, Context, Result};
 use hf_hub::{
     repository::{AddSource, CommitOperation},
-    RepoType,
+    RepoType, RepoTypeKernel, RepoTypeModel,
 };
 use kernels_data::metadata::Metadata;
 use walkdir::WalkDir;
@@ -27,15 +27,6 @@ pub enum RepoTypeArg {
     Model,
     #[default]
     Kernel,
-}
-
-impl From<RepoTypeArg> for RepoType {
-    fn from(arg: RepoTypeArg) -> Self {
-        match arg {
-            RepoTypeArg::Model => RepoType::Model,
-            RepoTypeArg::Kernel => RepoType::Kernel,
-        }
-    }
 }
 
 #[derive(Debug, Args)]
@@ -96,8 +87,14 @@ fn get_repo_and_branch(
 }
 
 pub fn run_upload(args: UploadArgs) -> Result<()> {
+    match args.repo_type {
+        RepoTypeArg::Model => run_upload_typed::<RepoTypeModel>(args),
+        RepoTypeArg::Kernel => run_upload_typed::<RepoTypeKernel>(args),
+    }
+}
+
+fn run_upload_typed<T: RepoType>(args: UploadArgs) -> Result<()> {
     let api = hf::api()?;
-    let repo_type: RepoType = args.repo_type.into();
     let kernel_dir = check_or_infer_kernel_dir(args.kernel_dir)?;
     let kernel_dir = fs::canonicalize(&kernel_dir)
         .wrap_err_with(|| format!("Cannot resolve kernel directory `{}`", kernel_dir.display()))?;
@@ -112,9 +109,9 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
     let (repo_id, branch) = get_repo_and_branch(&kernel_dir, args.repo_id, args.branch, &variants)?;
 
     let repo_url = api
-        .create_repo()
+        .create_repository()
         .repo_id(&repo_id)
-        .repo_type(repo_type)
+        .repo_type(T::default())
         .private(args.private)
         .exist_ok(true)
         .send()
@@ -128,7 +125,7 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
         .unwrap_or(&repo_id)
         .to_owned();
 
-    let repo = repo_handle(&api, repo_type, &repo_id);
+    let repo = repo_handle::<T>(&api, &repo_id);
 
     let is_new_version_branch = if let Some(ref branch) = branch {
         let refs = repo
@@ -240,10 +237,7 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
     if total_ops == 0 {
         eprintln!("No changes to upload.");
     } else {
-        let type_prefix = match repo_type {
-            RepoType::Kernel => "kernels/",
-            _ => "",
-        };
+        let type_prefix = T::default().url_prefix();
         let tree_path = branch
             .as_ref()
             .map_or(String::new(), |b| format!("/tree/{b}"));

--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -7,9 +7,9 @@ use std::{
 
 use clap::Args;
 use eyre::{bail, Context, Result};
-use huggingface_hub::{
-    AddSource, CommitOperation, CreateRepoParams, RepoCreateBranchParams, RepoCreateCommitParams,
-    RepoListFilesParams, RepoListRefsParams, RepoType,
+use hf_hub::{
+    repository::{AddSource, CommitOperation},
+    RepoType,
 };
 use kernels_data::metadata::Metadata;
 use walkdir::WalkDir;
@@ -111,14 +111,13 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
 
     let (repo_id, branch) = get_repo_and_branch(&kernel_dir, args.repo_id, args.branch, &variants)?;
 
-    let params = CreateRepoParams::builder()
+    let repo_url = api
+        .create_repo()
         .repo_id(&repo_id)
         .repo_type(repo_type)
         .private(args.private)
         .exist_ok(true)
-        .build();
-    let repo_url = api
-        .create_repo(&params)
+        .send()
         .wrap_err("Cannot create repository")?;
     // Extract repo_id from URL, stripping "kernels/" prefix for kernel repos
     let repo_id = repo_url
@@ -132,15 +131,16 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
     let repo = repo_handle(&api, repo_type, &repo_id);
 
     let is_new_version_branch = if let Some(ref branch) = branch {
-        let refs_params = RepoListRefsParams::builder().build();
         let refs = repo
-            .list_refs(&refs_params)
+            .list_refs()
+            .send()
             .wrap_err("Cannot list repository refs")?;
         let exists = refs.branches.iter().any(|r| r.name == *branch);
 
         if !exists {
-            let params = RepoCreateBranchParams::builder().branch(branch).build();
-            repo.create_branch(&params)
+            repo.create_branch()
+                .branch(branch)
+                .send()
                 .wrap_err_with(|| format!("Cannot create branch `{branch}`"))?;
         }
         eprintln!(
@@ -163,10 +163,18 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
     );
 
     if let Some(ref branch) = branch {
-        let params = RepoListFilesParams {
-            revision: Some(branch.clone()),
-        };
-        let version_existing_files: Vec<String> = repo.list_files(&params).unwrap_or_default();
+        let version_existing_files: Vec<String> = repo
+            .list_tree()
+            .revision(branch.clone())
+            .recursive(true)
+            .send()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|entry| match entry {
+                hf_hub::repository::RepoTreeEntry::File { path, .. } => path,
+                hf_hub::repository::RepoTreeEntry::Directory { path, .. } => path,
+            })
+            .collect();
 
         let version_ops = operations_by_branch.entry(branch.clone()).or_default();
 
@@ -215,15 +223,11 @@ pub fn run_upload(args: UploadArgs) -> Result<()> {
                 "Uploaded using `kernel-builder`.".to_owned()
             };
 
-            let params = RepoCreateCommitParams {
-                operations: chunk.to_vec(),
-                commit_message,
-                commit_description: None,
-                revision: Some(branch.clone()),
-                create_pr: None,
-                parent_commit: None,
-            };
-            repo.create_commit(&params)
+            repo.create_commit()
+                .operations(chunk.to_vec())
+                .commit_message(&commit_message)
+                .revision(branch.clone())
+                .send()
                 .wrap_err_with(|| format!("Cannot create commit on branch `{branch}`"))?;
 
             if batch_count > 1 {

--- a/nix-builder/pkgs/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/kernel-abi-check/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ../../../Cargo.lock;
     outputHashes = {
-      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
+      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
     };
   };
 

--- a/nix-builder/pkgs/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/kernel-abi-check/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ../../../Cargo.lock;
     outputHashes = {
-      "huggingface-hub-0.0.1" = "sha256-By8b1NUPWu+XF3Om1NcEO+o2qdZUco+FxvrJGNRqxWs=";
+      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
     };
   };
 

--- a/nix-builder/pkgs/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/kernel-abi-check/default.nix
@@ -32,9 +32,6 @@ rustPlatform.buildRustPackage {
 
   cargoLock = {
     lockFile = ../../../Cargo.lock;
-    outputHashes = {
-      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
-    };
   };
 
   cargoBuildFlags = cargoFlags;

--- a/nix-builder/pkgs/kernel-builder/default.nix
+++ b/nix-builder/pkgs/kernel-builder/default.nix
@@ -51,9 +51,6 @@ rustPlatform.buildRustPackage {
 
   cargoLock = {
     lockFile = ../../../Cargo.lock;
-    outputHashes = {
-      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
-    };
   };
 
   cargoBuildFlags = cargoFlags;

--- a/nix-builder/pkgs/kernel-builder/default.nix
+++ b/nix-builder/pkgs/kernel-builder/default.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ../../../Cargo.lock;
     outputHashes = {
-      "huggingface-hub-0.0.1" = "sha256-By8b1NUPWu+XF3Om1NcEO+o2qdZUco+FxvrJGNRqxWs=";
+      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
     };
   };
 

--- a/nix-builder/pkgs/kernel-builder/default.nix
+++ b/nix-builder/pkgs/kernel-builder/default.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage {
   cargoLock = {
     lockFile = ../../../Cargo.lock;
     outputHashes = {
-      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
+      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
     };
   };
 

--- a/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
@@ -36,9 +36,6 @@ buildPythonPackage {
 
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
-    outputHashes = {
-      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
-    };
   };
 
   maturinBuildFlags = cargoFlags;

--- a/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
     outputHashes = {
-      "huggingface-hub-0.0.1" = "sha256-By8b1NUPWu+XF3Om1NcEO+o2qdZUco+FxvrJGNRqxWs=";
+      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
     };
   };
 

--- a/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
+++ b/nix-builder/pkgs/python-modules/kernel-abi-check/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
     outputHashes = {
-      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
+      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
     };
   };
 

--- a/nix-builder/pkgs/python-modules/kernels-data/default.nix
+++ b/nix-builder/pkgs/python-modules/kernels-data/default.nix
@@ -34,9 +34,6 @@ buildPythonPackage {
 
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
-    outputHashes = {
-      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
-    };
   };
 
   maturinBuildFlags = cargoFlags;

--- a/nix-builder/pkgs/python-modules/kernels-data/default.nix
+++ b/nix-builder/pkgs/python-modules/kernels-data/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
     outputHashes = {
-      "huggingface-hub-0.0.1" = "sha256-By8b1NUPWu+XF3Om1NcEO+o2qdZUco+FxvrJGNRqxWs=";
+      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
     };
   };
 

--- a/nix-builder/pkgs/python-modules/kernels-data/default.nix
+++ b/nix-builder/pkgs/python-modules/kernels-data/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage {
   cargoDeps = rustPlatform.importCargoLock {
     lockFile = ../../../../Cargo.lock;
     outputHashes = {
-      "hf-hub-1.0.0" = "sha256-XJVbG/dfxeSaTvyZMqB/6oF0I5cqKXIXzG5Zq00xmnk=";
+      "hf-hub-1.0.0" = "sha256-oCMBxgqSpSwnaP1fJKyleHA+4o9D19Nx1tz0mjZdgHk=";
     };
   };
 


### PR DESCRIPTION
This PR updates the kernel-builder to use the hf-hub repo based on the https://github.com/huggingface/hf-hub/pull/150 branch that ports the huggingface_hub_rust functionality to the existing hf-hub library

this PR will be updated to use the crate based distribution when the upstream is merged and published (will move out of draft at that point)