### PR TITLE
(fix): update get local kernel in benchmark

### DIFF
--- a/kernels/src/kernels/cli/benchmark.py
+++ b/kernels/src/kernels/cli/benchmark.py
@@ -464,7 +464,7 @@ def run_benchmark_class(
     from kernels import get_kernel, get_local_kernel
 
     if is_local:
-        kernel = get_local_kernel(Path(repo_id), "activation")
+        kernel = get_local_kernel(Path(repo_id))
     else:
         kernel = get_kernel(repo_id, revision=revision)
 


### PR DESCRIPTION
## What does this PR do?

Updates the `benchmark.py` to use the up-to-date version of `get_local_kernel(Path(repo_id))`

## Motivation

Hard fail currently in benchmark

## Testing

Just tested locally.

## Checklist

- [ ] This PR is linked to an issue that was discussed and approved
- [x] I have tested these changes locally

