### PR TITLE
Remove compatible variant enumeration, add decision trace

### DIFF
--- a/kernels/src/kernels/cli/versions.py
+++ b/kernels/src/kernels/cli/versions.py
@@ -3,6 +3,7 @@ from kernels.utils import _get_hf_api
 from kernels.variants import (
     get_variants,
     resolve_variants,
+    variants_trace_str,
 )
 
 
@@ -15,16 +16,5 @@ def print_kernel_versions(repo_id: str):
 
     for version, ref in sorted(versions.items(), key=lambda x: x[0]):
         variants = get_variants(api, repo_id=repo_id, revision=ref.ref)
-        resolved = resolve_variants(variants, None)
-        best = resolved[0] if resolved else None
-        resolved_set = set(resolved)
-        print(f"Version {version}: ", end="")
-        variant_strs = [
-            (
-                f"✅ {variant.variant_str} ({'compatible, preferred' if variant == best else 'compatible'})"
-                if variant in resolved_set
-                else f"{variant.variant_str}"
-            )
-            for variant in variants
-        ]
-        print(", ".join(variant_strs))
+        _, status = resolve_variants(variants, None)
+        print(f"Version {version}:\n\n{variants_trace_str(status)}")

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -27,6 +27,7 @@ from kernels.variants import (
     get_variants,
     get_variants_local,
     resolve_variant,
+    variants_trace_str,
 )
 
 KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
@@ -248,11 +249,11 @@ def install_kernel(
         repo_id, revision = resolve_status(api, repo_id, revision)
 
     variants = get_variants(api, repo_id=repo_id, revision=revision)
-    variant = resolve_variant(variants, backend)
+    variant, trace = resolve_variant(variants, backend)
 
     if variant is None:
         raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}). Available variants: {', '.join([variant.variant_str for variant in variants])}"
+            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(trace)}"
         )
 
     allow_patterns = [f"build/{variant.variant_str}/*"]
