### PR TITLE
kernel-builder: raise C++ standard level to C++20

### DIFF
--- a/kernel-builder/src/pyproject/templates/utils.cmake
+++ b/kernel-builder/src/pyproject/templates/utils.cmake
@@ -612,7 +612,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
     endif()
   endif()
 
-  set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 17)
+  set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 20)
 
   target_compile_options(${GPU_MOD_NAME} PRIVATE
     $<$<COMPILE_LANGUAGE:${GPU_LANGUAGE}>:${GPU_COMPILE_FLAGS}>)


### PR DESCRIPTION
## What does this PR do?

Raise C++ version to C++ 20.

## Motivation

Torch 2.12 on macOS requires at least C++20.