### PR TITLE
Fix update tests for kernel data lib and path and add ci rust tests

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -49,3 +49,25 @@ jobs:
           ( cd kernels-data/bindings/python && cargo clippy -- -D warnings )
       - name: Clippy (kernel-builder)
         run: ( cd kernel-builder && cargo clippy -- -D warnings )
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Test (kernel-abi-check)
+        run: cargo test -p kernel-abi-check
+      - name: Test (kernels-data)
+        run: cargo test -p kernels-data
+      - name: Test (kernel-builder)
+        run: cargo test -p hf-kernel-builder

--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -597,9 +597,9 @@ mod tests {
     }
 
     const METADATA_V3: &str =
-        r#"{"id": "kernel_id", "version": 3, "python-depends": [], "backend": {"type": "cuda"}}"#;
-    const METADATA_NO_VERSION: &str =
-        r#"{"id": "kernel_id", "python-depends": [], "backend": {"type": "cuda"}}"#;
+        r#"{"name": "test-kernel", "id": "kernel_id", "version": 3, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
+    const METADATA_V0: &str =
+        r#"{"name": "test-kernel", "id": "kernel_id", "version": 0, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
 
     #[test]
     fn test_detect_branch_from_metadata() {
@@ -614,15 +614,15 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_branch_from_metadata_no_version() {
+    fn test_detect_branch_from_metadata_v0() {
         let temp_dir = tempfile::tempdir().unwrap();
         let variant = temp_dir.path().join("variant");
         fs::create_dir_all(&variant).unwrap();
-        fs::write(variant.join("metadata.json"), METADATA_NO_VERSION).unwrap();
+        fs::write(variant.join("metadata.json"), METADATA_V0).unwrap();
 
         let variants = vec![variant];
         let branch = detect_branch_from_metadata(&variants).unwrap();
-        assert_eq!(branch, None);
+        assert_eq!(branch, Some("v0".to_owned()));
     }
 
     #[test]
@@ -634,12 +634,12 @@ mod tests {
         fs::create_dir_all(&v2).unwrap();
         fs::write(
             v1.join("metadata.json"),
-            r#"{"version": 1, "python-depends": [], "backend": {"type": "cuda"}}"#,
+            r#"{"name": "test-kernel", "version": 1, "id": "k1", "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#,
         )
         .unwrap();
         fs::write(
             v2.join("metadata.json"),
-            r#"{"version": 2, "python-depends": [], "backend": {"type": "cuda"}}"#,
+            r#"{"name": "test-kernel", "version": 2, "id": "k2", "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#,
         )
         .unwrap();
 
@@ -711,6 +711,7 @@ mod tests {
             kernel_dir.join("build.toml"),
             r#"[general]
 name = "test-kernel"
+license = "Apache-2.0"
 backends = ["cuda"]
 
 [general.hub]
@@ -747,6 +748,7 @@ branch = "custom-branch"
             kernel_dir.join("build.toml"),
             r#"[general]
 name = "test-kernel"
+license = "Apache-2.0"
 backends = ["cuda"]
 
 [general.hub]

--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -596,10 +596,8 @@ mod tests {
         assert!(delete_paths.contains("build/torch-cuda/inherited.py"));
     }
 
-    const METADATA_V3: &str =
-        r#"{"name": "test-kernel", "id": "kernel_id", "version": 3, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
-    const METADATA_V0: &str =
-        r#"{"name": "test-kernel", "id": "kernel_id", "version": 0, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
+    const METADATA_V3: &str = r#"{"name": "test-kernel", "id": "kernel_id", "version": 3, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
+    const METADATA_V0: &str = r#"{"name": "test-kernel", "id": "kernel_id", "version": 0, "license": "Apache-2.0", "python-depends": [], "backend": {"type": "cuda"}}"#;
 
     #[test]
     fn test_detect_branch_from_metadata() {

--- a/kernel-builder/tests/init_e2e.rs
+++ b/kernel-builder/tests/init_e2e.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 fn run_init(args: &[&str]) -> (bool, String, tempfile::TempDir) {
     let temp = tempfile::tempdir().unwrap();
-    let bin = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("target/debug/kernel-builder");
+    let bin = std::path::PathBuf::from(env!("CARGO_BIN_EXE_kernel-builder"));
 
     let output = Command::new(&bin)
         .args(["init"])
@@ -57,7 +57,7 @@ fn test_init_fails_on_existing_scaffold_file() {
     // Pre-create a scaffold file - should cause init to fail
     fs::write(dir.join("build.toml"), "existing content").unwrap();
 
-    let bin = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("target/debug/kernel-builder");
+    let bin = std::path::PathBuf::from(env!("CARGO_BIN_EXE_kernel-builder"));
 
     let out = Command::new(&bin)
         .args(["init", "--name", "user/exists", "--backends", "cpu"])
@@ -82,7 +82,7 @@ fn test_init_overwrite() {
     fs::write(dir.join("build.toml"), "old scaffold").unwrap();
     fs::write(dir.join("custom.txt"), "user content").unwrap();
 
-    let bin = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("target/debug/kernel-builder");
+    let bin = std::path::PathBuf::from(env!("CARGO_BIN_EXE_kernel-builder"));
 
     let out = Command::new(&bin)
         .args([


### PR DESCRIPTION
This PR simply updates the tests since they were failing due to the new kernel-data library and a bad path for the e2e tests

```bash
cargo test -p hf-kernel-builder
```
```
   Compiling hf-kernel-builder v0.14.0-dev1 (/Users/drbh/Projects/kernels/kernel-builder)
    Finished [`test` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.28s
     Running unittests src/main.rs (target/debug/deps/kernel_builder-38c44aa6fab662b1)

running 27 tests
test card::tests::test_extract_functions_missing ... ok
test card::tests::test_extract_functions_excludes_layers ... ok
test upload::tests::test_collect_benchmark_commit_ops_delete_stale ... ok
test card::tests::test_extract_functions ... ok
test upload::tests::test_collect_benchmark_commit_ops ... ok
test upload::tests::test_collect_build_commit_ops_deletes_stale ... ok
test card::tests::test_extract_layers_missing_file ... ok
test upload::tests::test_collect_readme_commit_ops ... ok
test upload::tests::test_collect_build_commit_ops_new_branch_deletes_all ... ok
test card::tests::test_extract_functions_only_layers ... ok
test card::tests::test_extract_functions_multiline ... ok
test upload::tests::test_args_take_priority_over_files ... ok
test upload::tests::test_collect_readme_commit_ops_no_card ... ok
test upload::tests::test_discover_build_file_not_found ... ok
test upload::tests::test_collect_build_commit_ops ... ok
test util::tests::test_discover_variants_no_variants ... ok
test upload::tests::test_discover_build_file_in_fully_specified_build_dir ... ok
test upload::tests::test_discover_build_file_in_build ... ok
test upload::tests::test_detect_branch_from_metadata ... ok
test card::tests::test_extract_layers_not_in_all ... ok
test upload::tests::test_branch_from_build_toml ... ok
test upload::tests::test_detect_branch_from_metadata_v0 ... ok
test card::tests::test_extract_layers ... ok
test upload::tests::test_discover_build_file_in_result_symlink ... ok
test upload::tests::test_detect_branch_from_metadata_mismatched_versions ... ok
test util::tests::test_discover_variants_from_result_symlink ... ok
test util::tests::test_discover_variants ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/init_e2e.rs (target/debug/deps/init_e2e-4d1304e2a31c5304)

running 4 tests
test test_init_fails_on_existing_scaffold_file ... ok
test test_init_templates_rendered ... ok
test test_init_creates_expected_files ... ok
test test_init_overwrite ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.97s
```

and before the changes

```bash
cargo test -p hf-kernel-builder
```
```
   Compiling hf-kernel-builder v0.14.0-dev1 (/Users/drbh/Projects/kernels/kernel-builder)
    Finished [`test` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.90s
     Running unittests src/main.rs (target/debug/deps/kernel_builder-38c44aa6fab662b1)

running 27 tests
test card::tests::test_extract_functions_missing ... ok
test upload::tests::test_collect_benchmark_commit_ops_delete_stale ... ok
test card::tests::test_extract_functions_excludes_layers ... ok
test card::tests::test_extract_layers_missing_file ... ok
test card::tests::test_extract_functions_only_layers ... ok
test upload::tests::test_collect_build_commit_ops_deletes_stale ... ok
test upload::tests::test_collect_build_commit_ops_new_branch_deletes_all ... ok
test card::tests::test_extract_functions_multiline ... ok
test upload::tests::test_collect_readme_commit_ops_no_card ... ok
test upload::tests::test_collect_build_commit_ops ... ok
test card::tests::test_extract_functions ... ok
test card::tests::test_extract_layers ... ok
test upload::tests::test_discover_build_file_not_found ... ok
test card::tests::test_extract_layers_not_in_all ... ok
test upload::tests::test_collect_benchmark_commit_ops ... ok
test upload::tests::test_discover_build_file_in_build ... ok
test util::tests::test_discover_variants_no_variants ... ok
test upload::tests::test_collect_readme_commit_ops ... ok
test upload::tests::test_detect_branch_from_metadata ... FAILED
test upload::tests::test_detect_branch_from_metadata_no_version ... FAILED
test upload::tests::test_discover_build_file_in_fully_specified_build_dir ... ok
test upload::tests::test_args_take_priority_over_files ... ok
test upload::tests::test_branch_from_build_toml ... FAILED
test upload::tests::test_discover_build_file_in_result_symlink ... ok
test upload::tests::test_detect_branch_from_metadata_mismatched_versions ... ok
test util::tests::test_discover_variants_from_result_symlink ... ok
test util::tests::test_discover_variants ... ok

failures:

---- upload::tests::test_detect_branch_from_metadata stdout ----

thread 'upload::tests::test_detect_branch_from_metadata' (10480561) panicked at kernel-builder/src/upload.rs:612:61:
called `Result::unwrap()` on an `Err` value: missing field `name` at line 1 column 84

Location:
    kernels-data/src/metadata.rs:33:12

---- upload::tests::test_detect_branch_from_metadata_no_version stdout ----

thread 'upload::tests::test_detect_branch_from_metadata_no_version' (10480563) panicked at kernel-builder/src/upload.rs:624:61:
called `Result::unwrap()` on an `Err` value: missing field `name` at line 1 column 70

Location:
    kernels-data/src/metadata.rs:33:12

---- upload::tests::test_branch_from_build_toml stdout ----

thread 'upload::tests::test_branch_from_build_toml' (10480553) panicked at kernel-builder/src/upload.rs:730:88:
called `Result::unwrap()` on an `Err` value: --repo-id is not provided and cannot parse build.toml.

Caused by:
   0: Cannot update build configuration
   1: Cannot migrate configuration: "The `license` key is required in the `general` section"

Location:
    kernel-builder/src/util.rs:15:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    upload::tests::test_branch_from_build_toml
    upload::tests::test_detect_branch_from_metadata
    upload::tests::test_detect_branch_from_metadata_no_version

test result: FAILED. 24 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

error: test failed, to rerun pass `-p hf-kernel-builder --bin kernel-builder`
```