### PR TITLE
Update version bumping scripts with the `--major` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ quality:
 	ruff format --check ${check_dirs}
 	ruff check ${check_dirs}
 
-# Bump every version site to the next dev release based on the currently
-# installed `kernels` package version (e.g. installed 0.13.0 -> 0.14.0.dev0).
+# Bump every version site to the next patch dev release
+# (e.g. 0.10.1 -> 0.10.2.dev0, or 0.10.1.dev0 -> 0.10.1.dev1).
 # Refreshes Cargo.lock and kernels/uv.lock so all sites stay consistent.
 bump-dev:
 	python scripts/bump_version.py --dev
@@ -39,9 +39,20 @@ bump-dev:
 bump-dev-dry-run:
 	python scripts/bump_version.py --dev --dry-run
 
-# Strip the `.dev0` / `-dev0` suffix from every version site in prep for a
-# release (e.g. codebase 0.14.0.dev0 -> 0.14.0). Refreshes Cargo.lock and
-# kernels/uv.lock so all sites stay consistent.
+# Bump every version site to the next minor dev release
+# (e.g. 0.10.1 -> 0.11.0.dev0, or 0.10.1.dev0 -> 0.11.0.dev0).
+# Refreshes Cargo.lock and kernels/uv.lock so all sites stay consistent.
+bump-dev-major:
+	python scripts/bump_version.py --dev --major
+	cargo check --workspace
+	cd kernels && uv lock
+
+bump-dev-major-dry-run:
+	python scripts/bump_version.py --dev --major --dry-run
+
+# Strip the dev suffix from every version site in prep for a patch release
+# (e.g. 0.10.1.dev0 -> 0.10.1, or 0.10.1 -> 0.10.2).
+# Refreshes Cargo.lock and kernels/uv.lock so all sites stay consistent.
 bump-release:
 	python scripts/bump_version.py
 	cargo check --workspace
@@ -49,3 +60,14 @@ bump-release:
 
 bump-release-dry-run:
 	python scripts/bump_version.py --dry-run
+
+# Bump every version site to the next minor release
+# (e.g. 0.10.1.dev0 -> 0.11.0, or 0.10.1 -> 0.11.0).
+# Refreshes Cargo.lock and kernels/uv.lock so all sites stay consistent.
+bump-major:
+	python scripts/bump_version.py --major
+	cargo check --workspace
+	cd kernels && uv lock
+
+bump-major-dry-run:
+	python scripts/bump_version.py --major --dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: style kernel-builder-cli-docs quality bump-dev bump-dev-dry-run bump-release bump-release-dry-run pin-actions
+.PHONY: style kernel-builder-cli-docs quality bump-dev bump-dev-dry-run bump-dev-major bump-dev-major-dry-run bump-release bump-release-dry-run bump-major bump-major-dry-run pin-actions
 
 
 export check_dirs := kernels/src kernels/tests kernels-data/bindings/python

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,12 +1,36 @@
 #!/usr/bin/env python3
 """Bump all version strings in the repo.
 
-Without ``--dev``: strip the development suffix ahead of a release.
-  Example: codebase at ``0.14.0.dev0`` -> all sites become ``0.14.0``.
+The two flags ``--dev`` and ``--major`` are independent and may be combined.
 
-With ``--dev``: advance to the next development cycle.
-  Example: codebase at ``0.13.0`` -> Python sites get ``0.14.0.dev0`` (PEP 440),
-  Cargo sites get ``0.14.0-dev0``.
+``--major`` controls *which component* is incremented:
+
+  False (default): if currently a dev release, keep the same release base;
+                   if currently a plain release, bump the patch component.
+  True:            bump the minor component and reset patch to 0, regardless
+                   of whether the current version is a dev release.
+
+``--dev`` controls whether a dev suffix is added to the result:
+
+  False (default): no dev suffix.
+  True:            append ``.devN`` (Python) / ``-devN`` (Cargo).
+                   If the target base matches the current base and the current
+                   version is already a dev release, N is bumped by one;
+                   otherwise N starts at 0.
+
+Examples (codebase at ``0.10.1.dev0``)::
+
+  (none)          -> 0.10.1
+  --major         -> 0.11.0
+  --dev           -> 0.10.1.dev1
+  --dev --major   -> 0.11.0.dev0
+
+Examples (codebase at ``0.10.1``)::
+
+  (none)          -> 0.10.2
+  --major         -> 0.11.0
+  --dev           -> 0.10.2.dev0
+  --dev --major   -> 0.11.0.dev0
 """
 
 from __future__ import annotations
