### PR TITLE
kernel-builder: fix failed uploads trying to remove directories

### DIFF
--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -188,9 +188,9 @@ fn run_upload_typed<T: RepoType>(args: UploadArgs) -> Result<()> {
             .send()
             .unwrap_or_default()
             .into_iter()
-            .map(|entry| match entry {
-                hf_hub::repository::RepoTreeEntry::File { path, .. } => path,
-                hf_hub::repository::RepoTreeEntry::Directory { path, .. } => path,
+            .filter_map(|entry| match entry {
+                hf_hub::repository::RepoTreeEntry::File { path, .. } => Some(path),
+                hf_hub::repository::RepoTreeEntry::Directory { .. } => None,
             })
             .collect();
 


### PR DESCRIPTION
When trying to collect candidates for stale entries, we included directories as well. This causes upload failures, since directories are not Git objects and the API would reject these.