@@ -421,7 +422,7 @@ def get_local_kernel(
     """
     for base_path in [repo_path, repo_path / "build"]:
         variants = get_variants_local(base_path)
-        variant = resolve_variant(variants, backend)
+        variant, _ = resolve_variant(variants, backend)
 
         if variant is not None:
             return _import_from_path(base_path / variant.variant_str)
@@ -462,7 +463,7 @@ def has_kernel(
 
     api = _get_hf_api()
     variants = get_variants(api, repo_id=repo_id, revision=revision)
-    variant = resolve_variant(variants, backend)
+    variant, _ = resolve_variant(variants, backend)
 
     if variant is None:
         return False
@@ -511,11 +512,11 @@ def load_kernel(
 
     api = _get_hf_api()
     variants = get_variants(api, repo_id=repo_id, revision=locked_sha)
-    variant = resolve_variant(variants, backend)
+    variant, status = resolve_variant(variants, backend)
 
     if variant is None:
         raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {locked_sha}). Available variants: {', '.join([variant.variant_str for variant in variants])}"
+            f"Cannot find a build variant for this system in {repo_id} (revision: {locked_sha}):\n\n{variants_trace_str(status)}"
         )
 
     allow_patterns = [f"build/{variant.variant_str}/*"]

--- a/kernels/src/kernels/variants.py
+++ b/kernels/src/kernels/variants.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import platform
 import re
@@ -17,7 +16,6 @@ from kernels.backends import (
     XPU,
     Backend,
     ROCm,
-    _backend,
     _select_backend,
     parse_backend,
 )
@@ -42,28 +40,6 @@ class Torch:
 
     version: Version
     cxx11_abi: bool | None
-
-    @staticmethod
-    def possible_variants() -> list["Torch"]:
-        if has_torch:
-            import torch
-
-            torch_version = parse(torch.__version__)
-            torch_version = Version(f"{torch_version.major}.{torch_version.minor}")
-
-            os_ = platform.system().lower()
-            if os_ == "linux":
-                cxx11_abi = torch.compiled_with_cxx11_abi()
-                return [
-                    Torch(version=torch_version, cxx11_abi=cxx11_abi),
-                    # We already accept build variants without an ABI tag, so
-                    # that we can remove the tag from builds in the future.
-                    Torch(version=torch_version, cxx11_abi=None),
-                ]
-            else:
-                return [Torch(version=torch_version, cxx11_abi=None)]
-        else:
-            return []
 
     @property
     def variant_str(self) -> str:
@@ -94,17 +70,6 @@ class TvmFfi:
 
     version: Version
 
-    @staticmethod
-    def possible_variants() -> list["TvmFfi"]:
-        if has_tvm_ffi:
-            import tvm_ffi
-
-            tvm_ffi_version = parse(tvm_ffi.__version__)
-            tvm_ffi_version = Version(f"{tvm_ffi_version.major}.{tvm_ffi_version.minor}")
-            return [TvmFfi(version=tvm_ffi_version)]
-        else:
-            return []
-
     @property
     def variant_str(self) -> str:
         return f"tvm-ffi{self.version.major}{self.version.minor}"
@@ -121,13 +86,6 @@ class TvmFfi:
 @dataclass(unsafe_hash=True)
 class TorchNoarch:
     """Versionless Torch framework (noarch variants)."""
-
-    @staticmethod
-    def possible_variants() -> list["TorchNoarch"]:
-        if has_torch:
-            return [TorchNoarch()]
-        else:
-            return []
 
     @property
     def variant_str(self) -> str:
@@ -148,20 +106,6 @@ class Arch:
         return f"{self.backend.variant_str}-{self.platform}-{self.os}"
 
     @staticmethod
-    def possible_variants() -> list["Arch"]:
-        cpu = platform.machine()
-        os = platform.system().lower()
-
-        if os == "darwin":
-            cpu = "aarch64" if cpu == "arm64" else cpu
-        elif os == "windows":
-            cpu = "x86_64" if cpu == "AMD64" else cpu
-
-        backend = _backend()
-
-        return [Arch(backend=backend, platform=cpu, os=os)]
-
-    @staticmethod
     def parse(parts: list[str]) -> "Arch":
         if len(parts) != 3:
             raise ValueError(f"Invalid arch variant parts: {parts!r}")
@@ -180,13 +124,6 @@ class Noarch:
 
     backend_name: str
 
-    @staticmethod
-    def possible_variants() -> list["Noarch"]:
-        backend = _backend()
-        noarch_backend_name = "npu" if backend.name == "cann" else backend.name
-        names = {noarch_backend_name, "universal"}
-        return [Noarch(backend_name=name) for name in sorted(names)]
-
     @property
     def variant_str(self) -> str:
         return self.backend_name
@@ -204,12 +141,6 @@ class ArchVariant:
     framework: Torch | TvmFfi
     arch: Arch
 
-    @staticmethod
-    def possible_variants() -> list["ArchVariant"]:
-        frameworks: list[Torch | TvmFfi] = Torch.possible_variants() + TvmFfi.possible_variants()
-        archs = Arch.possible_variants()
-        return [ArchVariant(framework=fw, arch=arch) for fw, arch in itertools.product(frameworks, archs)]
-
     @property
     def variant_str(self) -> str:
         return f"{self.framework.variant_str}-{self.arch.variant_str}"
@@ -223,12 +154,6 @@ class NoarchVariant:
     framework: TorchNoarch
     arch: Noarch
 
-    @staticmethod
-    def possible_variants() -> list["NoarchVariant"]:
-        frameworks = TorchNoarch.possible_variants()
-        archs = Noarch.possible_variants()
-        return [NoarchVariant(framework=fw, arch=arch) for fw, arch in itertools.product(frameworks, archs)]
-
     @property
     def variant_str(self) -> str:
         return f"{self.framework.variant_str}-{self.arch.variant_str}"
@@ -237,16 +162,22 @@ class NoarchVariant:
 Variant = ArchVariant | NoarchVariant
 
 
-def system_variants() -> list[Variant]:
-    """Return all possible build variants for the current system.
+@dataclass(unsafe_hash=True)
+class VariantAccepted:
+    """Variant that is compatible with the current system."""
 
-    Warning: this function should only be used internally (so don't export
-             at the top-level) and for informational purposes, such as user
-             feedback. When loading kernels, etc. rely what is on disk and
-             use `parse_variant` + `resolve_variant`, since this uses our
-             priority order, etc."""
-    result: list[Variant] = ArchVariant.possible_variants() + NoarchVariant.possible_variants()
-    return _sort_variants(result)
+    variant: Variant
+
+
+@dataclass(unsafe_hash=True)
+class VariantRejected:
+    """Variant that is incompatible with the current system."""
+
+    variant: Variant
+    reason: str
+
+
+Decision = VariantAccepted | VariantRejected
 
 
 def parse_variant(variant_str: str) -> Variant:
@@ -305,16 +236,18 @@ def get_variants_local(repo_path: Path) -> list[Variant]:
     return variants
 
 
-def resolve_variant(variants: list[Variant], backend: str | None = None) -> Variant | None:
-    """Return the best matching variant for the current system."""
-    resolved = resolve_variants(variants, backend)
+def resolve_variant(variants: list[Variant], backend: str | None = None) -> tuple[Variant | None, list[Decision]]:
+    """Return the best matching variant for the current system and
+    a trace with the acceptance/rejection decision for each variant."""
+    resolved, trace = resolve_variants(variants, backend)
 
-    return resolved[0] if resolved else None
+    return resolved[0] if resolved else None, trace
 
 
-def resolve_variants(variants: list[Variant], backend: str | None = None) -> list[Variant]:
+def resolve_variants(variants: list[Variant], backend: str | None = None) -> tuple[list[Variant], list[Decision]]:
     """Return the matching variants for the current system, sorted
-    by decreasing order of preference."""
+    by decreasing order of preference, and a trace of the
+    acceptance/rejection decision for each variant."""
     selected_backend = _select_backend(backend)
 
     cpu = platform.machine()
@@ -363,9 +296,12 @@ def _resolve_variant_for_system(
     torch_version: Version | None,
     torch_cxx11_abi: bool | None,
     tvm_ffi_version: Version | None,
-) -> list[Variant]:
-    """Resolve the best matching variant given explicit system parameters."""
-    applicable = _filter_variants(
+) -> tuple[list[Variant], list[Decision]]:
+    """Resolve the best matching variant given explicit system parameters.
+
+    Returns the preference-sorted list of accepted variants and a trace of
+    the acceptance/rejection decision for each variant."""
+    trace = _check_variants(
         variants,
         selected_backend,
         cpu,
@@ -374,10 +310,13 @@ def _resolve_variant_for_system(
         torch_cxx11_abi,
         tvm_ffi_version,
     )
-    return _sort_variants(applicable)
+    trace = _sort_variants(trace)
+
+    applicable = [decision.variant for decision in trace if isinstance(decision, VariantAccepted)]
+    return applicable, trace
 
 
-def _filter_variants(
+def _check_variants(
     variants: list[Variant],
     selected_backend: Backend,
     cpu: str,
@@ -385,23 +324,55 @@ def _filter_variants(
     torch_version: Version | None,
     torch_cxx11_abi: bool | None,
     tvm_ffi_version: Version | None,
-) -> list[Variant]:
+) -> list[Decision]:
     """Return only the variants applicable to the current system."""
-    result: list[Variant] = []
+    result: list[Decision] = []
     for v in variants:
         if isinstance(v, ArchVariant):
             # Skip non-matching CPU or OS.
-            if v.arch.platform != cpu or v.arch.os != os:
+            if v.arch.platform != cpu:
+                result.append(
+                    VariantRejected(
+                        variant=v,
+                        reason=f"CPU ({v.arch.platform}) does not match system CPU ({cpu})",
+                    )
+                )
+                continue
+            if v.arch.os != os:
+                result.append(
+                    VariantRejected(
+                        variant=v,
+                        reason=f"OS ({v.arch.os}) does not match system OS ({os})",
+                    )
+                )
                 continue
             # If the variant is a Torch or tvm-ffi variant, check that it has the
             # correct version and ABI.
             if isinstance(v.framework, Torch):
                 if v.framework.version != torch_version:
+                    result.append(
+                        VariantRejected(
+                            variant=v,
+                            reason=f"Torch version ({v.framework.version}) does not match environment Torch version ({torch_version})",
+                        )
+                    )
                     continue
                 if v.framework.cxx11_abi is not None and v.framework.cxx11_abi != torch_cxx11_abi:
+                    result.append(
+                        VariantRejected(
+                            variant=v,
+                            reason=f"Torch CXX11 ABI ({v.framework.cxx11_abi}) does not match environment Torch CXX11 ABI ({torch_cxx11_abi})",
+                        )
+                    )
                     continue
             elif isinstance(v.framework, TvmFfi):
                 if v.framework.version != tvm_ffi_version:
+                    result.append(
+                        VariantRejected(
+                            variant=v,
+                            reason=f"tvm-ffi version ({v.framework.version}) does not match environment tvm-ffi version ({tvm_ffi_version})",
+                        )
+                    )
                     continue
             # Given a system CUDA version of x.y, only CUDA versions x.z,
             # where z <= y qualify. Otherwise, the backend + version (if present)
@@ -411,31 +382,53 @@ def _filter_variants(
                     v.arch.backend.version.major != selected_backend.version.major
                     or v.arch.backend.version.minor > selected_backend.version.minor
                 ):
+                    result.append(
+                        VariantRejected(
+                            variant=v,
+                            reason=f"CUDA version ({v.arch.backend.version}) is not compatible with system CUDA version ({selected_backend.version})",
+                        )
+                    )
                     continue
             elif v.arch.backend.variant_str != selected_backend.variant_str:
+                result.append(
+                    VariantRejected(
+                        variant=v,
+                        reason=f"backend ({v.arch.backend.variant_str}) does not match selected backend ({selected_backend.variant_str})",
+                    )
+                )
                 continue
         elif isinstance(v, NoarchVariant):
             # Only noarch variants with a matching backend or "universal"
             # are applicable.
             noarch_backend_name = "npu" if selected_backend.name == "cann" else selected_backend.name
             if v.arch.backend_name != noarch_backend_name and v.arch.backend_name != "universal":
+                result.append(
+                    VariantRejected(
+                        variant=v,
+                        reason=f"backend ({v.arch.backend_name}) does not match system backend ({noarch_backend_name}) and is not universal",
+                    )
+                )
                 continue
-        result.append(v)
+        result.append(VariantAccepted(variant=v))
     return result
 
 
 def _sort_variants(
-    variants: list[Variant],
-) -> list[Variant]:
-    """Sort variants in preference order:
+    variants: list[Decision],
+) -> list[Decision]:
+    """Sort the decision trace in preference order:
 
-    1. Torch arch kernels with with the highest compatible CUDA version.
-    2. tvm-ffi arch kernels with with the highest compatible CUDA version.
-    3. Torch noarch kernels.
-    4. Old Torch universal kernels.
+    1. AcceptedVariant before RejectedVariant.
+    2. Torch arch kernels with with the highest compatible CUDA version.
+    3. tvm-ffi arch kernels with with the highest compatible CUDA version.
+    4. Torch noarch kernels.
+    5. Old Torch universal kernels.
     """
 
-    def sort_key(v: Variant) -> tuple:
+    def sort_key(vs: Decision) -> tuple[int, ...]:
+        # Returns a tuple of ints used for comparison.
+        decision_order = 0 if isinstance(vs, VariantAccepted) else 1
+        v = vs.variant
         if isinstance(v, ArchVariant):
             framework_order = 0 if isinstance(v.framework, Torch) else 1
             if isinstance(v.arch.backend, (CUDA, ROCm, XPU, CANN)):
@@ -443,10 +436,26 @@ def _sort_variants(
                 backend_order = -v.arch.backend.version.minor
             else:
                 backend_order = 0
-            return (framework_order, backend_order)
+            return (decision_order, framework_order, backend_order)
         else:
             assert isinstance(v, NoarchVariant)
             universal_order = 1 if v.arch.backend_name == "universal" else 0
-            return (2, universal_order)
+            return (decision_order, 2, universal_order)
 
     return sorted(variants, key=sort_key)
+
+
+def variants_trace_str(trace: list[Decision]) -> str:
+    # Ensure that the list is sorted.
+    sorted = _sort_variants(trace)
+    best = sorted[0].variant if len(sorted) and isinstance(sorted[0], VariantAccepted) else None
+    return "\n".join(
+        [
+            (
+                f"{variant_trace.variant.variant_str} {'compatible, preferred' if variant_trace.variant == best else 'compatible'} ✅"
+                if isinstance(variant_trace, VariantAccepted)
+                else f"{variant_trace.variant.variant_str}: {variant_trace.reason}"
+            )
+            for variant_trace in trace
+        ]
+    )

--- a/kernels/tests/test_variants.py
+++ b/kernels/tests/test_variants.py
@@ -7,8 +7,6 @@ from kernels.variants import (
     _resolve_variant_for_system,
     get_variants,
     parse_variant,
-    resolve_variants,
-    system_variants,
 )
 
 VARIANT_STRINGS = (
@@ -130,7 +128,7 @@ RESOLVE_VARIANTS = [
 
 def test_resolve_cuda_exact():
     # CUDA 12.8 should resolve to cu128.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CUDA(Version("12.8")),
         cpu="x86_64",
@@ -145,7 +143,7 @@ def test_resolve_cuda_exact():
 
 def test_resolve_cuda_best_older_minor():
     # CUDA 12.9 is not available, should fall back to cu128 (highest <= 12.9).
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CUDA(Version("12.9")),
         cpu="x86_64",
@@ -160,7 +158,7 @@ def test_resolve_cuda_best_older_minor():
 
 def test_resolve_cuda_no_newer_minor():
     # CUDA 12.5 is older than all the variants, fall back to noarch.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CUDA(Version("12.5")),
         cpu="x86_64",
@@ -175,7 +173,7 @@ def test_resolve_cuda_no_newer_minor():
 
 def test_resolve_cuda_no_different_major():
     # Different major version must not match.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CUDA(Version("11.8")),
         cpu="x86_64",
@@ -189,7 +187,7 @@ def test_resolve_cuda_no_different_major():
 
 
 def test_resolve_rocm():
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=ROCm(Version("7.0")),
         cpu="x86_64",
@@ -203,7 +201,7 @@ def test_resolve_rocm():
 
 
 def test_resolve_cpu_linux():
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CPU(),
         cpu="x86_64",
@@ -217,7 +215,7 @@ def test_resolve_cpu_linux():
 
 
 def test_resolve_cpu_darwin():
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CPU(),
         cpu="aarch64",
@@ -231,7 +229,7 @@ def test_resolve_cpu_darwin():
 
 
 def test_resolve_metal_darwin():
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CPU(),
         cpu="aarch64",
@@ -246,7 +244,7 @@ def test_resolve_metal_darwin():
 
 def test_resolve_noarch_fallback():
     # With no matching arch variant, should fall back to torch noarch.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=CUDA(Version("12.8")),
         cpu="aarch64",
@@ -260,7 +258,7 @@ def test_resolve_noarch_fallback():
 
 
 def test_resolve_no_match():
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS,
         selected_backend=ROCm(Version("7.0")),
         cpu="x86_64",
@@ -269,7 +267,7 @@ def test_resolve_no_match():
         torch_cxx11_abi=True,
         tvm_ffi_version=None,
     )
-    assert result == []
+    assert result, trace == []
 
 
 RESOLVE_VARIANTS_UNIVERSAL = [
@@ -283,7 +281,7 @@ RESOLVE_VARIANTS_UNIVERSAL = [
 
 def test_resolve_universal_matches_any_backend():
     # Universal works with every backend.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS_UNIVERSAL,
         selected_backend=ROCm(Version("7.0")),
         cpu="x86_64",
@@ -298,7 +296,7 @@ def test_resolve_universal_matches_any_backend():
 
 def test_resolve_universal_is_last_resort():
     # Specific match is preferred over universal.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS_UNIVERSAL,
         selected_backend=CUDA(Version("12.8")),
         cpu="x86_64",
@@ -314,7 +312,7 @@ def test_resolve_universal_is_last_resort():
 def test_resolve_specific_noarch_preferred_over_universal():
     # Backend-specific noarch is preferred over universal.
     variants = [parse_variant(s) for s in ["torch-universal", "torch-cuda"]]
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=variants,
         selected_backend=CUDA(Version("12.8")),
         cpu="x86_64",
@@ -339,7 +337,7 @@ RESOLVE_VARIANTS_NO_NOARCH = [
 
 def test_resolve_cuda_no_newer_minor_no_noarch():
     # No compatible variant for 12.5.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS_NO_NOARCH,
         selected_backend=CUDA(Version("12.5")),
         cpu="x86_64",
@@ -353,7 +351,7 @@ def test_resolve_cuda_no_newer_minor_no_noarch():
 
 def test_resolve_cuda_no_different_major_no_noarch():
     # 11.8 has a different major, so there is no compatible fallback.
-    result = _resolve_variant_for_system(
+    result, trace = _resolve_variant_for_system(
         variants=RESOLVE_VARIANTS_NO_NOARCH,
         selected_backend=CUDA(Version("11.8")),
         cpu="x86_64",
@@ -363,21 +361,3 @@ def test_resolve_cuda_no_different_major_no_noarch():
         tvm_ffi_version=None,
     )
     assert result == []
-
-
-def test_system_variants_roundtrip():
-    variants = system_variants()
-    for v in variants:
-        assert parse_variant(v.variant_str).variant_str == v.variant_str
-
-
-def test_system_variants_no_duplicates():
-    variants = system_variants()
-    variant_strs = [v.variant_str for v in variants]
-    assert len(variant_strs) == len(set(variant_strs))
-
-
-def test_system_variants_all_resolve():
-    variants = system_variants()
-    resolved = resolve_variants(variants)
-    assert set(v.variant_str for v in resolved) == set(v.variant_str for v in variants)

--- a/kernels/tests/test_variants.py
+++ b/kernels/tests/test_variants.py
@@ -267,7 +267,7 @@ def test_resolve_no_match():
         torch_cxx11_abi=True,
         tvm_ffi_version=None,
     )
-    assert result, trace == []
+    assert result == []
 
 
 RESOLVE_VARIANTS_UNIVERSAL = [

--- a/kernels/tests/test_variants.py
+++ b/kernels/tests/test_variants.py
@@ -4,6 +4,7 @@ from packaging.version import Version
 
 from kernels.backends import CPU, CUDA, ROCm
 from kernels.variants import (
+    VariantAccepted,
     _resolve_variant_for_system,
     get_variants,
     parse_variant,
@@ -139,6 +140,8 @@ def test_resolve_cuda_exact():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cxx11-cu128-x86_64-linux"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_cuda_best_older_minor():
@@ -154,6 +157,8 @@ def test_resolve_cuda_best_older_minor():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cxx11-cu128-x86_64-linux"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_cuda_no_newer_minor():
@@ -169,6 +174,8 @@ def test_resolve_cuda_no_newer_minor():
     )
     assert result != []
     assert result[0].variant_str == "torch-cuda"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_cuda_no_different_major():
@@ -184,6 +191,8 @@ def test_resolve_cuda_no_different_major():
     )
     assert result != []
     assert result[0].variant_str == "torch-cuda"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_rocm():
@@ -198,6 +207,8 @@ def test_resolve_rocm():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cxx11-rocm70-x86_64-linux"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_cpu_linux():
@@ -212,6 +223,8 @@ def test_resolve_cpu_linux():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cxx11-cpu-x86_64-linux"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_cpu_darwin():
@@ -226,6 +239,8 @@ def test_resolve_cpu_darwin():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cpu-aarch64-darwin"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_metal_darwin():
@@ -240,6 +255,8 @@ def test_resolve_metal_darwin():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cpu-aarch64-darwin"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_noarch_fallback():
@@ -255,6 +272,8 @@ def test_resolve_noarch_fallback():
     )
     assert result != []
     assert result[0].variant_str == "torch-cuda"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 def test_resolve_no_match():
@@ -268,6 +287,8 @@ def test_resolve_no_match():
         tvm_ffi_version=None,
     )
     assert result == []
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS)
 
 
 RESOLVE_VARIANTS_UNIVERSAL = [
@@ -292,6 +313,8 @@ def test_resolve_universal_matches_any_backend():
     )
     assert result != []
     assert result[0].variant_str == "torch-universal"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS_UNIVERSAL)
 
 
 def test_resolve_universal_is_last_resort():
@@ -307,6 +330,8 @@ def test_resolve_universal_is_last_resort():
     )
     assert result != []
     assert result[0].variant_str == "torch210-cxx11-cu128-x86_64-linux"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS_UNIVERSAL)
 
 
 def test_resolve_specific_noarch_preferred_over_universal():
@@ -323,6 +348,8 @@ def test_resolve_specific_noarch_preferred_over_universal():
     )
     assert result != []
     assert result[0].variant_str == "torch-cuda"
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(variants)
 
 
 RESOLVE_VARIANTS_NO_NOARCH = [
@@ -347,6 +374,8 @@ def test_resolve_cuda_no_newer_minor_no_noarch():
         tvm_ffi_version=None,
     )
     assert result == []
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS_NO_NOARCH)
 
 
 def test_resolve_cuda_no_different_major_no_noarch():
@@ -361,3 +390,5 @@ def test_resolve_cuda_no_different_major_no_noarch():
         tvm_ffi_version=None,
     )
     assert result == []
+    assert result == [vs.variant for vs in trace if isinstance(vs, VariantAccepted)]
+    assert {vs.variant for vs in trace} == set(RESOLVE_VARIANTS_NO_NOARCH)


### PR DESCRIPTION
We added support for enumerating variants that are compatible with the system. However, this has the issue that it is nearly impossible to make the enumeration exhaustive (e.g. because we have fallback from backend versions) and it is easy to miss variants.

As discussed on Slack, it would be better to instead have an explanation/decision trace on why the available variants were rejected. This PR add such traces and hooks them up in `kernels versions` and some error messages.

Fixes #436.