### PR TITLE
feat: enforce that a version must be specified

### DIFF
--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -28,8 +28,7 @@ get the latest kernel build from the `v1` branch.
 Kernels within a version branch must never break the API or remove builds
 for older PyTorch versions. This ensures that your code will continue to work.
 
-Some kernels have not yet been updated to use versioning yet. In these cases,
-you can use `get_kernel` without the `version` argument.
+Hub kernels must be loaded with either a `version` or an explicit `revision`.
 
 ## Checking Kernel Availability
 

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -177,9 +177,8 @@ will get the latest kernel build from the `v1` branch. Kernel layers
 within a version branch must never break the API or remove builds for
 older PyTorch versions. This ensures that your code will continue to
 work.
-
-Some kernels have not yet been updated to use versioning yet. In these cases,
-you can use `LayerRepository` without the `version` argument.
+Hub-backed `LayerRepository` and `FuncRepository` entries must specify
+either a `version` or an explicit `revision`.
 
 You can register a mapping, like the one above, using `register_kernel_mapping`:
 
@@ -210,6 +209,7 @@ kernel_layer_mapping = {
         "cuda": FuncRepository(
             repo_id="kernels-community/activation",
             func_name="silu_and_mul",
+            version=1,
         ),
     }
 }

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -6,8 +6,8 @@
 
 Before `kernels` 0.12, kernels could be pulled from a repository
 without specifying a version. This is deprecated in kernels 0.12
-and will become an error in kernels 0.14. Instead, use of a kernel
-should always specify a version (except for local kernels).
+and is an error in kernels 0.15. Instead, use of a kernel should
+always specify a version or revision (except for local kernels).
 
 Kernels only use a major version. The kernel maintainer is responsible
 for never breaking a kernel within a major version and should bump up

