### PR TITLE
kernels/_versions: sort available versions numerically in error message

### DIFF
--- a/kernels/src/kernels/_versions.py
+++ b/kernels/src/kernels/_versions.py
@@ -33,7 +33,7 @@ def resolve_version_spec_as_ref(repo_id: str, version_spec: int) -> GitRefInfo:
     ref = versions.get(version_spec, None)
     if ref is None:
         raise ValueError(
-            f"Version {version_spec} not found, available versions: {', '.join(sorted(str(v) for v in versions.keys()))}"
+            f"Version {version_spec} not found, available versions: {', '.join(str(v) for v in sorted(versions.keys()))}"
         )
 
     latest_version = max(versions.keys())


### PR DESCRIPTION
## Important: Read before submitting

> **New contributors:** Please open or comment on an issue **before** submitting a
> PR to discuss the change you'd like to make. This helps us align on approach and
> avoids wasted effort on changes we may not be able to merge. Please only create
> a PR once one of the project maintainers agrees on your outlined approach.
>
> PRs of contributors who are not vouched for are automatically closed. You can
> become a vouched contributor by discussing a change first as outlined above.

## Related issue

Closes #

## What does this PR do?

Fixes the version list in the `ValueError` raised by `resolve_version_spec_as_ref`
so that available versions are sorted numerically instead of lexicographically.

## Motivation

`versions.keys()` is a collection of `int` version numbers. The previous code
converted each key to a `str` before passing the generator to `sorted()`, which
caused Python to sort the values as strings. For any repository that has reached
double-digit version numbers (e.g. v10, v11) the error message would display an
unintuitive order such as `1, 10, 11, 2, 9` instead of `1, 2, 9, 10, 11`,
making it harder for users to identify which versions are actually available.

## Changes

- `kernels/src/kernels/_versions.py`: moved `str()` conversion to after
  `sorted()` so the sort key is the integer value — `str(v) for v in
  sorted(versions.keys())` — rather than the string representation.

## Testing

Verified locally with a mock `versions` dict containing keys
`{1, 2, 9, 10, 11}`:

```python
# Before
sorted(str(v) for v in versions.keys())  # ['1', '10', '11', '2', '9']

# After
[str(v) for v in sorted(versions.keys())]  # ['1', '2', '9', '10', '11']
```

- No existing tests were broken by this change.
- The fix is display-only; no logic, return values, or data structures are
  affected.

## Checklist

- [ ] This PR is linked to an issue that was discussed and approved
- [ ] I have tested these changes locally
- [ ] New/changed functionality has test coverage