### PR TITLE
fix: remove existing test repo before upload

### DIFF
--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -48,14 +48,22 @@ jobs:
       # Remove the existing test repo if it exists so we test repo creation in the upload step
       - name: Delete existing test repo
         run: |
-          pip install huggingface_hub
-          python -c "
+          cat > /tmp/delete_repos.py << 'PYEOF'
           from huggingface_hub import HfApi
-          api = HfApi(endpoint='${{ env.HF_ENDPOINT }}', token='${{ secrets.HF_STAGING_TOKEN }}')
-          for repo_type in ['kernel', 'model']:
-              api.delete_repo('${{ env.E2E_REPO_ID }}', repo_type=repo_type, missing_ok=True)
-              print(f'Deleted {repo_type} repo (or it did not exist)')
-          "
+          import os
+
+          api = HfApi(
+              endpoint=os.environ["HF_ENDPOINT"],
+              token=os.environ["HF_STAGING_TOKEN"],
+          )
+          repo_id = os.environ["E2E_REPO_ID"]
+          for repo_type in ["kernel", "model"]:
+              api.delete_repo(repo_id, repo_type=repo_type, missing_ok=True)
+              print(f"Deleted {repo_type} repo (or it did not exist)")
+          PYEOF
+          nix-shell -p python3Packages.huggingface-hub --run "python /tmp/delete_repos.py"
+        env:
+          HF_STAGING_TOKEN: ${{ secrets.HF_STAGING_TOKEN }}
 
       - name: Init kernel project
         run: |

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -148,7 +148,7 @@ jobs:
           import torch
           from kernels import get_kernel
 
-          kernel = get_kernel('${{ env.E2E_REPO_ID }}', revision='${{ env.E2E_BRANCH }}')
+          kernel = get_kernel('${{ env.E2E_REPO_ID }}', revision='${{ env.E2E_BRANCH }}', trust_remote_code=True)
 
           x = torch.randn(1024, 1024, dtype=torch.float32, device='cuda')
           result = kernel.kernels_upload_test(x)

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -48,18 +48,14 @@ jobs:
       # Remove the existing test repo if it exists so we test repo creation in the upload step
       - name: Delete existing test repo
         run: |
-          curl -sf -X DELETE \
-            "${{ env.HF_ENDPOINT }}/api/repos/delete" \
-            -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"type":"kernel","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
-          || true
-          curl -sf -X DELETE \
-            "${{ env.HF_ENDPOINT }}/api/repos/delete" \
-            -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"type":"model","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
-          || true
+          pip install huggingface_hub
+          python -c "
+          from huggingface_hub import HfApi
+          api = HfApi(endpoint='${{ env.HF_ENDPOINT }}', token='${{ secrets.HF_STAGING_TOKEN }}')
+          for repo_type in ['kernel', 'model']:
+              api.delete_repo('${{ env.E2E_REPO_ID }}', repo_type=repo_type, missing_ok=True)
+              print(f'Deleted {repo_type} repo (or it did not exist)')
+          "
 
       - name: Init kernel project
         run: |

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -51,11 +51,13 @@ jobs:
           curl -sf -X DELETE \
             "${{ env.HF_ENDPOINT }}/api/repos/delete" \
             -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
+            -H "Content-Type: application/json" \
             -d '{"type":"kernel","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
           || true
           curl -sf -X DELETE \
             "${{ env.HF_ENDPOINT }}/api/repos/delete" \
             -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
+            -H "Content-Type: application/json" \
             -d '{"type":"model","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
           || true
 

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -20,7 +20,7 @@ env:
   E2E_BRANCH: e2e-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -53,8 +53,7 @@ jobs:
           import os
 
           api = HfApi(
-              endpoint=os.environ["HF_ENDPOINT"],
-              token=os.environ["HF_STAGING_TOKEN"],
+              endpoint=os.environ["HF_ENDPOINT"]
           )
           repo_id = os.environ["E2E_REPO_ID"]
           for repo_type in ["kernel", "model"]:
@@ -62,8 +61,6 @@ jobs:
               print(f"Deleted {repo_type} repo (or it did not exist)")
           PYEOF
           nix-shell -p python3Packages.huggingface-hub --run "python /tmp/delete_repos.py"
-        env:
-          HF_STAGING_TOKEN: ${{ secrets.HF_STAGING_TOKEN }}
 
       - name: Init kernel project
         run: |

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -45,6 +45,20 @@ jobs:
         env:
           USER: runner
 
+      # Remove the existing test repo if it exists so we test repo creation in the upload step
+      - name: Delete existing test repo
+        run: |
+          curl -sf -X DELETE \
+            "${{ env.HF_ENDPOINT }}/api/repos/delete" \
+            -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
+            -d '{"type":"kernel","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
+          || true
+          curl -sf -X DELETE \
+            "${{ env.HF_ENDPOINT }}/api/repos/delete" \
+            -H "Authorization: Bearer ${{ secrets.HF_STAGING_TOKEN }}" \
+            -d '{"type":"model","organization":"__DUMMY_KERNELS_USER__","name":"kernels-upload-test"}' \
+          || true
+
       - name: Init kernel project
         run: |
           cd /tmp

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -138,6 +138,8 @@ jobs:
           CUDA_TAG=$(echo "$VARIANT" | grep -oP 'cu\d+')
           echo "Installing torch matching variant $VARIANT (CUDA tag: $CUDA_TAG)"
           uv sync --all-extras --dev
+          # E2E validates this checkout, so use the local kernels-data binding instead of the released wheel from uv.lock.
+          uv pip install --reinstall ../kernels-data/bindings/python
           uv pip install --upgrade torch --index-url https://download.pytorch.org/whl/$CUDA_TAG
           uv run --no-sync python -c "import torch; print(f'torch={torch.__version__}, cuda={torch.version.cuda}, cxx11_abi={torch.compiled_with_cxx11_abi()}')"
 


### PR DESCRIPTION
This PR deletes the existing test repo from staging before upload so we force repo creation each time, this should also fix issues where staging repos have refs removed but keep the repo which causes upload to fail on the `/refs` call