### PR TITLE
ci: test the kernels on two EL versions

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -61,8 +61,11 @@ jobs:
             silu-and-mul-kernel
 
   test:
-    name: Test kernels
+    name: Test kernels (UBI ${{ matrix.ubi_version }})
     needs: build
+    strategy:
+      matrix:
+        ubi_version: [8, 9]
     runs-on:
       group: aws-g6-12xlarge-plus
     steps:
@@ -77,9 +80,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-            -t kernel-builder:latest \
+            -t kernel-builder:ubi${{ matrix.ubi_version }} \
+            --build-arg UBI_VERSION=${{ matrix.ubi_version }} \
             -f nix-builder/tests/Dockerfile.test-kernel .
 
       - name: Run Tests
         run: |
-          docker run --gpus all kernel-builder:latest
+          docker run --gpus all kernel-builder:ubi${{ matrix.ubi_version }}

--- a/nix-builder/tests/Dockerfile.test-kernel
+++ b/nix-builder/tests/Dockerfile.test-kernel
@@ -15,7 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # Install uv.
-RUN dnf install -y curl && \
+RUN dnf install -y --allowerasing curl && \
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     dnf clean all
 


### PR DESCRIPTION
This ensures that the kernels work across different glibc/libstdc++ versions.