### PR TITLE
kernel-builder: start to dynamically link against libstdc++

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -41,6 +41,29 @@ jobs:
 
       - name: Build all example kernels
         run: nix build -L ./examples/kernels#ci-build
+
+      - name: Build invalid-cpp-manylinux-symbols kernel (expected to fail)
+        id: build_invalid_kernel
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          nix build -L \
+            './examples/kernels/invalid-cpp-manylinux-symbols#packages.${{ matrix.arch }}.redistributable.torch211-cxx11-cpu-${{ matrix.arch }}' \
+            2>&1 | tee /tmp/invalid_kernel_build.txt
+
+      - name: Validate invalid-cpp-manylinux-symbols build failure
+        run: |
+          if [ '${{ steps.build_invalid_kernel.outcome }}' != 'failure' ]; then
+            echo "❌ Expected build to fail but it succeeded"
+            exit 1
+          fi
+          if ! grep -qF '⛔ Symbols incompatible with `manylinux_2_28` found:' /tmp/invalid_kernel_build.txt; then
+            echo "❌ Expected ABI error message not found in build output:"
+            cat /tmp/invalid_kernel_build.txt
+            exit 1
+          fi
+          echo "✅ Build correctly failed with expected manylinux_2_28 ABI error"
+
       - name: Copy kernel artifacts
         run: cp -rL result/* .
 

--- a/examples/kernels/invalid-cpp-manylinux-symbols/build.toml
+++ b/examples/kernels/invalid-cpp-manylinux-symbols/build.toml
@@ -1,0 +1,16 @@
+[general]
+name = "invalid-cpp-manylinux-symbols"
+version = 1
+license = "Apache-2.0"
+backends = ["cpu"]
+
+[torch]
+src = [
+    "torch-ext/torch_binding.cpp",
+    "torch-ext/torch_binding.h",
+]
+
+[kernel.invalid_cpp_manylinux_symbols_cpu]
+backend = "cpu"
+depends = ["torch"]
+src = ["cpu/cpu.cpp"]

--- a/examples/kernels/invalid-cpp-manylinux-symbols/cpu/cpu.cpp
+++ b/examples/kernels/invalid-cpp-manylinux-symbols/cpu/cpu.cpp
@@ -1,0 +1,18 @@
+#include <array>
+#include <charconv>
+#include <stdexcept>
+
+#include <torch/all.h>
+
+// std::to_chars(char*, char*, double) is a floating-point overload that
+// requires GLIBCXX_3.4.29, introduced in GCC 11. The manylinux_2_28 policy
+// only allows up to GLIBCXX_3.4.25 (the GCC 8.5 system libstdc++ on
+// AlmaLinux 8 / RHEL 8), so this symbol is prohibited and should be
+// rejected by the ABI check.
+torch::Tensor invalid_cpp_symbol(torch::Tensor const &input) {
+    std::array<char, 32> buf;
+    auto [ptr, ec] = std::to_chars(buf.begin(), buf.end(), input.item<double>());
+    if (ec != std::errc{})
+        throw std::runtime_error("to_chars failed");
+    return input;
+}

--- a/examples/kernels/invalid-cpp-manylinux-symbols/flake.nix
+++ b/examples/kernels/invalid-cpp-manylinux-symbols/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for invalid-cpp-manylinux-symbols kernel";
+
+  inputs = {
+    kernel-builder.url = "path:../../..";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/examples/kernels/invalid-cpp-manylinux-symbols/torch-ext/torch_binding.cpp
+++ b/examples/kernels/invalid-cpp-manylinux-symbols/torch-ext/torch_binding.cpp
@@ -1,0 +1,13 @@
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+    ops.def("invalid_cpp_symbol(Tensor input) -> Tensor");
+#if defined(CPU_KERNEL)
+    ops.impl("invalid_cpp_symbol", torch::kCPU, &invalid_cpp_symbol);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/examples/kernels/invalid-cpp-manylinux-symbols/torch-ext/torch_binding.h
+++ b/examples/kernels/invalid-cpp-manylinux-symbols/torch-ext/torch_binding.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <torch/torch.h>
+
+// Uses std::to_chars for floating-point, which requires GLIBCXX_3.4.29
+// (introduced in GCC 11). This exceeds the GLIBCXX_3.4.25 ceiling of
+// manylinux_2_28 target systems and should be caught by the ABI check.
+torch::Tensor invalid_cpp_symbol(torch::Tensor const &input);

--- a/kernel-builder/src/pyproject/templates/torch/torch-extension.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/torch-extension.cmake
@@ -15,10 +15,6 @@ define_gpu_extension_target(
   USE_SABI 3
   WITH_SOABI)
 
-if(NOT (MSVC OR GPU_LANG STREQUAL "SYCL"))
-    target_link_options(${OPS_NAME} PRIVATE -static-libstdc++)
-endif()
-
 if(GPU_LANG STREQUAL "SYCL")
     target_link_options(${OPS_NAME} PRIVATE ${sycl_link_flags})
     target_link_libraries(${OPS_NAME} PRIVATE dnnl)

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
@@ -6,10 +6,6 @@ target_compile_definitions(${OPS_NAME} PRIVATE
   "-DTVM_FFI_EXTENSION_NAME=${OPS_NAME}")
 tvm_ffi_configure_target(${OPS_NAME})
 
-if(NOT (MSVC OR GPU_LANG STREQUAL "SYCL"))
-   target_link_options(${OPS_NAME} PRIVATE -static-libstdc++)
-endif()
-
 if(GPU_LANG STREQUAL "SYCL")
     target_link_options(${OPS_NAME} PRIVATE ${sycl_link_flags})
     target_link_libraries(${OPS_NAME} PRIVATE dnnl)

--- a/kernel-builder/src/pyproject/templates/utils.cmake
+++ b/kernel-builder/src/pyproject/templates/utils.cmake
@@ -612,7 +612,12 @@ function (define_gpu_extension_target GPU_MOD_NAME)
     endif()
   endif()
 
-  set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 20)
+
+  if (TORCH_VERSION VERSION_LESS 2.12.0)
+    set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 17)
+  else()
+    set_property(TARGET ${GPU_MOD_NAME} PROPERTY CXX_STANDARD 20)
+  endif()
 
   target_compile_options(${GPU_MOD_NAME} PRIVATE
     $<$<COMPILE_LANGUAGE:${GPU_LANGUAGE}>:${GPU_COMPILE_FLAGS}>)


### PR DESCRIPTION
Before this change, we linked libstdc++ statically to avoid issues when relying on newer symbols than those supported on manylinux_2_28.

This, however leads to issues for C++ functionality that rely on proper initialization of the statically linked libstdc++, such as `std::regex` relying on properly initialized global locale data structures.

To resolve this issue, we have to load the C++ standard library dynamically, using the operating system version. Unfortunately, in contrast to glibc, the version of libstdc++ itself is strongly coupled to the gcc version, so we cannot build gcc against an old libstdc++.

So for libstdc++ we have to rely on the user not using functionality (and thus symbols) newer than GLIBCXX 3.4.24. Using newer symbols will be rejected during the build using `kernel-abi-check`. In practice it is hopefully not a large issue, since a lot of the standard library is now template-based.

This change also adds a test that too-new symbols are really rejected, since we now have to rely fully on kernel-abi-check rather than it being an additional safety check.

This change also makes C++20 conditional on PyTorch 2.12, since using C++20 with previous PyTorch version (headers) will introduce symbols that require GLIBCXX > 3.4.24. 