### PR TITLE
doc updates

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,12 +17,12 @@
       title: Locking Kernel Versions
     - local: env
       title: Environment Variables
-    - local: faq
-      title: FAQ
     - local: migration
       title: Migrating from older versions
     - local: integrating-kernels
       title: Integrating kernels into a project
+    - local: faq
+      title: FAQ
   title: Using kernels
 - sections:
     - local: builder/writing-kernels

--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -45,8 +45,8 @@ print(f"Kernel available: {is_available}")
 
 ## Inspecting Loaded Kernels
 
-`get_loaded_kernels()` returns a snapshot of every kernel that has been loaded
-into the current process. Each entry is a `LoadedKernel` namedtuple with the
+[`~kernels.get_loaded_kernels`] returns a snapshot of every kernel that has been loaded
+into the current process. Each entry is a [`~kernels.LoadedKernel`] namedtuple with the
 imported `module`, the `package_name`, and `repo_infos` (repo id, resolved
 revision, and the backend argument that was passed).
 
@@ -59,10 +59,10 @@ for loaded in get_loaded_kernels():
     print(loaded.package_name, loaded.repo_infos)
 ```
 
-`repo_infos` is populated only for kernels loaded with `get_kernel`. Kernels
-loaded from a local path (`get_local_kernel`) or via a lockfile
-(`get_locked_kernel`, `load_kernel`) have `repo_infos=None`.
+`repo_infos` is populated only for kernels loaded with [`~kernels.get_kernel`]. Kernels
+loaded from a local path ([`~kernels.get_local_kernel`]) or via a lockfile
+([`~kernels.get_locked_kernel`], [`~kernels.load_kernel`]) have `repo_infos=None`.
 
 Browse through different kernels compatible with `kernels` from [here](https://huggingface.co/kernels).
 
-A kernel can provide layers in addition to kernel functions. Refer to [Layers](../source/layers.md) to know more.
+A kernel can provide layers in addition to kernel functions. Refer to [Layers](./layers.md) to know more.

--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -35,6 +35,11 @@ as the running example. After reading this page, you may also want to have
 a look at the more realistic [ReLU kernel with backprop and `torch.compile`](https://github.com/huggingface/kernels/tree/main/examples/kernels/relu-backprop-compile)
 support.
 
+> [!TIP]
+> We maintain a set of conforming kernels in the
+> [kernels-community repository](https://github.com/huggingface/kernels-community).
+> We try to keep these kernels synced with upstream as much as possible.
+
 ## Setting up environment
 
 ### Quick install

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -6,13 +6,10 @@ The `kernels` CLI provides commands for managing compute kernels.
 
 | Command                                                 | Description                                              |
 | ------------------------------------------------------- | -------------------------------------------------------- |
-| [upload](cli-upload.md)                                 | Upload kernels to the Hub                                |
 | [benchmark](cli-benchmark.md)                           | Run benchmark results for a kernel                       |
 | [check](cli-check.md)                                   | Check a kernel for compliance                            |
 | [versions](cli-versions.md)                             | Show kernel versions                                     |
 | [lock](cli-lock.md)                                     | Lock kernel revisions                                    |
-| [download](cli-download.md)                             | Download locked kernels                                  |
-| [skills](cli-skills-add.md)                             | Add skills for AI coding assistants                      |
 
 ## Quick Start
 

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -5,14 +5,14 @@
 ### Why is the kernelization step needed as a separate step?
 
 In earlier versions of `kernels`, a layer's `forward` method was replaced
-by `use_kernel_forward_from_hub` and `replace_kernel_forward_from_hub`.
+by [`~kernels.use_kernel_forward_from_hub`] and [`~kernels.replace_kernel_forward_from_hub`].
 The new `forward` would dispatch to a kernel based on the device type,
 whether a model was training, etc. However, this approach was
 fundamentally incompatible with `torch.compile` since it relied
 on data-dependent branching.
 
 To avoid branching, we have to make dispatch decisions ahead of time,
-which is what the `kernelize` function does.
+which is what the [`~kernels.kernelize`] function does.
 
 ### Why does kernelization only replace `forward` methods?
 
@@ -23,13 +23,13 @@ that layers are fully compatible with the layers that they are
 replacing. For instance, they could have completely different member
 variables. Besides that, we would also need to hold on to the original
 layers, in case we need to revert to the base layers when the model
-is `kernelize`d again with different options.
+is [`~kernels.kernelize`]d again with different options.
 
 A second approach would be to make an auxiliary layer that wraps the
 original layer and the kernel layer and dispatches to the kernel layer.
 This wouldn't have the issues of the first approach, because kernel layers
 could be similarly strict as they are now, and we would still have access
-to the original layers when `kernelize`-ing the model again. However,
+to the original layers when [`~kernels.kernelize`]-ing the model again. However,
 this would change the graph structure of the model and would break use
 cases where programs access the model internals (e.g.
 `model.layers[0].attention.query_weight`) or rely on the graph structure
@@ -44,7 +44,7 @@ the corresponding class still has the original `forward`.
 
 ### How can I disable kernel reporting in the user-agent?
 
-By default, we collect telemetry when a call to `get_kernel()` is made.
+By default, we collect telemetry when a call to [`~kernels.get_kernel`] is made.
 This only includes the `kernels` version, `torch` version, and the build
 information for the kernel being requested.
 

--- a/docs/source/integrating-kernels.md
+++ b/docs/source/integrating-kernels.md
@@ -5,7 +5,7 @@ This page shows how different projects use `kernels`.
 ## autoresearch
 
 [karpathy/autoresearch](https://github.com/karpathy/autoresearch) [uses](https://github.com/karpathy/autoresearch/blob/c2450add72cc80317be1fe8111974b892da10944/train.py#L23) `kernels` to
-integrate Flash-Attention 3 through the `get_kernes()` method.
+integrate Flash-Attention 3 through the [`~kernels.get_kernel`] method.
 
 ## AReaL
 
@@ -17,7 +17,7 @@ optimized attention mechanisms.
 [huggingface/transformers](https://github.com/huggingface/transformers/) primarily
 depends on `kernels` for all optimizations related to optimized kernels, including
 optimized attention implementations, MoE blocks, and quantization. Besides
-`get_kernel()`, it also uses [kernel layers](./layers.md) to optimize the forward passes
+[`~kernels.get_kernel`], it also uses [kernel layers](./layers.md) to optimize the forward passes
 of common layers involved in the modeling blocks. Some references are available
 [here](<https://github.com/search?q=repo%3Ahuggingface%2Ftransformers%20get_kernel(&type=code>)
 and [here](https://github.com/search?q=repo%3Ahuggingface%2Ftransformers+use_kernel_forward_from_hub&type=code).
@@ -38,3 +38,6 @@ kernels on the Hugging Face Hub platform. This is made possible by the
 ["builder" component of `kernels`](./builder/writing-kernels.md).
 Visit [huggingface.co/kernels](https://huggingface.co/kernels) to browse
 the pre-built compute kernels available on the Hub.
+
+Feel free to open a PR enlisting your project to show how `kernels`
+is leveraged there.

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -12,7 +12,7 @@ requirements of Hub layers.
 
 ### Using a decorator
 
-A layer can be made extensible with the `use_kernel_forward_from_hub`
+A layer can be made extensible with the [`~kernels.use_kernel_forward_from_hub`]
 decorator. For example:
 
 ```python
