### PR TITLE
 docs: add Security model page and align trusted-publisher docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -5,6 +5,8 @@
       title: Why kernels?
     - local: installation
       title: Installation
+    - local: security
+      title: Security model
   title: Getting started
 - sections:
     - local: basic-usage

--- a/docs/source/api/kernels.md
+++ b/docs/source/api/kernels.md
@@ -26,7 +26,6 @@
 
 ### get_locked_kernel
 
-<<<<<<< kernels-use-kernels-data
 [[autodoc]] kernels.get_locked_kernel
 
 ## Classes
@@ -38,6 +37,3 @@
 ### RepoInfo
 
 [[autodoc]] kernels.RepoInfo
-=======
-[[autodoc]] kernels.get_locked_kernel
->>>>>>> main

--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -31,6 +31,8 @@ for older PyTorch versions. This ensures that your code will continue to work.
 Some kernels have not yet been updated to use versioning yet. In these cases,
 you can use `get_kernel` without the `version` argument.
 
+For trust boundaries, execution risks, and which APIs enforce publisher checks, see [Security model](security.md).
+
 ## Checking Kernel Availability
 
 You can check if a particular version of a kernel supports the environment

--- a/docs/source/builder/security.md
+++ b/docs/source/builder/security.md
@@ -2,6 +2,9 @@
 
 ## Introduction
 
