### PR TITLE
upload: fix benchmark deletion filter to match upload filter

### DIFF
--- a/kernel-builder/src/upload.rs
+++ b/kernel-builder/src/upload.rs
@@ -319,7 +319,7 @@ fn collect_benchmark_commit_ops(
             || file
                 .split('/')
                 .next_back()
-                .is_some_and(|n| n.starts_with("benchmark"))
+                .is_some_and(|n| n.starts_with("benchmark") && n.ends_with(".py"))
         {
             operations.push(CommitOperation::Delete {
                 path_in_repo: file.clone(),


### PR DESCRIPTION
## Related issue

Closes #

## What does this PR do?

The deletion predicate in `collect_benchmark_commit_ops` was missing `&& n.ends_with(".py")`, causing non-`.py` files under `benchmarks/` to be incorrectly deleted on existing branches.

## Motivation

The upload pass only adds `benchmark*.py` files. The deletion pass should match the same filter. The existing comment even stated "only delete benchmark*.py" but the predicate didn't enforce it.

## Changes

- Added `&& n.ends_with(".py")` to the deletion predicate in `collect_benchmark_commit_ops`

## Testing

- Existing tests pass unchanged

## Checklist

- [ ] This PR is linked to an issue that was discussed and approved
- [ ] I have tested these changes locally
- [ ] New/changed functionality has test coverage