### PR TITLE
feat: implement coverage reporting

### DIFF
--- a/.github/workflows/coverage_comment.yaml
+++ b/.github/workflows/coverage_comment.yaml
@@ -48,8 +48,16 @@ jobs:
             exit 1
           fi
 
+          # Only match comments authored by the GITHUB_TOKEN bot, so a human
+          # comment that happens to start with the marker doesn't get
+          # silently overwritten.
           EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq 'first(.[] | select(.body | startswith("<!-- coverage-report -->")) | .id) // empty')
+            --jq 'first(
+                    .[]
+                    | select(.user.login == "github-actions[bot]"
+                             and (.body | startswith("<!-- coverage-report -->")))
+                    | .id
+                  ) // empty')
 
           # Body comes from the untrusted upstream run; pass via --rawfile +
           # --input - so it's never shell-interpolated.

--- a/.github/workflows/coverage_comment.yaml
+++ b/.github/workflows/coverage_comment.yaml
@@ -1,0 +1,62 @@
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["Test kernels"]
+    types: [completed]
+
+concurrency:
+  group: coverage-comment-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  post:
+    name: Post coverage comment
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: coverage-report
+          path: coverage-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post or update sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # PR number from artifact (not workflow_run.pull_requests, which is
+          # empty for fork PRs).
+          PR_NUMBER=$(cat coverage-artifact/pr_number.txt)
+
+          # Validate: must be a positive integer. Defends against a malicious
+          # PR replacing pr_number.txt with arbitrary content that we'd then
+          # interpolate into a URL.
+          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::pr_number.txt does not contain a valid PR number: ${PR_NUMBER}"
+            exit 1
+          fi
+
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq 'first(.[] | select(.body | startswith("<!-- coverage-report -->")) | .id) // empty')
+
+          # Body comes from the untrusted upstream run; pass via --rawfile +
+          # --input - so it's never shell-interpolated.
+          if [ -n "$EXISTING" ]; then
+            jq -n --rawfile body coverage-artifact/body.md '{body: $body}' \
+              | gh api --method PATCH "repos/${REPO}/issues/comments/${EXISTING}" --input -
+          else
+            jq -n --rawfile body coverage-artifact/body.md '{body: $body}' \
+              | gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
+          fi

--- a/.github/workflows/test_kernels.yaml
+++ b/.github/workflows/test_kernels.yaml
@@ -138,8 +138,8 @@ jobs:
             echo "<!-- coverage-report -->"
             echo "## Coverage report — \`kernels/\`"
             echo
-            echo "> Measured on the canonical matrix cell: **Python ${PY_VERSION} / Torch ${TORCH_VERSION}**."
-            echo "> Other matrix cells are not included in this number."
+            echo "> Measured on: **Python ${PY_VERSION} / Torch ${TORCH_VERSION}**."
+            echo "> Other CI configurations are not included in this number."
             echo "> Hardware-gated code paths (ROCm/XPU/NPU/Darwin/Windows) are excluded or unreachable on the Linux+CUDA runner."
             echo
             echo "**Total coverage: \`${PCT_DISPLAY}%\`** — threshold: 80% — ${EMOJI}"

--- a/.github/workflows/test_kernels.yaml
+++ b/.github/workflows/test_kernels.yaml
@@ -31,6 +31,7 @@ jobs:
 
     env:
       UV_PYTHON_PREFERENCE: only-managed
+      COVERAGE_CELL: ${{ matrix.python-version == '3.10' && matrix.torch-version == '2.12.0' }}
 
     steps:
       - name: Checkout code
@@ -66,7 +67,14 @@ jobs:
         env:
           HF_HUB_DOWNLOAD_TIMEOUT: 60
         run: |
-          uv run pytest tests
+          if [ "${COVERAGE_CELL}" = "true" ]; then
+            uv run pytest tests \
+              --cov=kernels \
+              --cov-report=term-missing \
+              --cov-report=json:coverage.json
+          else
+            uv run pytest tests
+          fi
 
       - name: Re-run dependency test with dependencies installed
         working-directory: ./kernels
@@ -98,3 +106,63 @@ jobs:
         run: |
           uv run kernels check kernels-community/activation
           uv run kernels versions kernels-community/activation
