### PR TITLE
feat: implement get-kernel-variants

### DIFF
--- a/docs/source/api/kernels.md
+++ b/docs/source/api/kernels.md
@@ -14,6 +14,10 @@
 
 [[autodoc]] kernels.has_kernel
 
+### get_kernel_variants
+
+[[autodoc]] kernels.get_kernel_variants
+
 ### get_loaded_kernels
 
 [[autodoc]] kernels.get_loaded_kernels

--- a/docs/source/basic-usage.md
+++ b/docs/source/basic-usage.md
@@ -43,6 +43,23 @@ is_available = has_kernel("kernels-community/activation", version=1)
 print(f"Kernel available: {is_available}")
 ```
 
+When no compatible kernel is found, [`~kernels.has_kernel`] does not say *why*.
+[`~kernels.get_kernel_variants`] returns the full resolution trace instead: one
+decision per build variant in the repository, with compatible variants listed
+first. Each decision is a `VariantAccepted` or a `VariantRejected`, and rejected
+variants carry a human-readable `reason`:
+
+```python
+from kernels import get_kernel_variants, VariantAccepted
+
+for decision in get_kernel_variants("kernels-community/activation", version=1):
+    name = decision.variant.variant_str
+    if isinstance(decision, VariantAccepted):
+        print(f"{name}: compatible")
+    else:
+        print(f"{name}: rejected ({decision.reason})")
+```
+
 ## Inspecting Loaded Kernels
 
 [`~kernels.get_loaded_kernels`] returns a snapshot of every kernel that has been loaded

--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -28,12 +28,17 @@ from kernels.utils import (
     LoadedKernel,
     RepoInfo,
     get_kernel,
+    get_kernel_variants,
     get_loaded_kernels,
     get_local_kernel,
     get_locked_kernel,
     has_kernel,
     install_kernel,
     load_kernel,
+)
+from kernels.variants import (
+    VariantAccepted,
+    VariantRejected,
 )
 
 _add_additional_dll_paths()
@@ -54,7 +59,10 @@ __all__ = [
     "Metadata",
     "Mode",
     "RepoInfo",
+    "VariantAccepted",
+    "VariantRejected",
     "get_kernel",
+    "get_kernel_variants",
     "get_loaded_kernels",
     "get_local_kernel",
     "get_locked_kernel",

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -25,10 +25,12 @@ from kernels.deps import validate_dependencies
 from kernels.lockfile import KernelLock, VariantLock
 from kernels.status import resolve_status
 from kernels.variants import (
+    Decision,
     Variant,
     get_variants,
     get_variants_local,
     resolve_variant,
+    resolve_variants,
     variants_trace_str,
 )
 
@@ -550,6 +552,42 @@ def has_kernel(
         revision=revision,
         filename=f"build/{variant.variant_str}/metadata.json",
     )
+
+
+def get_kernel_variants(
+    repo_id: str,
+    revision: str | None = None,
+    version: int | None = None,
+    backend: str | None = None,
+) -> list[Decision]:
+    """
+    Resolve all build variants of a kernel against the current environment.
+
+    The decisions are sorted with compatible variants first, the most preferred
+    variant leading.
+
+    Args:
+        repo_id (`str`):
+            The Hub repository containing the kernel.
+        revision (`str`, *optional*):
+            The specific revision (branch, tag, or commit) to inspect. Cannot be used together with `version`.
+        version (`int`, *optional*):
+            The kernel version to inspect. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
+        backend (`str`, *optional*):
+            The backend to resolve variants for. Can only be `cpu` or the backend that Torch is compiled for.
+            The backend will be detected automatically if not provided.
+
+    Returns:
+        `list[Decision]`: One `VariantAccepted` or `VariantRejected` per build variant
+            in the repository, compatible variants first.
+    """
+    revision = select_revision_or_version(repo_id, revision=revision, version=version)
+
+    api = _get_hf_api()
+    variants = get_variants(api, repo_id=repo_id, revision=revision)
+    _, trace = resolve_variants(variants, backend)
+    return trace
 
 
 def load_kernel(


### PR DESCRIPTION
As discussed internally.

User code:

```py
from kernels import get_kernel_variants, VariantAccepted

for decision in get_kernel_variants("kernels-community/activation", version=1):
    name = decision.variant.variant_str
    if isinstance(decision, VariantAccepted):
        print(f"{name}: compatible")
    else:
        print(f"{name}: rejected ({decision.reason})")
```

or do we want it more simplified?

<details>
<summary>Sample output:</summary>

```bash
torch211-cxx11-cu128-x86_64-linux: compatible
torch211-cxx11-cu126-x86_64-linux: compatible
torch28-cxx11-cu129-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu129-x86_64-linux: rejected (Torch version (2.9) does not match environment Torch version (2.11))
torch29-cxx11-cu129-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch28-cxx11-cu129-x86_64-linux: rejected (Torch version (2.8) does not match environment Torch version (2.11))
torch210-cxx11-cu128-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch28-cxx11-cu128-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu128-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch211-cu128-x86_64-windows: rejected (OS (windows) does not match system OS (linux))
torch211-cxx11-cu128-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch27-cxx11-cu128-x86_64-linux: rejected (Torch version (2.7) does not match environment Torch version (2.11))
torch27-cxx11-cu118-x86_64-linux: rejected (Torch version (2.7) does not match environment Torch version (2.11))
torch210-cu128-x86_64-windows: rejected (OS (windows) does not match system OS (linux))
torch28-cxx11-cu128-x86_64-linux: rejected (Torch version (2.8) does not match environment Torch version (2.11))
torch27-cxx11-cu128-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu128-x86_64-linux: rejected (Torch version (2.9) does not match environment Torch version (2.11))
torch210-cxx11-cu128-x86_64-linux: rejected (Torch version (2.10) does not match environment Torch version (2.11))
torch211-cxx11-cu126-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch210-cxx11-cu126-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu126-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch212-cxx11-cu126-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch210-cxx11-cu126-x86_64-linux: rejected (Torch version (2.10) does not match environment Torch version (2.11))
torch28-cxx11-cu126-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch212-cxx11-cu126-x86_64-linux: rejected (Torch version (2.12) does not match environment Torch version (2.11))
torch28-cxx11-cu126-x86_64-linux: rejected (Torch version (2.8) does not match environment Torch version (2.11))
torch27-cxx11-cu126-x86_64-linux: rejected (Torch version (2.7) does not match environment Torch version (2.11))
torch29-cxx11-cu126-x86_64-linux: rejected (Torch version (2.9) does not match environment Torch version (2.11))
torch212-cxx11-cu132-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch212-cxx11-cu132-x86_64-linux: rejected (Torch version (2.12) does not match environment Torch version (2.11))
torch210-cxx11-cu130-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu130-x86_64-linux: rejected (Torch version (2.9) does not match environment Torch version (2.11))
torch212-metal-aarch64-darwin: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-metal-aarch64-darwin: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch212-cxx11-cu130-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch211-cxx11-cu130-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch210-metal-aarch64-darwin: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch29-cxx11-cu130-aarch64-linux: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch211-metal-aarch64-darwin: rejected (CPU (aarch64) does not match system CPU (x86_64))
torch210-cxx11-cu130-x86_64-linux: rejected (Torch version (2.10) does not match environment Torch version (2.11))
torch211-cxx11-cu130-x86_64-linux: rejected (CUDA version (13.0) is not compatible with system CUDA version (12.9))
torch212-cxx11-cu130-x86_64-linux: rejected (Torch version (2.12) does not match environment Torch version (2.11))
```

</details>