@@ -24,13 +24,13 @@ class SiluAndMul(nn.Module):
 ```
 
 The decorator does not change the behavior of the class -- it annotates
-the class with the given name (here `SiluAndMul`). The `kernelize` function
+the class with the given name (here `SiluAndMul`). The [`~kernels.kernelize`] function
 described below uses this name to look up kernels for the layer.
 
 ### External layers
 
-An existing layer that does not (yet) have the `use_kernel_forward_from_hub`
-decorator can be made extensible using the `replace_kernel_forward_from_hub`
+An existing layer that does not (yet) have the [`~kernels.use_kernel_forward_from_hub`]
+decorator can be made extensible using the [`~kernels.replace_kernel_forward_from_hub`]
 function:
 
 ```python
@@ -47,7 +47,7 @@ compatible with layers from the hub.
 
 Sometimes it can be useful to make a function extensible, for example
 because the function cannot be replaced by a layer. In such cases, you
-can annotate the function with the `use_kernel_func_from_hub` decorator:
+can annotate the function with the [`~kernels.use_kernel_func_from_hub`] decorator:
 
 ```python
 @use_kernel_func_from_hub("silu_and_mul")
@@ -77,18 +77,18 @@ class FeedForward(nn.Module):
 
 A model will not use Hub kernels by default, even if it contains extensible
 layers. To enable the use of Hub kernels in the model, it needs to be
-'kernelized' using the `kernelize` function. This function traverses the
+'kernelized' using the [`~kernels.kernelize`] function. This function traverses the
 model graph and replaces the `forward` methods of extensible layers for which
-Hub kernels are registered. `kernelize` can be used as follows:
+Hub kernels are registered. [`~kernels.kernelize`] can be used as follows:
 
 ```python
 model = MyModel(...)
 model = kernelize(model, mode=Mode.INFERENCE)
 ```
 
-The `kernelize` function modifies the model in-place, the model itself is
+The [`~kernels.kernelize`] function modifies the model in-place, the model itself is
 returned as a convenience. The `mode` specifies that the model will be used
-in inference. Similarly, you can ask `kernelize` to prepare the model for
+in inference. Similarly, you can ask [`~kernels.kernelize`] to prepare the model for
 training:
 
 ```python
