### PR TITLE
docs: refresh for native kernel repo type on the Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <hr/>
 
 The Kernel Hub allows Python libraries and applications to load compute
-kernels directly from the [Hub](https://hf.co/). To support this kind
+kernels directly from the [Hub](https://huggingface.co/). To support this kind
 of dynamic loading, Hub kernels differ from traditional Python kernel
 packages in that they are made to be:
 
@@ -63,8 +63,7 @@ activation.gelu_fast(y, x)
 print(y)
 ```
 
-You can [search for kernels](https://huggingface.co/models?other=kernels) on
-the Hub.
+Browse available kernels at [huggingface.co/kernels](https://huggingface.co/kernels).
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # kernels
 
 <div align="center">
-<img src="https://github.com/user-attachments/assets/4b5175f3-1d60-455b-8664-43b2495ee1c3" width="450" height="450" alt="kernel-builder logo">
+<a href="https://huggingface.co/kernels">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/kernels/kernels-thumbnail-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/kernels/kernels-thumbnail-light.png">
+  <img alt="Kernels" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/kernels/kernels-thumbnail-light.png" style="max-width: 100%;">
+</picture>
+</a>
 <p align="center">
     <a href="https://pypi.org/project/kernels"><img alt="PyPI - Version" src="https://img.shields.io/pypi/v/kernels"></a>
     <a href="https://github.com/huggingface/kernels/tags"><img alt="GitHub tag" src="https://img.shields.io/github/v/tag/huggingface/kernels"></a>

--- a/docs/source/builder/build.md
+++ b/docs/source/builder/build.md
@@ -179,6 +179,13 @@ $ cd mykernel
 $ kernel-builder build-and-upload
 ```
 
+> [!NOTE]
+> Uploads go to a `kernel`-type Hub repository (the first-class kernel
+> repository type). The owning user or org must have kernel-creation
+> access. Request it from
+> [huggingface.co/settings/account](https://huggingface.co/settings/account)
+> ("Request Kernels Creation").
+
 Aside from building and uploading the kernel itself, this will also fill
 the card template and upload it as `README.md` to the Hub if the card
 template is provided in the source repository as `CARD.md`.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,13 +1,17 @@
 # Kernels
 
 <div align="center">
-<img src="https://github.com/user-attachments/assets/64a652f3-0cd3-4829-b3c1-df13f7933569" width="450" height="450" alt="kernel-builder logo">
+<a href="https://huggingface.co/kernels">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/kernels/kernels-thumbnail-light.png" alt="Kernels"/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/kernels/kernels-thumbnail-dark.png" alt="Kernels"/>
+</a>
 </div>
 
 The Kernel Hub allows Python libraries and applications to load compute
-kernels directly from the [Hub](https://hf.co/). To support this kind
-of dynamic loading, Hub kernels differ from traditional Python kernel
-packages in that they are made to be:
+kernels directly from the [Hub](https://huggingface.co/). Kernels are a first-class
+repository type on the Hub, with dedicated pages that surface supported
+hardware and versions. To support dynamic loading, Hub kernels differ from
+traditional Python kernel packages in that they are made to be:
 
 - **Portable**: a kernel can be loaded from paths outside `PYTHONPATH`.
 - **Unique**: multiple versions of the same kernel can be loaded in the
@@ -16,8 +20,7 @@ packages in that they are made to be:
   the different PyTorch build configurations (various CUDA versions
   and C++ ABIs). Furthermore, older C library versions must be supported.
 
-You can [search for kernels](https://huggingface.co/models?other=kernels) on
-the Hub.
+Browse available kernels at [huggingface.co/kernels](https://huggingface.co/kernels).
 
 If you're looking for a more involved "Why kernels?" answer, refer to
 [this page](./why_kernels.md).

--- a/docs/source/integrating-kernels.md
+++ b/docs/source/integrating-kernels.md
@@ -36,5 +36,5 @@ Besides leveraging pre-built compute kernels, different projects
 rely on `kernels` to also package, build, and distribute their
 kernels on the Hugging Face Hub platform. This is made possible by the
 ["builder" component of `kernels`](./builder/writing-kernels.md).
-Visit [this page](https://huggingface.co/models?other=kernels) to find out
-different pre-built compute kernels available on the Hub.
+Visit [huggingface.co/kernels](https://huggingface.co/kernels) to browse
+the pre-built compute kernels available on the Hub.

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -7,6 +7,30 @@ systems and Torch builds.
 [Join us on Discord](https://discord.gg/H6Tkmd88N3) for questions and discussions
 about building kernels!
 
+## Repository type
+
+Compliant kernels are published as `kernel`-type repositories on the Hub
+(the first-class kernel repository type). New uploads via `kernel-builder`
+default to this type; see the [migration guide](migration.md) if you
+maintain an older `model`-type kernel repository.
+
+## Trusted publishers
+
+`kernels` only loads kernels from a curated set of trusted publishers by
+default. Loading from any other publisher raises an error unless the caller
+opts in with `trust_remote_code=True`:
+
+```python
+# Trusted publisher: works without opt-in.
+get_kernel("kernels-community/activation", version=1)
+
+# Untrusted publisher: must opt in explicitly.
+get_kernel("some-other-org/my-kernel", version=1, trust_remote_code=True)
+```
+
+The Hub also exposes a `trustedKernelPublisher` flag on the kernel API and
+displays a corresponding badge in the UI.
+
 ## Directory layout
 
 A kernel repository on the Hub must contain a `build` directory. This

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -66,3 +66,28 @@ kernel_layer_mapping = {
     }
 }
 ```
+
+## 0.14
+
+### `kernel` repo type on the Hub
+
+Kernels are now a first-class repository type on the Hugging Face Hub, and
+`kernels` 0.14 loads kernels exclusively from `kernel`-type repositories.
+`model`-type kernel repositories are no longer supported by the loader.
+
+New uploads via `kernel-builder build-and-upload` default to
+`--repo-type kernel`. To publish, the owning user or org must have
+kernel-creation access. Request it from
+[huggingface.co/settings/account](https://huggingface.co/settings/account)
+("Request Kernels Creation").
+
+To migrate an existing `model`-type kernel repository:
+
+1. Make sure the publishing org has been granted kernel-creation access
+   (see above).
+2. Re-upload with `kernel-builder build-and-upload` to a `kernel`-type
+   repository. Either keep the same `repo-id` in `build.toml` if the
+   repository has been migrated to the new type, or point it at a newly
+   created `kernel`-type repository.
+3. Update consumers' `get_kernel(...)` and `LayerRepository(...)` calls
+   to reference the new repository if the `repo-id` changed.


### PR DESCRIPTION
Tried to keep it minimal but still need a quick check @danieldk @drbh - feel free to make changes or add more details directly :) cc @julien-c too btw

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/8e4a500b-3a3c-4218-8de8-f1a698719fba" />


## Summary

Minimal-touch refresh of the kernels docs to reflect the native Kernel Hub support that shipped at PyTorch Conference Europe (Apr 2026), and corrects a few outdated references.

- **Discovery URLs**: `huggingface.co/models?other=kernels` → `huggingface.co/kernels` (in `index.md` and `integrating-kernels.md`).
- **Landing-page thumbnail** (`index.md`): replace the GitHub attachment with light/dark variants stored in `huggingface/documentation-images` (`kernels/kernels-thumbnail-{light,dark}.png`), wrapped in a link to `huggingface.co/kernels`.
- **`index.md` framing**: one-sentence note that kernels are a first-class Hub repo type with hardware/version pages.
- **`migration.md`**: new `## 0.14` section covering the kernel-only loader (`kernels/src/kernels/utils.py` hardcodes `repo_type="kernel"` after `b26b7f6` "remove backward compat of model repo types"), kernel-creation access flow, and steps to migrate an existing `model`-type repo.
- **`builder/build.md`**: short prerequisite note above `build-and-upload` pointing to `huggingface.co/settings/account` ("Request Kernels Creation").
- **`kernel-requirements.md`**: new "Repository type" and "Trusted publishers" sections. The latter documents the actual loader behavior — non-trusted publishers raise `ValueError` unless the caller passes `trust_remote_code=True` — and notes the Hub-side `trustedKernelPublisher` flag.

Did **not** touch: `_toctree.yml`, `builder/security.md` (artifact signing isn't shipped yet), the `(./why_kernels.md)` link style or other pre-existing relative `.md` links.

## Test plan

- [x] `doc-builder build kernels docs/source/ --html` builds clean
- [x] Previewed locally via moon-landing (`/docs/kernels/main/en/{index,migration,builder/build,kernel-requirements,integrating-kernels}`)
- [x] Light/dark image swap verified by toggling system theme
- [ ] CI doc build green