### PR TITLE
feat: prefer aotrion from release

### DIFF
--- a/nix-builder/pkgs/aotriton/default.nix
+++ b/nix-builder/pkgs/aotriton/default.nix
@@ -1,21 +1,11 @@
 {
   callPackage,
-  fetchFromGitHub,
-  fetchpatch,
   fetchurl,
   stdenvNoCC,
 }:
 
 let
   generic = callPackage ./generic.nix { };
-  postFetch = ''
-    cd $out                                                                                                                                                                                                                        
-    git reset --hard HEAD                                                                                                                                                                                                          
-    for submodule in $(git config --file .gitmodules --get-regexp path | awk '{print $2}' | grep '^third_party/' | grep -v '^third_party/triton$'); do                                                                             
-      git submodule update --init --recursive "$submodule"                                                                                                                                                                         
-    done                                                                                                                                                                                                                           
-    find "$out" -name .git -print0 | xargs -0 rm -rf                                                                                                                                                                               
-  '';
   mkImages =
     version: srcs:
     stdenvNoCC.mkDerivation {
@@ -35,30 +25,11 @@ in
   aotriton_0_11_1 = generic rec {
     version = "0.11.1b";
 
-    src = fetchFromGitHub {
-      owner = "ROCm";
-      repo = "aotriton";
-      tag = version;
-      hash = "sha256-F7JjyS+6gMdCpOFLldTsNJdVzzVwd6lwW7+V8ZOZfig=";
-      leaveDotGit = true;
-      inherit postFetch;
+    hashes = {
+      "7.0" = "sha256-3rgEbp75dsJzn9BWO1AjnhLcAC19T5fBxKGHSstlq8Q=";
+      "7.1" = "sha256-wWE+2enuzHNZ8EoWJLtSjlT15jaeaC3URuqpNtlFI1g=";
+      "7.2" = "sha256-VsoxJUwWVfpNUWji2zFZeBwkQtX2sBiCFV6ThZuFzxY=";
     };
-
-    patches = [
-      # Fails with: ld.lld: error: unable to insert .comment after .comment
-      ./v0.11.1b-no-ld-script.diff
-    ];
-
-    gpuTargets = [
-      # aotriton GPU support list:
-      # https://github.com/ROCm/aotriton/blob/main/v2python/gpu_targets.py
-      "gfx90a"
-      "gfx942"
-      "gfx950"
-      "gfx1100"
-      "gfx1151"
-      "gfx1201"
-    ];
 
     images = mkImages version [
       (fetchurl {
@@ -82,37 +53,16 @@ in
         hash = "sha256-Ck/zJL/9rAwv3oeop/cFY9PISoCtTo8xNF8rQKE4TpU=";
       })
     ];
-
-    extraPythonDepends = ps: [ ps.pandas ];
   };
 
   aotriton_0_11_2 = generic rec {
     version = "0.11.2b";
 
-    src = fetchFromGitHub {
-      owner = "ROCm";
-      repo = "aotriton";
-      tag = version;
-      hash = "sha256-VIwwQR1fl40NLNOwO8KhQK/xOK6wb2l8qBugJ1cRjm4=";
-      leaveDotGit = true;
-      inherit postFetch;
+    hashes = {
+      "7.0" = "sha256-VQGgo7MAiQABtmJfKjU5p7rWDzhvCgYevn1O1coPr7k=";
+      "7.1" = "sha256-/uNr6z6khM4YFVu6/gJsV3/WcF5EaeWUBbJgvXS4zBA=";
+      "7.2" = "sha256-zYq/J7u2POxFyUE16bKHRZZgdCY6awVV5YeK4ctqI0k=";
     };
-
-    patches = [
-      # Fails with: ld.lld: error: unable to insert .comment after .comment
-      ./v0.11.1b-no-ld-script.diff
-    ];
-
-    gpuTargets = [
-      # aotriton GPU support list:
-      # https://github.com/ROCm/aotriton/blob/main/v2python/gpu_targets.py
-      "gfx90a"
-      "gfx942"
-      "gfx950"
-      "gfx1100"
-      "gfx1151"
-      "gfx1201"
-    ];
 
     images = mkImages version [
       (fetchurl {
@@ -136,8 +86,6 @@ in
         hash = "sha256-Ck/zJL/9rAwv3oeop/cFY9PISoCtTo8xNF8rQKE4TpU=";
       })
     ];
-
-    extraPythonDepends = ps: [ ps.pandas ];
   };
 
 }

--- a/nix-builder/pkgs/aotriton/generic.nix
+++ b/nix-builder/pkgs/aotriton/generic.nix
@@ -3,7 +3,6 @@
   clr,
   fetchurl,
   lib,
-  python3,
   rocm-core,
   stdenv,
   xz,
@@ -31,8 +30,6 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];
-  nativeInstallCheckInputs = [ python3 ];
-
   buildInputs = [
     clr
     stdenv.cc.cc.lib
@@ -42,8 +39,6 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
   dontStrip = true;
-  doInstallCheck = true;
-
   installPhase = ''
     runHook preInstall
 
@@ -52,24 +47,6 @@ stdenv.mkDerivation {
     ln -s ${images}/lib/aotriton.images "$out/lib/aotriton.images"
 
     runHook postInstall
-  '';
-
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    test -f "$out/lib/libaotriton_v2.so"
-    test -d "$out/lib/aotriton.images"
-    python - <<PY
-    import ctypes
-    import os
-
-    ctypes.CDLL(
-        "$out/lib/libaotriton_v2.so",
-        mode=os.RTLD_NOW | os.RTLD_LOCAL,
-    )
-    PY
-
-    runHook postInstallCheck
   '';
 
   meta = with lib; {

--- a/nix-builder/pkgs/aotriton/generic.nix
+++ b/nix-builder/pkgs/aotriton/generic.nix
@@ -1,137 +1,82 @@
-# Vendored from nixpkgs
 {
+  autoPatchelfHook,
+  fetchurl,
   lib,
-  stdenv,
-  cmake,
-  jq,
   python3,
-  ninja,
-  pkg-config,
-  rocmPackages,
-  writableTmpDirAsHomeHook,
-  writeShellScriptBin,
+  rocm-core,
+  rocm-hip-runtime,
+  stdenv,
   xz,
 }:
 
 {
   version,
-  gpuTargets,
-  patches ? [ ],
-  src,
   images,
-  extraPythonDepends ? ps: [ ],
+  hashes,
 }:
 
 let
-  gpuTargets' = lib.concatStringsSep ";" gpuTargets;
-  compiler = "amdclang++";
+  rocmVersion = lib.versions.majorMinor rocm-core.version;
+  hash =
+    hashes.${rocmVersion}
+      or (throw "aotriton ${version} binary package is not specified for ROCm ${rocmVersion}");
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "aotriton";
+  inherit version;
 
-  inherit version src patches;
-
-  env = {
-    #CXX = compiler;
-    ROCM_PATH = "${rocmPackages.clr}";
-    CFLAGS = "-w -g1 -gz -Wno-c++11-narrowing";
-    CXXFLAGS = finalAttrs.env.CFLAGS;
-
-    # aotriton passes a lot of files to the linker.
-    NIX_LD_USE_RESPONSE_FILE = 1;
+  src = fetchurl {
+    url = "https://github.com/ROCm/aotriton/releases/download/${version}/aotriton-${version}-manylinux_2_28_x86_64-rocm${rocmVersion}-shared.tar.gz";
+    inherit hash;
   };
 
-  requiredSystemFeatures = [ "big-parallel" ];
-
-  nativeBuildInputs = [
-    cmake
-    jq
-    rocmPackages.rocm-cmake
-    pkg-config
-    python3
-    ninja
-    rocmPackages.clr
-    writableTmpDirAsHomeHook # venv wants to cache in ~
-    (writeShellScriptBin "amdclang++" ''
-      exec ${rocmPackages.llvm.clang}/bin/clang++ "$@"
-    '')
-  ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeInstallCheckInputs = [ python3 ];
 
   buildInputs = [
-    rocmPackages.clr
+    rocm-hip-runtime
+    stdenv.cc.cc.lib
     xz
-  ]
-  ++ (with python3.pkgs; [
-    wheel
-    packaging
-    pyyaml
-    numpy
-    filelock
-    iniconfig
-    pluggy
-    pybind11
-    pandas
-    triton
-  ]);
+  ];
 
-  preConfigure = lib.optionalString (lib.versionAtLeast version "0.11.1") ''
-    # Since we use pre-built images, we can grab the image SHA from there.
-    # As of 0.11.1b this doesn't seem to be used for image loading yet, but
-    # just in case this happens in the future, we set this to the actual
-    # value and not a stub.
-    export AOTRITON_CI_SUPPLIED_SHA1=$(jq -r '.["AOTRITON_GIT_SHA1"]' ${images}/lib/aotriton.images/amd-gfx90a/__signature__)
-
-    # Need to set absolute paths to VENV and its PYTHON or
-    # build fails with "AOTRITON_INHERIT_SYSTEM_SITE_TRITON is enabled
-    # but triton is not available … no such file or directory"
-    # Set via a preConfigure hook so a valid absolute path can be
-    # picked if nix-shell is used against this package
-    cmakeFlagsArray+=(                                                                                                                                                                                                               
-      "-DVENV_DIR=$(pwd)/aotriton-venv/"                                                                                                                                                                                             
-      "-DVENV_BIN_PYTHON=$(pwd)/aotriton-venv/bin/python"                                                                                                                                                                            
-    )                                                                                                                                                                                                                                
-  '';
-
-  # From README:
-  # Note: do not run ninja separately, due to the limit of the current build system,
-  # ninja install will run the whole build process unconditionally.
+  dontConfigure = true;
   dontBuild = true;
+  dontStrip = true;
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall
-    ninja -v install
-    ln -sf ${images}/lib/aotriton.images $out/lib/aotriton.images
+
+    mkdir -p "$out"
+    cp -r include lib "$out/"
+    ln -s ${images}/lib/aotriton.images "$out/lib/aotriton.images"
+
     runHook postInstall
   '';
 
-  doCheck = false;
-  doInstallCheck = false;
+  installCheckPhase = ''
+    runHook preInstallCheck
 
-  cmakeFlags = [
-    # Disable building kernels if no supported targets are enabled
-    (lib.cmakeBool "AOTRITON_NOIMAGE_MODE" true)
-    # Use preinstalled triton from our python's site-packages
-    (lib.cmakeBool "AOTRITON_INHERIT_SYSTEM_SITE_TRITON" true)
-    # Avoid kernels being skipped if build host is overloaded
-    (lib.cmakeFeature "AOTRITON_GPU_BUILD_TIMEOUT" "0")
-    (lib.cmakeFeature "CMAKE_CXX_COMPILER" compiler)
-    # Manually define CMAKE_INSTALL_<DIR>
-    # See: https://github.com/NixOS/nixpkgs/pull/197838
-    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
-    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
-    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
-    (lib.cmakeFeature "AOTRITON_TARGET_ARCH" gpuTargets')
-    (lib.cmakeBool "AOTRITON_USE_TORCH" false)
-  ];
+    test -f "$out/lib/libaotriton_v2.so"
+    test -d "$out/lib/aotriton.images"
+    python - <<PY
+    import ctypes
+    import os
+
+    ctypes.CDLL(
+        "$out/lib/libaotriton_v2.so",
+        mode=os.RTLD_NOW | os.RTLD_LOCAL,
+    )
+    PY
+
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     description = "Ahead of Time (AOT) Triton Math Library";
     homepage = "https://github.com/ROCm/aotriton";
     license = with licenses; [ mit ];
-    platforms = platforms.linux;
-    sourceProvenance = with sourceTypes; [
-      fromSource
-      binaryNativeCode # aotriton.images
-    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
-})
+}

--- a/nix-builder/pkgs/aotriton/generic.nix
+++ b/nix-builder/pkgs/aotriton/generic.nix
@@ -1,10 +1,10 @@
 {
   autoPatchelfHook,
+  clr,
   fetchurl,
   lib,
   python3,
   rocm-core,
-  rocm-hip-runtime,
   stdenv,
   xz,
 }:
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   nativeInstallCheckInputs = [ python3 ];
 
   buildInputs = [
-    rocm-hip-runtime
+    clr
     stdenv.cc.cc.lib
     xz
   ];


### PR DESCRIPTION
This PR avoids compiling aotrion and prefers using the prebuilt `libaotriton_v2.so` from https://github.com/ROCm/aotriton/releases


example of contents from
https://github.com/ROCm/aotriton/releases/download/0.11b/aotriton-0.11b-manylinux_2_28_x86_64-rocm6.2-shared.tar.gz

```bash
├── include
│   └── aotriton
│       ├── _internal
│       │   ├── aiter_hip_common.h
│       │   ├── flash
│       │   │   └── aiter.h
│       │   ├── kernel_cluster.h
│       │   ├── lazy_tensor_internal.h
│       │   ├── packed_kernel.h
│       │   ├── triton_kernel.h
│       │   └── util.h
│       ├── config.h
│       ├── cpp_tune.h
│       ├── dtypes.h
│       ├── flash.h
│       ├── runtime.h
│       ├── util.h
│       └── v2
│           └── flash.h
└── lib
    ├── cmake
    │   └── aotriton
    │       ├── aotriton-config-version.cmake
    │       ├── aotriton-config.cmake
    │       ├── aotriton-targets-release.cmake
    │       └── aotriton-targets.cmake
    ├── libaotriton_v2.so -> libaotriton_v2.so.0.11.2
    └── libaotriton_v2.so.0.11.2
```