@@ -27,45 +51,49 @@ from _version_common import (
 from packaging.version import Version
 
 
-def next_dev_versions(current: Version) -> tuple[str, str]:
-    if current.is_prerelease or current.is_postrelease or current.local is not None:
+def compute_versions(current: Version, *, dev: bool, major: bool) -> tuple[str, str]:
+    """Return ``(python_version, cargo_version)`` for the requested bump."""
+    if current.pre is not None or current.post is not None or current.local is not None:
         raise SystemExit(
-            f"Codebase version `{current}` is not a plain release (e.g. 0.13.0). "
-            "This tool bumps from a release to the next dev cycle. Set "
-            f"{display_path(PRIMARY_PYPROJECT)} to a release version first."
+            f"Codebase version `{current}` has pre/post/local components and "
+            "cannot be bumped automatically. Set "
+            f"{display_path(PRIMARY_PYPROJECT)} to a plain or dev release first "
+            "(e.g. 0.10.1 or 0.10.1.dev0)."
         )
 
     release = current.release
     if len(release) < 2:
         raise SystemExit(
             f"Codebase version `{current}` is missing a minor component; "
-            "expected at least MAJOR.MINOR (e.g. 0.13.0)."
+            "expected at least MAJOR.MINOR.PATCH (e.g. 0.10.1)."
         )
 
-    major, minor = release[0], release[1]
-    next_minor = f"{major}.{minor + 1}.0"
-    return f"{next_minor}.dev0", f"{next_minor}-dev0"
+    cur_major = release[0]
+    cur_minor = release[1]
+    cur_patch = release[2] if len(release) > 2 else 0
+    cur_dev = current.dev  # int if dev release, else None
 
+    # Determine the target base tuple (major, minor, patch).
+    if major:
+        base = (cur_major, cur_minor + 1, 0)
+    elif cur_dev is not None:
+        base = (cur_major, cur_minor, cur_patch)  # same base as current dev
+    else:
+        base = (cur_major, cur_minor, cur_patch + 1)  # bump patch from release
 
-def next_release_version(current: Version) -> tuple[str, str]:
-    if (
-        not current.is_devrelease
-        or current.pre is not None
-        or current.post is not None
-        or current.local is not None
-    ):
-        raise SystemExit(
-            f"Codebase version `{current}` is not a development version "
-            "(e.g. 0.14.0.dev0). This tool strips the dev suffix ahead of a "
-            f"release. Set {display_path(PRIMARY_PYPROJECT)} to a dev version first."
+    base_str = f"{base[0]}.{base[1]}.{base[2]}"
+
+    if dev:
+        # Bump the dev counter when staying on the same release base; else 0.
+        same_base = (
+            not major
+            and cur_dev is not None
+            and base == (cur_major, cur_minor, cur_patch)
         )
+        dev_num = (cur_dev + 1) if same_base else 0
+        return f"{base_str}.dev{dev_num}", f"{base_str}-dev{dev_num}"
 
-    release = current.release
-    major = release[0] if len(release) > 0 else 0
-    minor = release[1] if len(release) > 1 else 0
-    patch = release[2] if len(release) > 2 else 0
-    ver = f"{major}.{minor}.{patch}"
-    return ver, ver
+    return base_str, base_str
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -73,7 +101,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--dev",
         action="store_true",
-        help="Bump to the next dev cycle.",
+        help="Add or bump the dev suffix on the result.",
+    )
+    parser.add_argument(
+        "--major",
+        action="store_true",
+        help="Bump the minor component (and reset patch) instead of patch.",
     )
     parser.add_argument(
         "--dry-run",
@@ -89,21 +122,26 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     current = get_codebase_version()
+    python_ver, cargo_ver = compute_versions(current, dev=args.dev, major=args.major)
 
-    if args.dev:
-        python_ver, cargo_ver = next_dev_versions(current)
-        print(f"Codebase kernels version : {current}")
-        print(f"Next Python dev version  : {python_ver}")
-        print(f"Next Cargo  dev version  : {cargo_ver}")
-        confirm_prompt = f"Bump all version sites to {python_ver} / {cargo_ver}?"
-        makefile_target = "bump-dev"
+    print(f"Codebase kernels version : {current}")
+    if python_ver == cargo_ver:
+        print(f"Next version             : {python_ver}")
+        confirm_prompt = f"Bump all version sites to {python_ver}?"
     else:
-        python_ver, cargo_ver = next_release_version(current)
-        print(f"Codebase kernels version : {current}")
-        print(f"Next release version     : {python_ver}")
-        confirm_prompt = f"Strip dev suffix from all version sites -> {python_ver}?"
-        makefile_target = "bump-release"
+        print(f"Next Python version      : {python_ver}")
+        print(f"Next Cargo  version      : {cargo_ver}")
+        confirm_prompt = f"Bump all version sites to {python_ver} / {cargo_ver}?"
     print()
+
+    if args.dev and args.major:
+        makefile_target = "bump-dev-major"
+    elif args.dev:
+        makefile_target = "bump-dev"
+    elif args.major:
+        makefile_target = "bump-major"
+    else:
+        makefile_target = "bump-release"
 
     if not args.dry_run and not args.yes:
         if not confirm(confirm_prompt):


### PR DESCRIPTION
With this change the script supports both major and minor version bumping. For example:

Codebase at `0.10.1.dev0`

```
  (none)          -> 0.10.1
  --major         -> 0.11.0
  --dev           -> 0.10.1.dev1
  --dev --major   -> 0.11.0.dev0
```

Codebase at `0.10.1`:

```
  (none)          -> 0.10.2
  --major         -> 0.11.0
  --dev           -> 0.10.2.dev0
```

These are the typical version bumping workflows within the project.