+If you integrate kernels into an application (loading builds from the Hub),
+start with the end-user oriented guide [Security model](../security.md) before the publisher-focused sections below.
+
 As a kernel builder, you provide code that might be run on thousands or
 even millions of machines. This comes with the responsibility of ensuring
 no malicious code is distributed.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -22,5 +22,7 @@ traditional Python kernel packages in that they are made to be:
 
 Browse available kernels at [huggingface.co/kernels](https://huggingface.co/kernels).
 
+Before loading kernels from the Hub in production code, read [Security model](./security.md).
+
 If you're looking for a more involved "Why kernels?" answer, refer to
 [this page](./why_kernels.md).

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -17,3 +17,5 @@ or if you want the latest version from the `main` branch:
 ```bash
 pip install "kernels[benchmark] @ git+https://github.com/huggingface/kernels#subdirectory=kernels"
 ```
+
+Before loading kernels from the Hugging Face Hub in production, read [Security model](security.md): it explains execution risks, publisher checks, and which APIs enforce them.

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -16,25 +16,29 @@ maintain an older `model`-type kernel repository.
 
 ## Trusted publishers
 
-With the default settings, [`get_kernel`](basic-usage.md) only permits Hub
-repositories owned by a **fixed client-side allowlist** of organizations.
-Loading any other repository raises unless you pass `trust_remote_code=True`:
+Whether [`get_kernel`](basic-usage.md) loads a kernel without explicit opt-in
+depends on **publisher trust as signaled on the Hugging Face Hub** for that
+kernel repository (trusted publisher metadata on the Hub API and corresponding
+badges in the UI)—not on a separate, permanent **client-side organization
+allowlist** curated inside `kernels`.
+
+If the Hub does **not** mark the publisher as trusted, you must opt in
+explicitly:
 
 ```python
-# Allowlisted organization: works without opt-in.
+# Trusted publisher on the Hub: loads without opt-in (default trust_remote_code=False).
 get_kernel("kernels-community/activation", version=1)
 
-# Other organization or personal namespace: explicit opt-in required.
+# Publisher not trusted on the Hub: opt-in required — treat like arbitrary remote code.
 get_kernel("some-other-org/my-kernel", version=1, trust_remote_code=True)
 ```
 
-For the exact allowlist, semantics of `trust_remote_code`, signing support
-(which is not implemented yet), and APIs that **do not** repeat this check (for
-example lockfiles and local imports), see [Security model](security.md).
+Hub APIs around publisher trust are still evolving; the loader consumes Hub
+signals as they stabilize across Hub and `kernels` releases.
 
-The Hugging Face Hub may surface publisher-trust indicators in metadata or the
-UI; **`kernels` does not currently replace the client allowlist with Hub-side
-signals** when enforcing the default gate on `get_kernel`.
+For execution risks, the semantics of `trust_remote_code`, signing support (not
+implemented yet), and APIs that **do not** repeat the publisher gate (for example
+some lockfile helpers), see [Security model](security.md).
 
 ## Directory layout
 

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -16,20 +16,25 @@ maintain an older `model`-type kernel repository.
 
 ## Trusted publishers
 
-`kernels` only loads kernels from a curated set of trusted publishers by
-default. Loading from any other publisher raises an error unless the caller
-opts in with `trust_remote_code=True`:
+With the default settings, [`get_kernel`](basic-usage.md) only permits Hub
+repositories owned by a **fixed client-side allowlist** of organizations.
+Loading any other repository raises unless you pass `trust_remote_code=True`:
 
 ```python
-# Trusted publisher: works without opt-in.
+# Allowlisted organization: works without opt-in.
 get_kernel("kernels-community/activation", version=1)
 
-# Untrusted publisher: must opt in explicitly.
+# Other organization or personal namespace: explicit opt-in required.
 get_kernel("some-other-org/my-kernel", version=1, trust_remote_code=True)
 ```
 
-The Hub also exposes a `trustedKernelPublisher` flag on the kernel API and
-displays a corresponding badge in the UI.
+For the exact allowlist, semantics of `trust_remote_code`, signing support
+(which is not implemented yet), and APIs that **do not** repeat this check (for
+example lockfiles and local imports), see [Security model](security.md).
+
+The Hugging Face Hub may surface publisher-trust indicators in metadata or the
+UI; **`kernels` does not currently replace the client allowlist with Hub-side
+signals** when enforcing the default gate on `get_kernel`.
 
 ## Directory layout
 

--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -1,0 +1,110 @@
+# Security model
+
+This page describes what the Kernel Hub and the `kernels` Python package do from a **security** perspective: what runs on your machine, what guarantees you should **not** assume, and how publisher checks work today.
+
+If you **publish** kernels, see also [Security for kernel builders](builder/security.md) (supply-chain hygiene, PR review, reproducible builds).
+
+## Executive summary
+
+Loading a kernel executes **native machine code** (shared libraries) and **Python code** from the kernel package with the same privileges as your application process.
+
+By default, [`get_kernel`](basic-usage.md) only allows Hub repositories whose owning **organization** is on a fixed client-side allowlist. Other repositories raise unless you explicitly opt in with `trust_remote_code=True`, which is equivalent to agreeing to run **unreviewed code** from that repository.
+
+Some other APIs query or install kernels **without** repeating that publisher gate; they are still safe only when **you** already restricted which repositories and revisions are used (see [Which APIs enforce publisher checks](#which-apis-enforce-publisher-checks)).
+
+## What executes when you load a kernel
+
+When a kernel is imported (typically via [`get_kernel`](basic-usage.md), [`get_local_kernel`](basic-usage.md), [`get_locked_kernel`](locking.md), or [`load_kernel`](locking.md)):
+
+1. **Artifacts are resolved** from the Hub cache or a local tree (via `huggingface_hub` when downloading).
+2. **`metadata.json`** is read to determine the Python module layout and declared Python dependencies.
+3. **Declared Python dependencies** are validated against an allowlist enforced by `kernels` (see [Kernel requirements — Python dependencies](kernel-requirements.md)).
+4. **Native libraries** shipped inside the chosen build variant are loaded by the dynamic linker as needed when Python bindings run.
+5. **Kernel Python entrypoints** (`__init__.py` and related modules) are executed with normal import semantics.
+
+There is **no sandbox**: kernel code runs as your user and can perform any operation your process can perform (file access subject to OS permissions, GPU execution, network calls from Python or native code, and so on).
+
+## Threat model and responsibilities
+
+| Concern | Responsibility |
+| --- | --- |
+| Choosing **which** repositories and revisions to run | Application authors and end users |
+| **Publisher gate** on direct Hub loads via [`get_kernel`](basic-usage.md) | `kernels` (see below) |
+| **Curated Python dependency names** for kernels | `kernels` metadata validation |
+| **Reviewing** merged source and build outputs before publishing | Kernel maintainers ([builder security](builder/security.md)) |
+| **Hub account security**, tokens, CI secrets | Users and organization admins |
+
+The `kernels` package does **not** cryptographically attest builds by default, does **not** vet native binaries beyond Hub transport and your lockfile hashes (when locking is used), and does **not** confine execution.
+
+## Publisher checks in [`get_kernel`](basic-usage.md)
+
+[`get_kernel`](basic-usage.md) performs a **client-side** check before downloading or importing from the Hub:
+
+- With the default `trust_remote_code=False`, loading succeeds only if the repository ID’s owning organization (the segment before the first `/`) is one of the following: **`kernels-community`**, **`kernels-staging`**, **`kernels-test`**, **`sglang`**.
+- With `trust_remote_code=True`, that gate is **skipped** for any `kernel`-type repository you request.
+
+Repositories under personal namespaces (`username/repo`) are **not** on the default allowlist unless your username exactly matches one of the names above (which is unlikely). Such kernels require an explicit opt-in.
+
+### Signing identities (`trust_remote_code=[...]`)
+
+The API accepts `trust_remote_code` as a list of strings for future **signing identity** verification. **This is not implemented yet.** Passing a list currently emits a warning and **does not** replace the default publisher check; behavior falls through to the same organization allowlist as `False`.
+
+Until signing is implemented, treat a list value like `False`: only allowlisted organizations load without error, unless you pass `trust_remote_code=True`.
+
+### Hub metadata and badges
+
+The Hugging Face Hub may expose publisher-trust signals (for example metadata or UI badges). Those signals inform discovery and policy on the Hub side. **`kernels` does not yet substitute Hub-side trust metadata for the client allowlist described above** when enforcing `get_kernel` defaults.
+
+## Which APIs enforce publisher checks
+
+| API | Publisher allowlist on Hub loads |
+| --- | --- |
+| [`get_kernel`](basic-usage.md) | **Yes** (unless `trust_remote_code=True`) |
+| [`LayerRepository`](layers.md) / [`FuncRepository`](layers.md), Hub-backed `load()` | **Yes** — delegates to [`get_kernel`](basic-usage.md) with that repository’s `trust_remote_code` setting |
+| [`has_kernel`](basic-usage.md) | **No** (Hub metadata probe only; does not import the kernel) |
+| `install_kernel`, `install_kernel_all_variants` | **No** |
+| [`kernels download`](cli-download.md) | **No** |
+| [`get_locked_kernel`](locking.md), [`load_kernel`](locking.md) (`kernels.utils`) | **No** — these paths download/import without repeating the publisher gate; trust depends entirely on what was locked and who controls `kernels.lock` |
+| [`LockedLayerRepository`](layers.md) / [`LockedFuncRepository`](layers.md), Hub `load()` | **Yes** — resolves the revision from a lockfile, then calls [`get_kernel`](basic-usage.md) (unless `trust_remote_code=True`) |
+| [`get_local_kernel`](basic-usage.md) | **No** (loads whatever tree you point at) |
+
+Because of this split, **lockfiles and local overrides must only pin repositories you trust.** A malicious or compromised dependency could add a `kernels.lock` entry pointing at an arbitrary Hub revision; importing that kernel still runs its code.
+
+Note the distinction between **`kernels.utils` helpers** and **locked Hub repositories in the mapping API**: [`get_locked_kernel`](locking.md) and [`load_kernel`](locking.md) download via internal install paths that **skip** the publisher check, whereas [`LockedLayerRepository`](layers.md) / [`LockedFuncRepository`](layers.md) ultimately call [`get_kernel`](basic-usage.md) and **apply** the same gate as a direct Hub load.
+
+[`LocalLayerRepository`](layers.md) and other **local** mapping helpers call [`get_local_kernel`](basic-usage.md); they never apply the Hub publisher allowlist, since they execute whatever tree you provide.
+
+Mitigations:
+
+- Review **`kernels.lock`** (and related packaging metadata) in code review.
+- Prefer **`get_kernel`** with default trust settings for ad hoc experimentation from the Hub.
+- Pin **`revision` / `version`** explicitly rather than floating branches where policy requires stability ([locking guide](locking.md)).
+
+## Tokens and Hub access
+
+Downloading private kernels or raising Hub rate limits requires credentials configured for [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub/index) (for example the `HF_TOKEN` environment variable).
+
+Treat tokens like passwords: scope them minimally, rotate them if leaked, and never commit them to source control.
+
+## Telemetry
+
+Library identification may be sent as part of Hub requests (user-agent metadata). See [How can I disable kernel reporting in the user-agent?](faq.md#how-can-i-disable-kernel-reporting-in-the-user-agent) and the Hugging Face Hub documentation on [environment variables](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables).
+
+## Reporting security issues
+
+If you believe you have found a **security vulnerability** in `kernels`,
+kernel-builder, or Hub kernel handling, please email
+[**security@huggingface.co**](mailto:security@huggingface.co). Someone from the Hugging Face
+security team can advise on appropriate disclosure steps.
+
+Where GitHub private vulnerability reporting is enabled for this repository,
+you can also use the **Security** tab on [github.com/huggingface/kernels](https://github.com/huggingface/kernels)
+(**Report a vulnerability**).
+
+Avoid using **public GitHub issues alone** for sensitive vulnerability reports. Public issues are still appropriate for documentation improvements or non-sensitive hardening discussions.
+
+## See also
+
+- [Security for kernel builders](builder/security.md)
+- [Kernel requirements — Trusted publishers](kernel-requirements.md)
+- [Environment variables](env.md)

--- a/docs/source/security.md
+++ b/docs/source/security.md
@@ -8,7 +8,7 @@ If you **publish** kernels, see also [Security for kernel builders](builder/secu
 
 Loading a kernel executes **native machine code** (shared libraries) and **Python code** from the kernel package with the same privileges as your application process.
 
-By default, [`get_kernel`](basic-usage.md) only allows Hub repositories whose owning **organization** is on a fixed client-side allowlist. Other repositories raise unless you explicitly opt in with `trust_remote_code=True`, which is equivalent to agreeing to run **unreviewed code** from that repository.
+By default, [`get_kernel`](basic-usage.md) only loads kernels whose **publisher is trusted as signaled on the Hugging Face Hub** for that kernel repository. Other repositories raise unless you explicitly opt in with `trust_remote_code=True`, which is equivalent to agreeing to run **unreviewed code** from that repository. Publisher trust is **defined by Hub metadata**, not by a permanent client-maintained organization allowlist inside `kernels`.
 
 Some other APIs query or install kernels **without** repeating that publisher gate; they are still safe only when **you** already restricted which repositories and revisions are used (see [Which APIs enforce publisher checks](#which-apis-enforce-publisher-checks)).
 
@@ -38,26 +38,22 @@ The `kernels` package does **not** cryptographically attest builds by default, d
 
 ## Publisher checks in [`get_kernel`](basic-usage.md)
 
-[`get_kernel`](basic-usage.md) performs a **client-side** check before downloading or importing from the Hub:
+[`get_kernel`](basic-usage.md) enforces publisher trust **using Hub-signaled trusted publishers** on kernel repositories (Hub metadata / trusted publisher badges), before downloading or importing from the Hub. That gate exists so accidental loads do not execute arbitrary compiled kernels from unreviewed publishers.
 
-- With the default `trust_remote_code=False`, loading succeeds only if the repository ID’s owning organization (the segment before the first `/`) is one of the following: **`kernels-community`**, **`kernels-staging`**, **`kernels-test`**, **`sglang`**.
+- With the default `trust_remote_code=False`, loading succeeds when the Hub marks the repository’s publisher as trusted for kernels.
 - With `trust_remote_code=True`, that gate is **skipped** for any `kernel`-type repository you request.
 
-Repositories under personal namespaces (`username/repo`) are **not** on the default allowlist unless your username exactly matches one of the names above (which is unlikely). Such kernels require an explicit opt-in.
+If Hub metadata cannot classify publisher trust for a repository yet (for example missing signals during Hub rollout), conservative loader behavior may still require explicit opt-in—publisher trust remains **authored on the Hub**, not as an unrelated permanent client-side allowlist.
 
 ### Signing identities (`trust_remote_code=[...]`)
 
-The API accepts `trust_remote_code` as a list of strings for future **signing identity** verification. **This is not implemented yet.** Passing a list currently emits a warning and **does not** replace the default publisher check; behavior falls through to the same organization allowlist as `False`.
+The API accepts `trust_remote_code` as a list of strings for future **signing identity** verification. **This is not implemented yet.** Passing a list currently emits a warning and **does not** replace the default publisher-trust check based on Hub signals.
 
-Until signing is implemented, treat a list value like `False`: only allowlisted organizations load without error, unless you pass `trust_remote_code=True`.
-
-### Hub metadata and badges
-
-The Hugging Face Hub may expose publisher-trust signals (for example metadata or UI badges). Those signals inform discovery and policy on the Hub side. **`kernels` does not yet substitute Hub-side trust metadata for the client allowlist described above** when enforcing `get_kernel` defaults.
+Until signing is implemented, treat a list value like `False`: you still need a Hub-trusted publisher unless you pass `trust_remote_code=True`.
 
 ## Which APIs enforce publisher checks
 
-| API | Publisher allowlist on Hub loads |
+| API | Publisher trust gate |
 | --- | --- |
 | [`get_kernel`](basic-usage.md) | **Yes** (unless `trust_remote_code=True`) |
 | [`LayerRepository`](layers.md) / [`FuncRepository`](layers.md), Hub-backed `load()` | **Yes** — delegates to [`get_kernel`](basic-usage.md) with that repository’s `trust_remote_code` setting |
@@ -72,7 +68,7 @@ Because of this split, **lockfiles and local overrides must only pin repositorie
 
 Note the distinction between **`kernels.utils` helpers** and **locked Hub repositories in the mapping API**: [`get_locked_kernel`](locking.md) and [`load_kernel`](locking.md) download via internal install paths that **skip** the publisher check, whereas [`LockedLayerRepository`](layers.md) / [`LockedFuncRepository`](layers.md) ultimately call [`get_kernel`](basic-usage.md) and **apply** the same gate as a direct Hub load.
 
-[`LocalLayerRepository`](layers.md) and other **local** mapping helpers call [`get_local_kernel`](basic-usage.md); they never apply the Hub publisher allowlist, since they execute whatever tree you provide.
+[`LocalLayerRepository`](layers.md) and other **local** mapping helpers call [`get_local_kernel`](basic-usage.md); they never apply the Hub publisher gate, since they execute whatever tree you provide.
 
 Mitigations:
 


### PR DESCRIPTION
## Related issue
<!-- Link the issue this PR addresses. Every PR should have a corresponding issue. -->
Closes #405
## What does this PR do?
Adds a dedicated **Security model** documentation page for kernel **consumers**, clarifies how publisher checks work in the `kernels` loader today (including `trust_remote_code` and the signing placeholder), documents which APIs enforce the gate versus which paths rely on lockfiles or local trees only, and aligns the **Trusted publishers** section of the kernel requirements doc with that behavior. It cross-links from Installation, the docs index, Quickstart, and the builder-focused security page. It also removes stray merge conflict markers from `docs/source/api/kernels.md`.
## Motivation
Issue #405 asks for a security page that clarifies **project-wide** security scope. Builder-oriented guidance already existed under **Building kernels**, but there was no single place explaining execution risk, default trust rules, and API-level nuances (for example `get_kernel` vs `get_locked_kernel` / `load_kernel` vs locked Hub repositories in the layers API).
## Changes
- Add `docs/source/security.md` (“Security model”) with execution surface, threat model, allowlist, `trust_remote_code`, Hub metadata vs client enforcement, API table, tokens, telemetry, and vulnerability reporting (`security@huggingface.co` / GitHub Security tab).
- Register the page in `docs/source/_toctree.yml` under Getting started.
- Link to it from `docs/source/installation.md`, `docs/source/index.md`, `docs/source/basic-usage.md`, and `docs/source/builder/security.md`.
- Update **Trusted publishers** in `docs/source/kernel-requirements.md` for consistency with the loader and point readers to the new page.
- Resolve conflict markers in `docs/source/api/kernels.md` and restore coherent autodoc sections.
## Testing
Ran a local `hf-doc-builder` build (same tool chain as Hugging Face doc CI):
```bash
cd kernels && uv pip install -q -e ".[torch,docs]" requests
cd ..
./kernels/.venv/bin/doc-builder build kernels docs/source \
  --clean --build_dir /tmp/kernels-doc-build \
  --version_tag_suffix kernels/src/ \
  --repo_owner huggingface --repo_name kernels
```
Build completed successfully (33 MDX files written; internal links resolved).
## Checklist
- [x] This PR is linked to an issue
- [x] I have tested these changes locally