### PR TITLE
nix-builder: support building CI per framework

### DIFF
--- a/nix-builder/lib/gen-flake-outputs.nix
+++ b/nix-builder/lib/gen-flake-outputs.nix
@@ -246,6 +246,24 @@ in
           rev = revUnderscored;
         };
 
+      backendCi =
+        let
+          backends = lib.unique (map (set: set.buildConfig.framework) buildSetsSorted);
+        in
+        builtins.listToAttrs (
+          builtins.map (backend: {
+            name = backend;
+            value = build.mkExtensionBundle {
+              inherit path doGetKernelCheck;
+              # It is too costly to build all variants in CI, so we just build one per framework.
+              buildSets = headOrEmpty (
+                builtins.filter (set: set.buildConfig.framework == backend) buildSetsSorted
+              );
+              rev = revUnderscored;
+            };
+          }) backends
+        );
+
       ci-test = ciTests.${bestVariant};
 
       kernels =


### PR DESCRIPTION
Support building CI per framework to support per-backend CI in kernels-community.