@@ -98,7 +98,7 @@ model = kernelize(model, mode=Mode.TRAINING)
 
 A model that is kernelized for training can also be used for inference, but
 not the other way around. If you want to change the mode of the kernelized
-model, you can just run `kernelize` on the model again with the new mode.
+model, you can just run [`~kernels.kernelize`] on the model again with the new mode.
 
 If you want to compile a model with `torch.compile`, this should be indicated
 in the mode as well. You can do this by combining `Mode.INFERENCE` or
@@ -118,8 +118,8 @@ model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE)
 
 Kernels can be registered per device type. For instance, separate `cuda` and
 `metal` kernels could be registered for the name `SiluAndMul`. By default,
-`kernelize` will try to infer the device type from the model's parameters.
-You can pass the device type to `kernelize` if the device type cannot be
+[`~kernels.kernelize`] will try to infer the device type from the model's parameters.
+You can pass the device type to [`~kernels.kernelize`] if the device type cannot be
 inferred (e.g. because the model has no parameters):
 
 ```python
@@ -131,8 +131,8 @@ model = kernelize(model, device="cuda", mode=Mode.INFERENCE)
 
 If the `TRAINING` and/or `TORCH_COMPILE` modes are used, but a registered
 kernel does not support backward passes or `torch.compile` respectively,
-`kernelize` will fall back to the original, non-kernelized, layer. You
-can let `kernelize` raise an exception instead by using `use_fallback=False`:
+[`~kernels.kernelize`] will fall back to the original, non-kernelized, layer. You
+can let [`~kernels.kernelize`] raise an exception instead by using `use_fallback=False`:
 
 ```python
 model = MyModel(...)
@@ -143,13 +143,13 @@ This can be useful if you want to guarantee that Hub kernels are used.
 
 ### Inspecting which kernels are used
 
-The kernels that are used are logged at the `INFO` level by `kernelize`.
+The kernels that are used are logged at the `INFO` level by [`~kernels.kernelize`].
 See the [Python logging](https://docs.python.org/3/library/logging.html)
 documentation for information on how to configure logging.
 
 ## Registering a hub kernel for a layer
 
-`kernelize` relies on kernel mappings to find Hub kernels for layers.
+[`~kernels.kernelize`] relies on kernel mappings to find Hub kernels for layers.
 Kernel mappings map a kernel name such as `SiluAndMul` to a kernel on
 the Hub. For example:
 
@@ -177,10 +177,10 @@ will get the latest kernel build from the `v1` branch. Kernel layers
 within a version branch must never break the API or remove builds for
 older PyTorch versions. This ensures that your code will continue to
 work.
-Hub-backed `LayerRepository` and `FuncRepository` entries must specify
+Hub-backed [`~kernels.LayerRepository`] and [`~kernels.FuncRepository`] entries must specify
 either a `version` or an explicit `revision`.
 
-You can register a mapping, like the one above, using `register_kernel_mapping`:
+You can register a mapping, like the one above, using [`~kernels.register_kernel_mapping`]:
 
 ```python
 register_kernel_mapping(kernel_layer_mapping)
@@ -188,7 +188,7 @@ register_kernel_mapping(kernel_layer_mapping)
 
 This will register the kernel mapping in the current context, which is
 normally global. It is recommended to scope the mapping to where it is
-used with the `use_kernel_mapping` context manager:
+used with the [`~kernels.use_kernel_mapping`] context manager:
 
 ```python
 with use_kernel_mapping(kernel_layer_mapping):
@@ -201,7 +201,7 @@ This ensures that the mapping is not active anymore outside the
 
 If the layer is stateless (it does not use member variables in its forward _or_ it was
 originally a function that was converted into a kernel layer with
-`use_kernel_func_from_hub`), it can also be mapped to a kernel function:
+[`~kernels.use_kernel_func_from_hub`]), it can also be mapped to a kernel function:
 
 ```python
 kernel_layer_mapping = {
@@ -240,7 +240,7 @@ kernel_layer_mapping = {
 }
 ```
 