+
+      # This is done to securely run the coverage test and to post comments even
+      # on fork PRs.
+      - name: Render coverage report for PR comment
+        if: env.COVERAGE_CELL == 'true' && github.event_name == 'pull_request'
+        working-directory: ./kernels
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PY_VERSION: ${{ matrix.python-version }}
+          TORCH_VERSION: ${{ matrix.torch-version }}
+        run: |
+          set -euo pipefail
+          mkdir -p coverage-artifact
+
+          PCT=$(jq -r '.totals.percent_covered' coverage.json)
+          PCT_INT=$(printf '%.0f' "$PCT")
+          PCT_DISPLAY=$(printf '%.1f' "$PCT")
+          if [ "$PCT_INT" -ge 80 ]; then
+            EMOJI=":white_check_mark:"
+          elif [ "$PCT_INT" -ge 70 ]; then
+            EMOJI=":warning:"
+          else
+            EMOJI=":red_circle:"
+          fi
+
+          uv run coverage report --format=markdown > coverage-artifact/cov-table.md
+
+          {
+            echo "<!-- coverage-report -->"
+            echo "## Coverage report — \`kernels/\`"
+            echo
+            echo "> Measured on the canonical matrix cell: **Python ${PY_VERSION} / Torch ${TORCH_VERSION}**."
+            echo "> Other matrix cells are not included in this number."
+            echo "> Hardware-gated code paths (ROCm/XPU/NPU/Darwin/Windows) are excluded or unreachable on the Linux+CUDA runner."
+            echo
+            echo "**Total coverage: \`${PCT_DISPLAY}%\`** — threshold: 80% — ${EMOJI}"
+            echo
+            echo "<details>"
+            echo "<summary>Per-file breakdown</summary>"
+            echo
+            cat coverage-artifact/cov-table.md
+            echo
+            echo "</details>"
+            echo
+            echo "_Updated by the \`Test kernels\` workflow on commit \`${HEAD_SHA}\`._"
+          } > coverage-artifact/body.md
+
+          # `workflow_run.pull_requests` is empty for fork PRs, so the
+          # downstream comment workflow reads the PR number from here.
+          echo "${PR_NUMBER}" > coverage-artifact/pr_number.txt
+
+      - name: Upload coverage artifact
+        if: env.COVERAGE_CELL == 'true' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: coverage-report
+          path: kernels/coverage-artifact/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/test_kernels.yaml
+++ b/.github/workflows/test_kernels.yaml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       UV_PYTHON_PREFERENCE: only-managed
-      COVERAGE_CELL: ${{ matrix.python-version == '3.10' && matrix.torch-version == '2.12.0' }}
+      CHECK_COVERAGE: ${{ matrix.python-version == '3.10' && matrix.torch-version == '2.12.0' }}
 
     steps:
       - name: Checkout code
@@ -67,7 +67,7 @@ jobs:
         env:
           HF_HUB_DOWNLOAD_TIMEOUT: 60
         run: |
-          if [ "${COVERAGE_CELL}" = "true" ]; then
+          if [ "${CHECK_COVERAGE}" = "true" ]; then
             uv run pytest tests \
               --cov=kernels \
               --cov-report=term-missing \
@@ -110,7 +110,7 @@ jobs:
       # This is done to securely run the coverage test and to post comments even
       # on fork PRs.
       - name: Render coverage report for PR comment
-        if: env.COVERAGE_CELL == 'true' && github.event_name == 'pull_request'
+        if: env.CHECK_COVERAGE == 'true' && github.event_name == 'pull_request'
         working-directory: ./kernels
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -159,7 +159,7 @@ jobs:
           echo "${PR_NUMBER}" > coverage-artifact/pr_number.txt
 
       - name: Upload coverage artifact
-        if: env.COVERAGE_CELL == 'true' && github.event_name == 'pull_request'
+        if: env.CHECK_COVERAGE == 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-report

--- a/kernels/README.md
+++ b/kernels/README.md
@@ -48,3 +48,13 @@ the Hub.
 ## 📚 Documentation
 
 Read the [documentation of kernels](https://huggingface.co/docs/kernels/).
+
+## Test coverage
+
+To reproduce the coverage number reported on PRs locally:
+
+```bash
+uv run pytest --cov=kernels --cov-report=term-missing tests
+```
+
+CI measures coverage on a single canonical matrix cell (Python 3.10 / Torch 2.12.0) and posts a sticky comment on the PR; the threshold is 80% (warn-only — the check stays green either way).

--- a/kernels/pyproject.toml
+++ b/kernels/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
   "pytest>=8",
   # Whatever version is compatible with pytest.
   "pytest-benchmark",
+  "pytest-cov>=5",
   "torch>=2.5",
   "apache-tvm-ffi>=0.1.9,<0.2.0",
   "types-pyyaml",
@@ -89,3 +90,18 @@ lint.ignore = ["E501"]
 lint.select = ["E", "F", "I", "W"]
 
 [tool.ruff.format]
+
+[tool.coverage.run]
+source = ["kernels"]
+branch = false
+relative_files = true
+omit = [
+  "*/benchmarks/*",
+  "*/benchmark.py",
+  "*/cli/*",
+  "*/_windows.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true


### PR DESCRIPTION
Some in-line comments.

Should we also run coverage on `main` pushes and keep a status on README? I think we don't need it. Open to suggestions.