### PR TITLE
[ci] optimize ci runtime ⚡️

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/build_kernel.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/build_kernel.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/build_kernel_macos.yaml
+++ b/.github/workflows/build_kernel_macos.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/build_kernel_macos.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/build_kernel_macos.yaml
+++ b/.github/workflows/build_kernel_macos.yaml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/build_kernel_macos.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/build_kernel_rocm.yaml
+++ b/.github/workflows/build_kernel_rocm.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/build_kernel_rocm.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/build_kernel_rocm.yaml
+++ b/.github/workflows/build_kernel_rocm.yaml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/build_kernel_rocm.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/build_kernel_windows.yaml
+++ b/.github/workflows/build_kernel_windows.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/build_kernel_windows.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/build_kernel_windows.yaml
+++ b/.github/workflows/build_kernel_windows.yaml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/build_kernel_windows.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/build_kernel_xpu.yaml
+++ b/.github/workflows/build_kernel_xpu.yaml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/build_kernel_xpu.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/build_kernel_xpu.yaml
+++ b/.github/workflows/build_kernel_xpu.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/build_kernel_xpu.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/check_variants.yaml
+++ b/.github/workflows/check_variants.yaml
@@ -7,8 +7,8 @@ on:
     types: [opened, synchronize, reopened] # trigger on PRs
     paths:
       - "nix-builder/**"
-      - "flake.nix"
-      - "flake.lock"
+      - "**/*.nix"
+      - "**/flake.lock"
       - "docs/source/builder/build-variants.md"
       - ".github/workflows/check_variants.yaml"
   workflow_dispatch:

--- a/.github/workflows/check_variants.yaml
+++ b/.github/workflows/check_variants.yaml
@@ -5,10 +5,17 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "docs/source/builder/build-variants.md"
+      - ".github/workflows/check_variants.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/kernel-builder-cli-docs.yaml
+++ b/.github/workflows/kernel-builder-cli-docs.yaml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-cli-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/kernel_abi_python_release.yaml
+++ b/.github/workflows/kernel_abi_python_release.yaml
@@ -21,7 +21,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Hardcoded prefix because this workflow shares `name: CI` with
+  # kernels_data_python_release.yaml; ${{ github.workflow }} would
+  # otherwise collide and cancel the sibling workflow's run.
+  group: kernel-abi-python-release-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/kernel_abi_python_release.yaml
+++ b/.github/workflows/kernel_abi_python_release.yaml
@@ -13,10 +13,16 @@ on:
     tags:
       - "*"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernel-abi-check/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/kernel_abi_python_release.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/kernels_data_python_release.yaml
+++ b/.github/workflows/kernels_data_python_release.yaml
@@ -7,7 +7,9 @@
 #  - manifest paths made relative
 #  - publish step switched from `uv publish` + API token to
 #    `PyO3/maturin-action` + PyPI trusted publishing (see plan.md §3a, §3b)
-#  - pull_request trigger gained `paths-ignore` for docs-only PRs
+#  - pull_request trigger scoped to kernels-data/** and Cargo.{toml,lock}
+#    so unrelated PRs don't trigger the full wheel matrix
+#  - added concurrency cancellation for in-progress PR builds
 name: CI
 
 on:
@@ -18,10 +20,16 @@ on:
     tags:
       - "*"
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernels-data/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/kernels_data_python_release.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/kernels_data_python_release.yaml
+++ b/.github/workflows/kernels_data_python_release.yaml
@@ -28,7 +28,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Hardcoded prefix because this workflow shares `name: CI` with
+  # kernel_abi_python_release.yaml; ${{ github.workflow }} would
+  # otherwise collide and cancel the sibling workflow's run.
+  group: kernels-data-python-release-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,16 @@
 name: Lints
 on:
   push:
+    branches: [main]
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernels/**"
+      - "kernels-data/src/python_dependencies.json"
+      - ".github/workflows/lint.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   RUFF_VERSION: "0.15.10"

--- a/.github/workflows/nix_checks.yml
+++ b/.github/workflows/nix_checks.yml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "default.nix"
+      - ".github/workflows/nix_checks.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/nix_checks.yml
+++ b/.github/workflows/nix_checks.yml
@@ -9,9 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "default.nix"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/nix_checks.yml"
   workflow_dispatch:
 

--- a/.github/workflows/publish_kernels.yml
+++ b/.github/workflows/publish_kernels.yml
@@ -1,6 +1,10 @@
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches: [main]
+    tags:
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,10 +2,19 @@ name: Rust
 
 on:
   push:
+    branches: [main]
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernel-abi-check/**"
+      - "kernels-data/**"
+      - "kernel-builder/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/rust.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   fmt:
@@ -41,6 +50,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: clippy
@@ -69,6 +80,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - name: Test (kernel-abi-check)
         run: cargo test -p kernel-abi-check

--- a/.github/workflows/test_extra_commands.yaml
+++ b/.github/workflows/test_extra_commands.yaml
@@ -5,10 +5,18 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "nix-builder/**"
+      - "kernel-builder/**"
+      - "examples/kernels/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/test_extra_commands.yaml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/test_extra_commands.yaml
+++ b/.github/workflows/test_extra_commands.yaml
@@ -9,8 +9,8 @@ on:
       - "nix-builder/**"
       - "kernel-builder/**"
       - "examples/kernels/**"
-      - "flake.nix"
-      - "flake.lock"
+      - "**/*.nix"
+      - "**/flake.lock"
       - ".github/workflows/test_extra_commands.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/test_kernels.yaml
