### PR TITLE
fix: use local cache for kernel variant discovery in offline mode

### DIFF
--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -244,8 +244,52 @@ def install_kernel(
     """
     api = _get_hf_api(user_agent=user_agent)
 
-    if not local_files_only:
-        repo_id, revision = resolve_status(api, repo_id, revision)
+    # Honour both the explicit flag and the global HF_HUB_OFFLINE env var.
+    # When offline, list_repo_tree() is unavailable, so we discover build
+    # variants from the local snapshot and skip any network requests.
+    offline = local_files_only or constants.HF_HUB_OFFLINE
+
+    if offline:
+        try:
+            repo_path = Path(
+                str(
+                    api.snapshot_download(
+                        repo_id,
+                        repo_type="kernel",
+                        cache_dir=CACHE_DIR,
+                        revision=revision,
+                        local_files_only=True,
+                    )
+                )
+            )
+        except Exception as exc:
+            raise FileNotFoundError(
+                f"Kernel {repo_id!r} (revision: {revision!r}) is not available in the local "
+                "cache. Run without HF_HUB_OFFLINE to download it first."
+            ) from exc
+
+        variants = get_variants_local(repo_path / "build")
+        variant = resolve_variant(variants, backend)
+
+        if variant is None:
+            raise FileNotFoundError(
+                f"Cannot find a build variant for this system in {repo_id} "
+                f"(revision: {revision}) from local cache. "
+                f"Available variants: {', '.join(v.variant_str for v in variants)}"
+            )
+
+        try:
+            return _find_kernel_in_repo_path(
+                repo_path,
+                variant=variant,
+                variant_locks=variant_locks,
+            )
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"Cannot load kernel from local cache for repo {repo_id} (revision: {revision})"
+            )
+
+    repo_id, revision = resolve_status(api, repo_id, revision)
 
     variants = get_variants(api, repo_id=repo_id, revision=revision)
     variant = resolve_variant(variants, backend)
@@ -265,7 +309,7 @@ def install_kernel(
                 allow_patterns=allow_patterns,
                 cache_dir=CACHE_DIR,
                 revision=revision,
-                local_files_only=local_files_only,
+                local_files_only=False,
             )
         )
     )

--- a/kernels/tests/test_offline_install.py
+++ b/kernels/tests/test_offline_install.py
@@ -1,0 +1,174 @@
+"""Tests for offline kernel loading (issue #553).
+
+When HF_HUB_OFFLINE=1 (or local_files_only=True), install_kernel() must
+discover available build variants from the local cache instead of calling
+api.list_repo_tree(), which fails with a network error in offline mode.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kernels.utils import install_kernel
+from kernels.variants import Variant
+
+
+def _make_fake_variant() -> Variant:
+    """Return a minimal Variant object for mocking resolve_variant."""
+    v = MagicMock(spec=Variant)
+    v.variant_str = "torch26-cuda12-linux-x86_64"
+    return v
+
+
+class TestOfflineInstallKernel:
+    """install_kernel() must use local cache when HF_HUB_OFFLINE=1."""
+
+    def test_local_files_only_does_not_call_list_repo_tree(self, tmp_path):
+        """With local_files_only=True, list_repo_tree() must never be called."""
+        fake_variant = _make_fake_variant()
+        repo_path = tmp_path / "snapshot"
+        repo_path.mkdir()
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.return_value = str(repo_path)
+
+        with (
+            patch("kernels.utils._get_hf_api", return_value=mock_api),
+            patch("kernels.utils.get_variants_local", return_value=[fake_variant]),
+            patch("kernels.utils.resolve_variant", return_value=fake_variant),
+            patch("kernels.utils._find_kernel_in_repo_path") as mock_find,
+        ):
+            mock_find.return_value = repo_path / "build" / fake_variant.variant_str
+            install_kernel(
+                "kernels-community/fake-kernel",
+                revision="abc123",
+                local_files_only=True,
+            )
+
+        mock_api.list_repo_tree.assert_not_called()
+
+    def test_hf_hub_offline_env_does_not_call_list_repo_tree(self, tmp_path, monkeypatch):
+        """With HF_HUB_OFFLINE=1 (via constants), list_repo_tree() must never
+        be called and get_variants_local() must be used instead."""
+        fake_variant = _make_fake_variant()
+        repo_path = tmp_path / "snapshot"
+        repo_path.mkdir()
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.return_value = str(repo_path)
+
+        with (
+            patch("kernels.utils._get_hf_api", return_value=mock_api),
+            patch("kernels.utils.constants") as mock_constants,
+            patch("kernels.utils.get_variants_local", return_value=[fake_variant]),
+            patch("kernels.utils.resolve_variant", return_value=fake_variant),
+            patch("kernels.utils._find_kernel_in_repo_path") as mock_find,
+        ):
+            mock_constants.HF_HUB_OFFLINE = True
+            mock_constants.HF_HUB_DISABLE_TELEMETRY = False
+            mock_find.return_value = repo_path / "build" / fake_variant.variant_str
+            install_kernel(
+                "kernels-community/fake-kernel",
+                revision="abc123",
+            )
+
+        mock_api.list_repo_tree.assert_not_called()
+
+    def test_local_files_only_passes_flag_to_snapshot_download(self, tmp_path):
+        """snapshot_download() must be called with local_files_only=True in
+        offline mode so it reads from cache without any network request."""
+        fake_variant = _make_fake_variant()
+        repo_path = tmp_path / "snapshot"
+        repo_path.mkdir()
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.return_value = str(repo_path)
+
+        with (
+            patch("kernels.utils._get_hf_api", return_value=mock_api),
+            patch("kernels.utils.get_variants_local", return_value=[fake_variant]),
+            patch("kernels.utils.resolve_variant", return_value=fake_variant),
+            patch("kernels.utils._find_kernel_in_repo_path") as mock_find,
+        ):
+            mock_find.return_value = repo_path / "build" / fake_variant.variant_str
+            install_kernel(
+                "kernels-community/fake-kernel",
+                revision="abc123",
+                local_files_only=True,
+            )
+
+        call_kwargs = mock_api.snapshot_download.call_args.kwargs
+        assert call_kwargs.get("local_files_only") is True
+
+    def test_local_files_only_uses_get_variants_local(self, tmp_path):
+        """get_variants_local() must be called (not get_variants) in offline mode."""
+        fake_variant = _make_fake_variant()
+        repo_path = tmp_path / "snapshot"
+        repo_path.mkdir()
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.return_value = str(repo_path)
+
+        with (
+            patch("kernels.utils._get_hf_api", return_value=mock_api),
+            patch("kernels.utils.get_variants") as mock_get_variants,
+            patch("kernels.utils.get_variants_local", return_value=[fake_variant]) as mock_local,
+            patch("kernels.utils.resolve_variant", return_value=fake_variant),
+            patch("kernels.utils._find_kernel_in_repo_path") as mock_find,
+        ):
+            mock_find.return_value = repo_path / "build" / fake_variant.variant_str
+            install_kernel(
+                "kernels-community/fake-kernel",
+                revision="abc123",
+                local_files_only=True,
+            )
+
+        mock_get_variants.assert_not_called()
+        mock_local.assert_called_once_with(repo_path / "build")
+
+    def test_missing_cache_raises_file_not_found(self, tmp_path):
+        """When the kernel is not in the local cache, a FileNotFoundError
+        with a helpful message must be raised."""
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.side_effect = LocalEntryNotFoundError("not cached")
+
+        with patch("kernels.utils._get_hf_api", return_value=mock_api):
+            with pytest.raises(FileNotFoundError, match="not available in the local cache"):
+                install_kernel(
+                    "kernels-community/not-cached",
+                    revision="abc123",
+                    local_files_only=True,
+                )
+
+    def test_online_path_still_calls_get_variants(self, tmp_path):
+        """The online code path must not regress: get_variants() must still be
+        called when local_files_only=False and HF_HUB_OFFLINE=False."""
+        fake_variant = _make_fake_variant()
+        repo_path = tmp_path / "snapshot"
+        repo_path.mkdir()
+
+        mock_api = MagicMock()
+        mock_api.snapshot_download.return_value = str(repo_path)
+
+        with (
+            patch("kernels.utils._get_hf_api", return_value=mock_api),
+            patch("kernels.utils.constants") as mock_constants,
+            patch("kernels.utils.resolve_status", return_value=("kernels-community/fake-kernel", "abc123")),
+            patch("kernels.utils.get_variants", return_value=[fake_variant]) as mock_get_variants,
+            patch("kernels.utils.resolve_variant", return_value=fake_variant),
+            patch("kernels.utils._find_kernel_in_repo_path") as mock_find,
+        ):
+            mock_constants.HF_HUB_OFFLINE = False
+            mock_constants.HF_HUB_DISABLE_TELEMETRY = False
+            mock_find.return_value = repo_path / "build" / fake_variant.variant_str
+            install_kernel(
+                "kernels-community/fake-kernel",
+                revision="abc123",
+                local_files_only=False,
+            )
+
+        mock_get_variants.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #553.

When `HF_HUB_OFFLINE=1` is set, `install_kernel()` called `get_variants()` which internally calls `api.list_repo_tree()`. That network request fails immediately in offline mode even when the required files are already in the local Hugging Face Hub cache.

### Root cause

```python
# install_kernel — before this fix
variants = get_variants(api, repo_id=repo_id, revision=revision)
#                       ↑ always calls api.list_repo_tree() — fails offline
```

### Fix

Detect the offline condition (`local_files_only=True` or `constants.HF_HUB_OFFLINE`) and, when true, take a dedicated offline code path that:

1. Retrieves the local snapshot root via `snapshot_download(local_files_only=True)` — no network request.
2. Discovers build variants with `get_variants_local(repo_path / "build")` instead of the network-dependent `get_variants()`.
3. Resolves the best variant and returns the path via `_find_kernel_in_repo_path()`.

The online code path is unchanged.

### Changes

**`kernels/src/kernels/utils.py`**
- `install_kernel()` — split into an offline branch (local cache) and the existing online branch.

**`kernels/tests/test_offline_install.py`** (new)
- `list_repo_tree()` is never called when `local_files_only=True`
- `list_repo_tree()` is never called when `constants.HF_HUB_OFFLINE` is `True`
- `snapshot_download()` receives `local_files_only=True` in offline mode
- `get_variants_local()` is called instead of `get_variants()` in offline mode
- `FileNotFoundError` with a clear message when the kernel is not in the local cache
- Online code path regression: `get_variants()` still called when online

### Repro (from #553)

```python
# Before this fix, raises OfflineModeIsEnabled / network error
import os
os.environ["HF_HUB_OFFLINE"] = "1"

from kernels import get_kernel
get_kernel("kernels-community/finegrained-fp8", revision="b0b199bf716f33c14bb7a3ea9ca86b87e5635906")
# Now correctly loads from local cache
```

## Test results

```
6 passed in 0.02s
```