### PR TITLE
[`FuncRepository`] Add ability of detecting flags

### DIFF
--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -296,6 +296,10 @@ def _create_func_module(func: Callable) -> Type["nn.Module"]:
     from torch import nn
 
     class Func(nn.Module):
+        # Same flags as possible with normal `nn.Module` objects that are exchanged
+        can_torch_compile = getattr(func, "can_torch_compile", False)
+        has_backward = getattr(func, "has_backward", True)
+
         def forward(self, *args, **kwargs):
             return func(*args, **kwargs)
 


### PR DESCRIPTION
Similar to `LayerRepository` we should allow flags to be passed. In this case it's a bit weird because we attach it to a callable but it does enable torch compile with other functions such as the RoPE kernel.