### PR TITLE
fix: update nix warns to throws

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
                 torchVersions';
           in
           builtins.toJSON buildVariants;
-        genFlakeOutputs = builtins.warn ''
+        genFlakeOutputs = builtins.throw ''
           `genFlakeOutputs` was renamed to `genKernelFlakeOutputs` and will be removed
           in kernel-builder 0.14.
         '' genKernelFlakeOutputs;

--- a/nix-builder/lib/gen-flake-outputs.nix
+++ b/nix-builder/lib/gen-flake-outputs.nix
@@ -25,12 +25,12 @@ let
   '';
   flakeRev =
     if self != null then
-      self.shortRev or self.dirtyShortRev or (builtins.warn ''
+      self.shortRev or self.dirtyShortRev or (builtins.throw ''
         Kernel is not in a git repository, this will create a non-reproducible build.
         This will not be supported in the future.
       '' self.lastModifiedDate)
     else if rev != null then
-      builtins.warn "`rev` argument of `genKernelFlakeOutputs` is deprecated, pass `self` as follows:\n\n${supportedFormat}" rev
+      builtins.throw "`rev` argument of `genKernelFlakeOutputs` is deprecated, pass `self` as follows:\n\n${supportedFormat}" rev
     else
       throw "Flake's `self` must be passed to `genKernelFlakeOutputs` as follows:\n\n${supportedFormat}";
 


### PR DESCRIPTION
This PR simply bumps old deprecation warnings to throws