+++ b/.github/workflows/test_kernels.yaml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernels/**"
+      - "kernels-data/bindings/python/**"
+      - "kernel-abi-check/bindings/python/**"
+      - ".github/workflows/test_kernels.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -16,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Run kernels tests
+  gpu-tests:
+    name: GPU tests
     runs-on:
       group: aws-g6-24xlarge
     permissions:
@@ -57,10 +59,6 @@ jobs:
         working-directory: ./kernels
         run: uv pip install setuptools
 
-      - name: Check typing
-        working-directory: ./kernels
-        run: uv run mypy src/kernels
-
       - name: Run tests
         working-directory: ./kernels
         env:
@@ -75,6 +73,34 @@ jobs:
         run: |
           uv pip install einops nvidia-cutlass-dsl
           uv run pytest tests/test_deps.py
+
+  cpu-checks:
+    name: CPU checks (mypy, no-torch import, CLI)
+    runs-on: ubuntu-latest
+
+    env:
+      UV_PYTHON_PREFERENCE: only-managed
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Override kernels-data source to local bindings
+        working-directory: ./kernels
+        run: uv add ../kernels-data/bindings/python --no-sync
+
+      - name: Install the project
+        working-directory: ./kernels
+        run: uv sync --all-extras --dev
+
+      - name: Check typing
+        working-directory: ./kernels
+        run: uv run mypy src/kernels
 
       - name: Check kernel check
         working-directory: ./kernels

--- a/.github/workflows/test_kernels.yaml
+++ b/.github/workflows/test_kernels.yaml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gpu-tests:
-    name: GPU tests
+  build:
+    name: Run kernels tests
     runs-on:
       group: aws-g6-24xlarge
     permissions:
@@ -59,6 +59,10 @@ jobs:
         working-directory: ./kernels
         run: uv pip install setuptools
 
+      - name: Check typing
+        working-directory: ./kernels
+        run: uv run mypy src/kernels
+
       - name: Run tests
         working-directory: ./kernels
         env:
@@ -73,34 +77,6 @@ jobs:
         run: |
           uv pip install einops nvidia-cutlass-dsl
           uv run pytest tests/test_deps.py
-
-  cpu-checks:
-    name: CPU checks (mypy, no-torch import, CLI)
-    runs-on: ubuntu-latest
-
-    env:
-      UV_PYTHON_PREFERENCE: only-managed
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          python-version: "3.12"
-
-      - name: Override kernels-data source to local bindings
-        working-directory: ./kernels
-        run: uv add ../kernels-data/bindings/python --no-sync
-
-      - name: Install the project
-        working-directory: ./kernels
-        run: uv sync --all-extras --dev
-
-      - name: Check typing
-        working-directory: ./kernels
-        run: uv run mypy src/kernels
 
       - name: Check kernel check
         working-directory: ./kernels

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -6,9 +6,10 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened] # trigger on PRs
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
+    paths:
+      - "kernel-abi-check/**"
+      - "kernels-data/**"
+      - ".github/workflows/test_python.yaml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Most workflows trigger on every PR that touches anything outside `docs/**` and `*.md`. 

For example, on [#583](https://github.com/huggingface/kernels/pull/583), for small changes w.r.t `ruff` in `.pre-commit-config.yaml` and `Makefile` triggered ~50 CI jobs. This is not desirable. An unnecessarily long CI is probably not the best use of the resources configured for our CI and also generally, not a good developer/contribution experience.

To put things in numbers and perspective (with the help of Claude):

| Job (ran on #583) | Runtime | Could the diff affect it? |
|---|---|---|
| Build kernel (windows-2022, py3.12, torch 2.9.1) | 32m 47s | no |
| Test kernels (UBI 8) — Docker GPU | 7m 40s | no |
| Test kernels (UBI 9) — Docker GPU | 7m 40s | no |
| Build kernels (x86_64-linux) — Nix | 4m 44s | no |
| Build kernels (aarch64-linux) — Nix | 3m 23s | no |
| Build kernel (ROCm) | 8m 58s | no |
| Build kernel (XPU) | 8m 0s | no |
| Build kernel (macOS / Nix) | 4m 4s | no |
| Nix checks | 4m 22s | no |
| `kernel_abi_python_release` wheel matrix (linux × 6 arches, musllinux × 4, win × 3, mac × 2, sdist) | ~3 min × 16 | no |
| `kernels_data_python_release` wheel matrix (same shape) | ~3 min × 16 | no |
| Run kernels tests on `aws-g6-24xlarge` (GPU) × 4 matrix combos | ~2 min × 4 | no |
| Rust fmt/clippy/test × 3 crates | ~3 min total | no |
| Check build variants | 33s | no |
| Check API compatibility / griffe | ~10s | no |
| Run lints (ruff) | 5s | **yes** |

This PR tries to optimize our CI _without_ breaking robustness and reliability.

---

## Major changes

* For each workflow, declare the **set of paths whose changes can affect this workflow's outcome**. Anything else is skipped on PRs and should be safe enough that way.
* No changes to the workflows that are triggered when pushing to `main`. 
* Add concurrency groups. Several workflows (`test_kernels.yaml`, `test_python.yaml`, etc.) still lack concurrency groups. When a contributor force-pushes a PR, the previous run keeps consuming runners.
* Other changes are commented in-line.

After this PR, we should expect to see good amount of reductions in the CI runtimes where relevant.