### PR TITLE
Remove non-HF repos from docs/tests

### DIFF
--- a/kernels/src/kernels/layer/kernelize.py
+++ b/kernels/src/kernels/layer/kernelize.py
@@ -139,12 +139,12 @@ def register_kernel_mapping(
             "MultiHeadAttention": {
                 "cuda": {
                     Mode.TRAINING: LayerRepository(
-                        repo_id="username/training-kernels",
+                        repo_id="kernels-community/training-kernels",
                         layer_name="TrainingAttention",
                         version=1,
                     ),
                     Mode.INFERENCE: LayerRepository(
-                        repo_id="username/inference-kernels",
+                        repo_id="kernels-community/inference-kernels",
                         layer_name="FastAttention",
                         version=1,
                     ),

--- a/kernels/tests/test_layer.py
+++ b/kernels/tests/test_layer.py
@@ -41,10 +41,6 @@ kernel_layer_mapping = {
             layer_name="SiluAndMul",
             version=1,
         ),
-        "npu": LayerRepository(
-            repo_id="kernels-ext-npu/SwiGlu",
-            layer_name="SwiGlu",
-        ),
     },
     "SiluAndMulNoCompile": {
         "cuda": LayerRepository(
@@ -291,23 +287,6 @@ def test_hub_forward_xpu():
 
     assert rms_norm.n_calls == 1
     assert rms_norm_with_kernel.n_calls == 0
-
-
-@pytest.mark.npu_only
-def test_hub_forward_npu():
-    torch.manual_seed(0)
-
-    silu_and_mul = SiluAndMul()
-    X = torch.randn((32, 64), device="npu")
-    Y = silu_and_mul(X)
-
-    silu_and_mul_with_kernel = kernelize(SiluAndMulWithKernel(), device="npu", mode=Mode.INFERENCE)
-    Y_kernel = silu_and_mul_with_kernel(X)
-
-    torch.testing.assert_close(Y_kernel, Y)
-
-    assert silu_and_mul.n_calls == 1
-    assert silu_and_mul_with_kernel.n_calls == 0
 
 
 def test_rocm_kernel_mapping(device):


### PR DESCRIPTION
## What does this PR do?

Remove stub organization names, kernels not owned by us from tests/docs. Completely remove the NPU test. The repo is not under our control, outdated, and we cannot test NPU anyway.

## Motivation

Security (avoid remote compromise).