### PR TITLE
it should be sgl-project in the trusted publishers list

### DIFF
--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -31,7 +31,7 @@ from kernels.variants import (
 
 KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
 
-_ALWAYS_TRUSTED_ORGS = {"kernels-community", "kernels-staging", "kernels-test", "sglang"}
+_ALWAYS_TRUSTED_ORGS = {"kernels-community", "kernels-staging", "kernels-test", "sgl-project"}
 
 
 def _check_trust_remote_code(repo_id: str, trust_remote_code: bool | list[str]) -> None:


### PR DESCRIPTION
It should be "sgl-project" and NOT "sglang".