--- a/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
+++ b/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/cutlass-gemm-tvm-ffi that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/cutlass-gemm-tvm-ffi", version=1)
-cutlass_gemm = kernel_module.cutlass_gemm
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-cutlass_gemm(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `cutlass_gemm`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
+++ b/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/cutlass-gemm-tvm-ffi that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/cutlass-gemm-tvm-ffi", version=1)
+cutlass_gemm = kernel_module.cutlass_gemm
 
-{{ functions[0] }}(...)
+cutlass_gemm(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `cutlass_gemm`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/cutlass-gemm/CARD.md
+++ b/examples/kernels/cutlass-gemm/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/cutlass-gemm that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/cutlass-gemm", version=1)
+cutlass_gemm = kernel_module.cutlass_gemm
 
-{{ functions[0] }}(...)
+cutlass_gemm(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `cutlass_gemm`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/cutlass-gemm/CARD.md
+++ b/examples/kernels/cutlass-gemm/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/cutlass-gemm that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/cutlass-gemm", version=1)
-cutlass_gemm = kernel_module.cutlass_gemm
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-cutlass_gemm(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `cutlass_gemm`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/cutlass-gemm/torch-ext/cutlass_gemm/__init__.py
+++ b/examples/kernels/cutlass-gemm/torch-ext/cutlass_gemm/__init__.py
@@ -2,6 +2,10 @@ import torch
 
 from ._ops import ops
 
+
 def cutlass_gemm(out: torch.Tensor, A: torch.Tensor, B: torch.Tensor) -> None:
     ops.cutlass_gemm(out, A, B)
     return out
+
+
+__all__ = ["cutlass_gemm"]

--- a/examples/kernels/extra-data/CARD.md
+++ b/examples/kernels/extra-data/CARD.md
@@ -1,29 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/extra-data that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/extra-data", version=1)
-EASTER_EGG = kernel_module.EASTER_EGG
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-EASTER_EGG(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `EASTER_EGG`
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
 
 ## Available layers
-- `ReLU`
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/extra-data/CARD.md
+++ b/examples/kernels/extra-data/CARD.md
@@ -1,56 +1,29 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/extra-data that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/extra-data", version=1)
+EASTER_EGG = kernel_module.EASTER_EGG
 
-{{ functions[0] }}(...)
+EASTER_EGG(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
+- `EASTER_EGG`
+- `relu`
 
 ## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `ReLU`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-backprop-compile/CARD.md
+++ b/examples/kernels/relu-backprop-compile/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-backprop-compile that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-backprop-compile", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-backprop-compile/CARD.md
+++ b/examples/kernels/relu-backprop-compile/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-backprop-compile that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-backprop-compile", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-backprop-compile/torch-ext/relu_backprop_compile/__init__.py
+++ b/examples/kernels/relu-backprop-compile/torch-ext/relu_backprop_compile/__init__.py
@@ -1,7 +1,7 @@
 import torch
 from torch.library import register_autograd
 
-from ._ops import ops, add_op_namespace_prefix
+from ._ops import add_op_namespace_prefix, ops
 
 
 @torch.library.register_fake(add_op_namespace_prefix("relu_fwd"))
@@ -28,6 +28,7 @@ def _backward(ctx, grad_outputs: torch.Tensor):
     return ops.relu_bwd(grad_outputs_contiguous, input)
 
 
-register_autograd(
-    add_op_namespace_prefix("relu_fwd"), _backward, setup_context=_setup_context
-)
+register_autograd(add_op_namespace_prefix("relu_fwd"), _backward, setup_context=_setup_context)
+
+
+__all__ = ["relu"]

--- a/examples/kernels/relu-compiler-flags/CARD.md
+++ b/examples/kernels/relu-compiler-flags/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-compiler-flags that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-compiler-flags", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-compiler-flags/CARD.md
+++ b/examples/kernels/relu-compiler-flags/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-compiler-flags that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-compiler-flags", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-compiler-flags/torch-ext/relu_compiler_flags/__init__.py
+++ b/examples/kernels/relu-compiler-flags/torch-ext/relu_compiler_flags/__init__.py
@@ -10,3 +10,6 @@ def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
         out = torch.empty_like(x)
     ops.relu(out, x)
     return out
+
+
+__all__ = ["relu"]

--- a/examples/kernels/relu-metal-cpp/CARD.md
+++ b/examples/kernels/relu-metal-cpp/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-metal-cpp that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-metal-cpp", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-metal-cpp/CARD.md
+++ b/examples/kernels/relu-metal-cpp/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-metal-cpp that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-metal-cpp", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-metal-cpp/torch-ext/relu/__init__.py
+++ b/examples/kernels/relu-metal-cpp/torch-ext/relu/__init__.py
@@ -10,3 +10,6 @@ def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
         out = torch.empty_like(x)
     ops.relu(out, x)
     return out
+
+
+__all__ = ["relu"]

--- a/examples/kernels/relu-nki/CARD.md
+++ b/examples/kernels/relu-nki/CARD.md
@@ -1,28 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-nki that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-nki", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
 
 ## Available layers
-- `ReLU`
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-nki/CARD.md
+++ b/examples/kernels/relu-nki/CARD.md
@@ -1,56 +1,28 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-nki that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-nki", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
+- `relu`
 
 ## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `ReLU`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-specific-torch/CARD.md
+++ b/examples/kernels/relu-specific-torch/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-specific-torch that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-specific-torch", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-specific-torch/CARD.md
+++ b/examples/kernels/relu-specific-torch/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-specific-torch that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-specific-torch", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-specific-torch/torch-ext/relu_specific_torch/__init__.py
+++ b/examples/kernels/relu-specific-torch/torch-ext/relu_specific_torch/__init__.py
@@ -10,3 +10,6 @@ def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
         out = torch.empty_like(x)
     ops.relu(out, x)
     return out
+
+
+__all__ = ["relu"]

--- a/examples/kernels/relu-torch-bounds/CARD.md
+++ b/examples/kernels/relu-torch-bounds/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-torch-bounds that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-torch-bounds", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-torch-bounds/CARD.md
+++ b/examples/kernels/relu-torch-bounds/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-torch-bounds that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-torch-bounds", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu-torch-bounds/torch-ext/relu/__init__.py
+++ b/examples/kernels/relu-torch-bounds/torch-ext/relu/__init__.py
@@ -10,3 +10,6 @@ def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
         out = torch.empty_like(x)
     ops.relu(out, x)
     return out
+
+
+__all__ = ["relu"]

--- a/examples/kernels/relu-tvm-ffi/CARD.md
+++ b/examples/kernels/relu-tvm-ffi/CARD.md
@@ -1,56 +1,26 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu-tvm-ffi that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu-tvm-ffi", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `relu`
+- `relu_jax`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu-tvm-ffi/CARD.md
+++ b/examples/kernels/relu-tvm-ffi/CARD.md
@@ -1,26 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu-tvm-ffi that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu-tvm-ffi", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
-- `relu_jax`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/relu/CARD.md
+++ b/examples/kernels/relu/CARD.md
@@ -1,56 +1,28 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/relu that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/relu", version=1)
+relu = kernel_module.relu
 
-{{ functions[0] }}(...)
+relu(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
+- `relu`
 
 ## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `ReLU`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/examples/kernels/relu/CARD.md
+++ b/examples/kernels/relu/CARD.md
@@ -1,28 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/relu that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/relu", version=1)
-relu = kernel_module.relu
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-relu(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `relu`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
 
 ## Available layers
-- `ReLU`
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/silu-and-mul/CARD.md
+++ b/examples/kernels/silu-and-mul/CARD.md
@@ -1,25 +1,56 @@
 ---
 library_name: kernels
-license: apache-2.0
----
+{% if license %}license: {{ license }}
+{% endif %}---
 
-This is the repository card of kernels-test/silu-and-mul that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
+{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("kernels-test/silu-and-mul", version=1)
-silu_and_mul = kernel_module.silu_and_mul
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
+{{ functions[0] }} = kernel_module.{{ functions[0] }}
 
-silu_and_mul(...)
+{{ functions[0] }}(...)
 ```
+{% else %}
+
+Usage example not available.
+{% endif %}
 
 ## Available functions
-- `silu_and_mul`
+{% if functions %}
+{% for func in functions %}
+- `{{ func }}`
+{% endfor %}
+{% else %}
+
+Function list not available.
+{% endif %}
+{% if layers %}
+
+## Available layers
+{% for layer in layers %}
+- `{{ layer }}`
+{% endfor %}
+{% endif %}
 
 ## Benchmarks
+{% if has_benchmark %}
+
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
+{% else %}
 
 No benchmark available yet.
+{% endif %}
+{% if upstream %}
+
+## Source code
+
+Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
+{% endif %}
+

--- a/examples/kernels/silu-and-mul/CARD.md
+++ b/examples/kernels/silu-and-mul/CARD.md
@@ -1,56 +1,25 @@
 ---
 library_name: kernels
-{% if license %}license: {{ license }}
-{% endif %}---
+license: apache-2.0
+---
 
-This is the repository card of {{ repo_id }} that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
+This is the repository card of kernels-test/silu-and-mul that has been pushed on the Hub. It was built to be used with the [`kernels` library](https://github.com/huggingface/kernels). This card was automatically generated.
 
 ## How to use
-{% if functions %}
 
 ```python
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
-{{ functions[0] }} = kernel_module.{{ functions[0] }}
+kernel_module = get_kernel("kernels-test/silu-and-mul", version=1)
+silu_and_mul = kernel_module.silu_and_mul
 
-{{ functions[0] }}(...)
+silu_and_mul(...)
 ```
-{% else %}
-
-Usage example not available.
-{% endif %}
 
 ## Available functions
-{% if functions %}
-{% for func in functions %}
-- `{{ func }}`
-{% endfor %}
-{% else %}
-
-Function list not available.
-{% endif %}
-{% if layers %}
-
-## Available layers
-{% for layer in layers %}
-- `{{ layer }}`
-{% endfor %}
-{% endif %}
+- `silu_and_mul`
 
 ## Benchmarks
-{% if has_benchmark %}
-
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
-{% else %}
 
 No benchmark available yet.
-{% endif %}
-{% if upstream %}
-
-## Source code
-
-Source code of this kernel originally comes from {{ upstream }} and it was repurposed for compatibility with `kernels`.
-{% endif %}
-

--- a/kernel-builder/src/card.rs
+++ b/kernel-builder/src/card.rs
@@ -126,6 +126,7 @@ fn render_card(build: &Build, kernel_dir: &Path) -> Result<String> {
         .wrap_err("Cannot get card template")?
         .render(context! {
             repo_id => repo_id,
+            version => build.general.version,
             functions => functions,
             layers => layers,
             has_benchmark => has_benchmark,

--- a/kernel-builder/src/card.rs
+++ b/kernel-builder/src/card.rs
@@ -13,12 +13,12 @@ use kernels_data::config::Build;
 use crate::util::{check_or_infer_kernel_dir, parse_build};
 
 fn extract_all(kernel_dir: &Path, module_name: &str) -> Option<Vec<String>> {
-    let init_path = kernel_dir
-        .join("torch-ext")
-        .join(module_name)
-        .join("__init__.py");
+    let init_path = ["torch-ext", "tvm-ffi-ext"]
+        .iter()
+        .map(|ext_dir| kernel_dir.join(ext_dir).join(module_name).join("__init__.py"))
+        .find(|path| path.exists())?;
 
-    let content = fs::read_to_string(&init_path).ok()?;
+    let content = fs::read_to_string(init_path).ok()?;
     let stmts = ast::Suite::parse(&content, "<module>").ok()?;
 
     for stmt in stmts {

--- a/kernel-builder/src/card.rs
+++ b/kernel-builder/src/card.rs
@@ -15,7 +15,12 @@ use crate::util::{check_or_infer_kernel_dir, parse_build};
 fn extract_all(kernel_dir: &Path, module_name: &str) -> Option<Vec<String>> {
     let init_path = ["torch-ext", "tvm-ffi-ext"]
         .iter()
-        .map(|ext_dir| kernel_dir.join(ext_dir).join(module_name).join("__init__.py"))
+        .map(|ext_dir| {
+            kernel_dir
+                .join(ext_dir)
+                .join(module_name)
+                .join("__init__.py")
+        })
         .find(|path| path.exists())?;
 
     let content = fs::read_to_string(init_path).ok()?;

--- a/kernel-builder/src/init/templates/CARD.md
+++ b/kernel-builder/src/init/templates/CARD.md
@@ -12,7 +12,7 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-kernel_module = get_kernel("{{ repo_id }}")
+kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 
 {{ functions[0] }}(...)
@@ -42,7 +42,7 @@ Function list not available.
 ## Benchmarks
 {% if has_benchmark %}
 
-Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }}`.
+Benchmarking script is available for this kernel. Run `kernels benchmark {{ repo_id }} --version {{ version }}`.
 {% else %}
 
 No benchmark available yet.

--- a/kernels/src/kernels/_versions.py
+++ b/kernels/src/kernels/_versions.py
@@ -61,7 +61,7 @@ def select_revision_or_version(
         return resolve_version_spec_as_ref(repo_id, version).target_commit
     else:
         raise ValueError(
-        "A kernel version or revision must be specified. "
-        "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
-        "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"
-    )
+            "A kernel version or revision must be specified. "
+            "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
+            "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"
+        )

--- a/kernels/src/kernels/_versions.py
+++ b/kernels/src/kernels/_versions.py
@@ -55,14 +55,12 @@ def select_revision_or_version(
 ) -> str:
     if revision is not None and version is not None:
         raise ValueError("Only one of `revision` or `version` must be specified.")
-
-    if revision is not None:
+    elif revision is not None:
         return revision
-
-    if version is not None:
+    elif version is not None:
         return resolve_version_spec_as_ref(repo_id, version).target_commit
-
-    raise ValueError(
+    else:
+        raise ValueError(
         "A kernel version or revision must be specified. "
         "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
         "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"

--- a/kernels/src/kernels/_versions.py
+++ b/kernels/src/kernels/_versions.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 from huggingface_hub.hf_api import GitRefInfo
 
@@ -59,14 +58,12 @@ def select_revision_or_version(
 
     if revision is not None:
         return revision
-    elif version is not None:
+
+    if version is not None:
         return resolve_version_spec_as_ref(repo_id, version).target_commit
 
-    warnings.warn(
-        "Future versions of `kernels` (>=0.15) will require specifying a kernel version or revision. "
-        "See: https://huggingface.co/docs/kernels/migration",
-        FutureWarning,
-        stacklevel=2,
+    raise ValueError(
+        "A kernel version or revision must be specified. "
+        "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
+        "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"
     )
-
-    return "main"

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -33,10 +33,11 @@ class FuncRepository:
             The Hub repository containing the layer.
         func_name (`str`):
             The name of the function within the kernel repository.
-        revision (`str`, *optional*, defaults to `"main"`):
+        revision (`str`, *optional*):
             The specific revision (branch, tag, or commit) to download. Cannot be used together with `version`.
         version (`int`, *optional*):
             The kernel version to download. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
 
     Example:
         ```python
@@ -46,6 +47,7 @@ class FuncRepository:
         layer_repo = FuncRepository(
             repo_id="kernels-community/activation",
             func_name="silu_and_mul",
+            revision="main",
         )
 
         # Reference a layer by version
@@ -68,6 +70,8 @@ class FuncRepository:
     ):
         if revision is not None and version is not None:
             raise ValueError("Either a revision or a version must be specified, not both.")
+        if revision is None and version is None:
+            raise ValueError("Either a revision or a version must be specified.")
 
         self._repo_id = repo_id
         self.func_name = func_name

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -38,10 +38,11 @@ class LayerRepository:
             The Hub repository containing the layer.
         layer_name (`str`):
             The name of the layer within the kernel repository.
-        revision (`str`, *optional*, defaults to `"main"`):
+        revision (`str`, *optional*):
             The specific revision (branch, tag, or commit) to download. Cannot be used together with `version`.
         version (`int`, *optional*):
             The kernel version to download. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
         trust_remote_code (`bool | list[str]`, *optional*, defaults to `False`):
             Whether to allow loading kernels from untrusted organisations. A list
             of signing identities can be provided for future verification support;
@@ -51,7 +52,7 @@ class LayerRepository:
         ```python
         from kernels import LayerRepository
 
-        # Reference a specific layer by revision
+        # Reference a specific layer by version
         layer_repo = LayerRepository(
             repo_id="kernels-community/activation",
             layer_name="SiluAndMul",
@@ -71,6 +72,8 @@ class LayerRepository:
     ):
         if revision is not None and version is not None:
             raise ValueError("Either a revision or a version must be specified, not both.")
+        if revision is None and version is None:
+            raise ValueError("Either a revision or a version must be specified.")
 
         self._repo_id = repo_id
         self.layer_name = layer_name

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -383,13 +383,6 @@ def get_kernel(
         result = activation.relu(out, x)
         ```
     """
-    if revision is None and version is None:
-        raise ValueError(
-            "A kernel version or revision must be specified. "
-            "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
-            "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"
-        )
-
     override = _get_local_kernel_overrides().get(repo_id, None)
     if override is not None:
         return get_local_kernel(override)

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -352,10 +352,11 @@ def get_kernel(
     Args:
         repo_id (`str`):
             The Hub repository containing the kernel.
-        revision (`str`, *optional*, defaults to `"main"`):
+        revision (`str`, *optional*):
             The specific revision (branch, tag, or commit) to download. Cannot be used together with `version`.
         version (`int`, *optional*):
             The kernel version to download. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
         backend (`str`, *optional*):
             The backend to load the kernel for. Can only be `cpu` or the backend that Torch is compiled for.
             The backend will be detected automatically if not provided.
@@ -382,6 +383,13 @@ def get_kernel(
         result = activation.relu(out, x)
         ```
     """
+    if revision is None and version is None:
+        raise ValueError(
+            "A kernel version or revision must be specified. "
+            "Use `version=<major>` for a stable kernel API version or `revision=<branch/tag/commit>` "
+            "for an explicit Hub revision. See: https://huggingface.co/docs/kernels/migration"
+        )
+
     override = _get_local_kernel_overrides().get(repo_id, None)
     if override is not None:
         return get_local_kernel(override)
@@ -447,10 +455,11 @@ def has_kernel(
     Args:
         repo_id (`str`):
             The Hub repository containing the kernel.
-        revision (`str`, *optional*, defaults to `"main"`):
+        revision (`str`, *optional*):
             The specific revision (branch, tag, or commit) to download. Cannot be used together with `version`.
         version (`int`, *optional*):
             The kernel version to download. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
         backend (`str`, *optional*):
             The backend to load the kernel for. Can only be `cpu` or the backend that Torch is compiled for.
             The backend will be detected automatically if not provided.

--- a/kernels/tests/test_basic.py
+++ b/kernels/tests/test_basic.py
@@ -27,7 +27,7 @@ def local_kernel(local_kernel_path):
 
 @pytest.fixture
 def metal_kernel():
-    return get_kernel("kernels-test/relu-metal")
+    return get_kernel("kernels-test/relu-metal", version=1)
 
 
 @pytest.fixture
@@ -129,18 +129,11 @@ def test_version_outdated_warning(caplog):
     assert "but version" not in caplog.text
 
 
-def test_no_version_or_revision_warning():
-    from packaging.version import Version
-
-    from kernels import __version__
-
-    assert Version(__version__) < Version("0.15"), (
-        "The deprecation cycle for requiring `version` or `revision` is complete. "
-        "Remove the fallback to 'main' in `select_revision_or_version` and make "
-        "`version` or `revision` a required argument."
-    )
-    with pytest.warns(FutureWarning, match="will require specifying a kernel version or revision"):
+def test_no_version_or_revision_error():
+    with pytest.raises(ValueError, match="A kernel version or revision must be specified"):
         get_kernel("kernels-test/versions")
+    with pytest.raises(ValueError, match="A kernel version or revision must be specified"):
+        has_kernel("kernels-test/versions")
 
 
 def test_noarch_kernel(device):
@@ -198,14 +191,14 @@ def test_local_overrides(monkeypatch, local_kernel_path):
             "LOCAL_KERNELS",
             f"kernels-test/activation={str(kernel_path)}:kernels-test/non-existing2=/non/existing",
         )
-        get_kernel("kernels-test/activation")
+        get_kernel("kernels-test/activation", revision="main")
 
     with monkeypatch.context() as m:
         m.setenv(
             "LOCAL_KERNELS",
             f"kernels-test/non-existing2=/non/existing:kernels-test/activation={str(kernel_path)}",
         )
-        get_kernel("kernels-test/activation")
+        get_kernel("kernels-test/activation", revision="main")
 
     with monkeypatch.context() as m:
         # Using a non-existing path should error.
@@ -214,7 +207,7 @@ def test_local_overrides(monkeypatch, local_kernel_path):
             "kernels-test/non-existing2=/non/existing:kernels-test/activation=/non/existing",
         )
         with pytest.raises(FileNotFoundError, match=r"Could not find kernel in /non/existing"):
-            get_kernel("kernels-test/activation")
+            get_kernel("kernels-test/activation", revision="main")
 
     with monkeypatch.context() as m:
         # Malformed entries must be rejected.
@@ -223,7 +216,7 @@ def test_local_overrides(monkeypatch, local_kernel_path):
             "kernels-test/non-existing2=/non/existing:kernels-test/activation",
         )
         with pytest.raises(ValueError, match=r"Invalid LOCAL_KERNELS entry"):
-            get_kernel("kernels-test/activation")
+            get_kernel("kernels-test/activation", revision="main")
 
 
 @pytest.mark.neuron_only

--- a/kernels/tests/test_benchmarks.py
+++ b/kernels/tests/test_benchmarks.py
@@ -6,7 +6,7 @@ from kernels import get_kernel
 
 @pytest.fixture
 def kernel():
-    return get_kernel("kernels-community/activation")
+    return get_kernel("kernels-community/activation", version=1)
 
 
 @pytest.fixture

--- a/kernels/tests/test_func.py
+++ b/kernels/tests/test_func.py
@@ -39,6 +39,11 @@ def test_decorator():
     assert isinstance(identity, nn.Module)
 
 
+def test_kernel_func_requires_version_or_revision():
+    with pytest.raises(ValueError, match="Either a revision or a version must be specified"):
+        FuncRepository("kernels-test/flattened-build", func_name="silu_and_mul")
+
+
 def test_kernel_func(device):
     model = SurpriseMe()
 
@@ -51,6 +56,7 @@ def test_kernel_func(device):
                 device: FuncRepository(
                     "kernels-test/flattened-build",
                     func_name="silu_and_mul",
+                    revision="main",
                 )
             }
         }

--- a/kernels/tests/test_layer.py
+++ b/kernels/tests/test_layer.py
@@ -46,10 +46,12 @@ kernel_layer_mapping = {
         "cuda": LayerRepository(
             repo_id="kernels-test/op-without-fake-test",
             layer_name="SiluAndMul",
+            revision="main",
         ),
         "rocm": LayerRepository(
             repo_id="kernels-test/op-without-fake-test",
             layer_name="SiluAndMul",
+            revision="main",
         ),
     },
     "SiluAndMulStringDevice": {
@@ -63,6 +65,7 @@ kernel_layer_mapping = {
         "xpu": LayerRepository(
             repo_id="kernels-community/liger_kernels",
             layer_name="LigerRMSNorm",  # Triton
+            revision="main",
         )
     },
 }
@@ -197,6 +200,7 @@ def test_hub_func(cls):
                 "cuda": FuncRepository(
                     "kernels-test/flattened-build",
                     func_name="silu_and_mul",
+                    revision="main",
                 )
             }
         }
@@ -301,6 +305,7 @@ def test_rocm_kernel_mapping(device):
             "rocm": LayerRepository(
                 repo_id="kernels-test/silu-and-mul",
                 layer_name="SiluAndMul",
+                revision="main",
             )
         }
     }
@@ -332,6 +337,7 @@ def test_capability():
                 ): LayerRepository(
                     repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearBackward",
+                    revision="main",
                 )
             }
         }
@@ -352,6 +358,7 @@ def test_capability():
                 ): LayerRepository(
                     repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearBackward",
+                    revision="main",
                 )
             }
         }
@@ -541,6 +548,11 @@ def test_mapping_contexts():
     }
 
 
+def test_layer_repository_requires_version_or_revision():
+    with pytest.raises(ValueError, match="Either a revision or a version must be specified"):
+        LayerRepository(repo_id="kernels-test/silu-and-mul", layer_name="SiluAndMul")
+
+
 def test_validate_kernel_layer():
     class BadLayer(nn.Module):
         def __init__(self, *args, **kwargs):
@@ -548,7 +560,7 @@ def test_validate_kernel_layer():
             self.foo = 42
 
     def stub_repo(layer):
-        return LayerRepository(repo_id="kernels-test/nonexisting", layer_name=layer.__name__)
+        return LayerRepository(repo_id="kernels-test/nonexisting", layer_name=layer.__name__, revision="main")
 
     with pytest.raises(
         TypeError,
@@ -595,6 +607,7 @@ def test_invalid_mode_for_mapping_rejected():
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearNoBackward",
+                        revision="main",
                     )
                 }
             }
@@ -616,6 +629,7 @@ def test_kernel_modes():
                 "cuda": LayerRepository(
                     repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearBackward",
+                    revision="main",
                 )
             }
         }
@@ -642,6 +656,7 @@ def test_kernel_modes():
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -670,10 +685,12 @@ def test_kernel_modes():
                     Mode.FALLBACK: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                 }
             }
@@ -703,6 +720,7 @@ def test_kernel_modes():
                     Mode.TRAINING | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -737,6 +755,7 @@ def test_fallback_used_when_training():
                 Device(type="cuda"): LayerRepository(
                     repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearBackward",
+                    revision="main",
                 )
             }
         }
@@ -759,6 +778,7 @@ def test_fallback_used_when_training():
                 Device(type="cuda"): LayerRepository(
                     repo_id="kernels-test/backward-marker-test",
                     layer_name="LinearImplicitBackward",
+                    revision="main",
                 )
             }
         }
@@ -801,6 +821,7 @@ def test_kernel_modes_inference():
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -829,6 +850,7 @@ def test_kernel_modes_inference():
                     Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -857,10 +879,12 @@ def test_kernel_modes_inference():
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                 }
             }
@@ -896,10 +920,12 @@ def test_kernel_modes_mixed():
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                 }
             }
@@ -932,18 +958,22 @@ def test_kernel_modes_mixed():
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.TRAINING | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                 }
             }
@@ -984,6 +1014,7 @@ def test_kernel_modes_cross_fallback():
                     Mode.TRAINING: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -1008,6 +1039,7 @@ def test_kernel_modes_cross_fallback():
                     Mode.TRAINING | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     )
                 }
             }
@@ -1042,10 +1074,12 @@ def test_kernel_modes_cross_fallback():
                     Mode.INFERENCE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                     Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                         repo_id="kernels-test/backward-marker-test",
                         layer_name="LinearBackward",
+                        revision="main",
                     ),
                 }
             }
@@ -1077,6 +1111,7 @@ def test_layer_versions(device):
                 Device(type=device): LayerRepository(
                     repo_id="kernels-test/versions",
                     layer_name="Version",
+                    revision="main",
                 )
             }
         }
@@ -1151,6 +1186,7 @@ def test_local_overrides_layer(monkeypatch, local_kernel_path):
             Device(type="cuda"): LayerRepository(
                 repo_id="kernels-test/silu-and-mul",
                 layer_name="SiluAndMul",
+                revision="main",
             ),
         },
     }


### PR DESCRIPTION
This PR enforces that a version or revision must be specified in all cases

note: this PR also updates the examples cards to render correctly; updates the `__all__`s for some functions, adds a small change for the cli to work on tvm-ffi kernels, and regenerates the cards since there were template placeholders previously. I added these changes to this PR since I updated the card template to include the version and thought the examples should reflect.