-The `kernelize` function will attempt to use the following registered
+The [`~kernels.kernelize`] function will attempt to use the following registered
 kernels for a given mode:
 
 - `INFERENCE`: `INFERENCE` → `INFERENCE | TORCH_COMPILE` → `TRAINING` →
@@ -287,7 +287,7 @@ since the other kernels do not support `torch.compile`.
 Some kernels only work with newer CUDA architectures. For instance, some
 kernels require capability 9.0 for the TMA unit on Hopper GPUs. `kernels`
 supports registering layers for a range of CUDA capabilities. To do so,
-you need to register the layer for a `Device` with type `cuda` and
+you need to register the layer for a [`~kernels.Device`] with type `cuda` and
 set the supported range of CUDA capabilities with using `CUDAProperties`:
 
 ```python
@@ -326,7 +326,7 @@ Capabilities behave as follows:
   with the smaller capability interval will be used. E.g. given:
   - `KernelA` with `min_capability=80` and `max_capability=89`;
   - `KernelB` with `min_capability=75` and `max_capability=89`;
-  - `kernelize` runs on a system with capability 8.6.
+  - [`~kernels.kernelize`] runs on a system with capability 8.6.
 
   Then `KernelA` will be used because the interval 80..89 is smaller
   than 75..89. The motivation is that kernels with smaller ranges
@@ -341,7 +341,7 @@ a kernel to a range of ROCm capabilities.
 
 ### Loading from a local repository for testing
 
-The `LocalLayerRepository` class is provided to load a repository from
+The [`~kernels.LocalLayerRepository`] class is provided to load a repository from
 a local directory. For example:
 
 ```python
@@ -360,7 +360,7 @@ with use_kernel_mapping(
     kernelize(linear, mode=Mode.INFERENCE)
 ```
 
-Similarly, the `LocalFuncRepository` class can be used to load a kernel
+Similarly, the [`~kernels.LocalFuncRepository`] class can be used to load a kernel
 function from a local directory:
 
 ```python

--- a/docs/source/locking.md
+++ b/docs/source/locking.md
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 Then run `kernels lock .` in the project directory. This generates a `kernels.lock` file with
 the locked revisions. The locked revision will be used when loading a kernel with
-`get_locked_kernel`:
+[`~kernels.get_locked_kernel`]:
 
 ```python
 from kernels import get_locked_kernel
@@ -29,7 +29,7 @@ to `kernels` after doing an (editable or regular) installation of your project.
 ## Locked kernel layers
 
 Locking is also supported for kernel layers. To use locked layers, register them
-with the `LockedLayerRepository` class:
+with the [`~kernels.LockedLayerRepository`] class:
 
 ```python
 kernel_layer_mapping = {
@@ -44,7 +44,7 @@ kernel_layer_mapping = {
 register_kernel_mapping(kernel_layer_mapping)
 ```
 
-Similarly, you can use the `LockedFuncRepository` class to lock kernel function
+Similarly, you can use the [`~kernels.LockedFuncRepository`] class to lock kernel function
 versions:
 
 ```python
@@ -66,10 +66,10 @@ Locked kernels can be pre-downloaded by running `kernels download .` in your
 project directory. This will download the kernels to your local Hugging Face
 Hub cache.
 
-The pre-downloaded kernels are used by the `get_locked_kernel` function.
-`get_locked_kernel` will download a kernel when it is not pre-downloaded. If you
+The pre-downloaded kernels are used by the [`~kernels.get_locked_kernel`] function.
+[`~kernels.get_locked_kernel`] will download a kernel when it is not pre-downloaded. If you
 want kernel loading to error when a kernel is not pre-downloaded, you can use
-the `load_kernel` function instead:
+the [`~kernels.load_kernel`] function instead:
 
 ```python
 from kernels import load_kernel

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -89,5 +89,5 @@ To migrate an existing `model`-type kernel repository:
    repository. Either keep the same `repo-id` in `build.toml` if the
    repository has been migrated to the new type, or point it at a newly
    created `kernel`-type repository.
-3. Update consumers' `get_kernel(...)` and `LayerRepository(...)` calls
+3. Update consumers' [`~kernels.get_kernel`] and [`~kernels.LayerRepository`] calls
    to reference the new repository if the `repo-id` changed.


### PR DESCRIPTION
* Hyperlink API references better: `get_kernel()` should be [`~kernels.get_kernel`] so that it renders the links appropriately. Applied to all the relevant classes and methods.
* Add a mention of https://github.com/huggingface/kernels-community in the writing kernels guide for better visibility.
* Misc typos.