### PR TITLE
kernel-builder: add `hash` subcommand and hook up in Nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,14 +1625,19 @@ dependencies = [
 name = "kernels-data"
 version = "0.16.0-dev0"
 dependencies = [
+ "base64",
+ "digest 0.11.2",
  "eyre",
  "itertools 0.13.0",
  "regex",
  "serde",
  "serde-value",
  "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
  "thiserror 1.0.69",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/docs/source/builder-cli.md
+++ b/docs/source/builder-cli.md
@@ -17,6 +17,7 @@ This document contains the help content for the `kernel-builder` command-line pr
 * [`kernel-builder create-pyproject`↴](#kernel-builder-create-pyproject)
 * [`kernel-builder devshell`↴](#kernel-builder-devshell)
 * [`kernel-builder list-variants`↴](#kernel-builder-list-variants)
+* [`kernel-builder hash`↴](#kernel-builder-hash)
 * [`kernel-builder testshell`↴](#kernel-builder-testshell)
 * [`kernel-builder update-build`↴](#kernel-builder-update-build)
 * [`kernel-builder skills`↴](#kernel-builder-skills)
@@ -43,6 +44,7 @@ Build Hugging Face Hub kernels
 * `create-pyproject` — Generate CMake files for a kernel extension build
 * `devshell` — Spawn a kernel development shell
 * `list-variants` — List build variants
+* `hash` — Hash the builds of a kernel
 * `testshell` — Spawn a kernel test shell
 * `update-build` — Update a `build.toml` to the current format
 * `skills` — Install skills for AI coding assistants (Claude, Codex, OpenCode)
@@ -277,6 +279,18 @@ List build variants
 ###### **Options:**
 
 * `--arch` — Only list variants for the current architecture
+
+
+
+## `kernel-builder hash`
+
+Hash the builds of a kernel
+
+**Usage:** `kernel-builder hash [KERNEL_DIR]`
+
+###### **Arguments:**
+
+* `<KERNEL_DIR>`
 
 
 

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -73,9 +73,9 @@ metadata. Currently the following top-level keys are supported:
   list of [supported license identifiers](https://huggingface.co/docs/hub/repositories-licenses).
 - `backend` (`dict`, required): information about the compute backend that
   this build variant supports.
+- `digest` (`Digest`, required): hash digest of the kernel files.
 - `python-depends` (`list[str]`, optional): list of Python dependencies
   from a curated set of Python dependencies.
-- `digest` (`Digest`, required): hash digest of the kernel files.
 
 Example `metadata.json`:
 

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -75,6 +75,7 @@ metadata. Currently the following top-level keys are supported:
   this build variant supports.
 - `python-depends` (`list[str]`, optional): list of Python dependencies
   from a curated set of Python dependencies.
+- `digest` (`Digest`, required): hash digest of the kernel files.
 
 Example `metadata.json`:
 
@@ -88,6 +89,15 @@ Example `metadata.json`:
   "backend": {
     "type": "cuda",
     "archs": ["7.0", "7.2", "7.5", "8.0", "8.6", "8.7", "8.9", "9.0+PTX"]
+  },
+  "digest": {
+    "algorithm": "sha256",
+    "files": {
+      "__init__.py": "xLMbARTcTl8L/m1kJLc/h/QL4Kzt772F872a46pfRGI=",
+      "_mykernel_cuda_7645816_dirty.abi3.so": "vtdzzToloH38HZkVs7sFEf69QFDxROuPsBAond3Jic0=",
+      "_ops.py": "Hrp5aF4o0eHSttw4sQGsbBAXFqvLJ42Y9YJ2KkqvZhg=",
+      "mykernel/__init__.py": "DFYPlrhXwYjEqCl/8n0SmWGZV8NFml5DPhMjKfv98GY="
+    }
   }
 }
 ```

--- a/kernel-builder/src/hash.rs
+++ b/kernel-builder/src/hash.rs
@@ -1,0 +1,46 @@
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+use eyre::{Context, Result};
+use kernels_data::digest::{Digest, DigestAlgorithm};
+use kernels_data::metadata::Metadata;
+
+use crate::util::{check_or_infer_kernel_dir, discover_variants};
+
+pub fn hash_kernel(kernel_dir: Option<PathBuf>) -> Result<()> {
+    let kernel_dir = check_or_infer_kernel_dir(kernel_dir)?;
+    let (build_dir, variants) = discover_variants(&kernel_dir)?;
+
+    for variant in variants {
+        let variant_path = build_dir.join(&variant);
+        let metadata_path = variant_path.join("metadata.json");
+
+        eprintln!(
+            "Signing variant `{}`...",
+            variant.file_name().unwrap().to_string_lossy()
+        );
+
+        let f = File::open(&metadata_path).context(format!(
+            "Cannot open `{}` for reading",
+            metadata_path.to_string_lossy()
+        ))?;
+        let mut metadata: Metadata = serde_json::from_reader(BufReader::new(f))?;
+
+        let source_digest = Digest::hash_variant(DigestAlgorithm::SHA256, &variant_path)?;
+        metadata.digest = Some(source_digest);
+
+        let f = File::create(&metadata_path).context(format!(
+            "Cannot open `{}` for writing file hashes",
+            metadata_path.to_string_lossy()
+        ))?;
+        serde_json::to_writer_pretty(BufWriter::new(f), &metadata).context(format!(
+            "Cannot write updated metadata to `{}`",
+            metadata_path.to_string_lossy()
+        ))?;
+    }
+
+    Ok(())
+}

--- a/kernel-builder/src/main.rs
+++ b/kernel-builder/src/main.rs
@@ -19,6 +19,9 @@ use develop::{devshell, testshell};
 mod build;
 use build::{run_build, run_build_and_copy};
 
+mod hash;
+use hash::hash_kernel;
+
 mod hf;
 
 mod init;
@@ -208,6 +211,12 @@ enum Commands {
         arch: bool,
     },
 
+    /// Hash the builds of a kernel.
+    Hash {
+        #[arg(name = "KERNEL_DIR")]
+        kernel_dir: Option<PathBuf>,
+    },
+
     /// Spawn a kernel test shell.
     Testshell {
         #[arg(name = "KERNEL_DIR")]
@@ -369,6 +378,7 @@ fn main() -> Result<()> {
             variant,
         ),
         Commands::ListVariants { kernel_dir, arch } => list_variants(kernel_dir, arch),
+        Commands::Hash { kernel_dir } => hash_kernel(kernel_dir),
         Commands::Testshell {
             kernel_dir,
             variant,

--- a/kernel-builder/src/pyproject/common.rs
+++ b/kernel-builder/src/pyproject/common.rs
@@ -49,6 +49,7 @@ pub fn write_metadata(
                 archs: None,
                 backend_type: *backend,
             },
+            digest: None,
         };
 
         serde_json::to_writer_pretty(writer, &metadata)?;

--- a/kernels-data/Cargo.toml
+++ b/kernels-data/Cargo.toml
@@ -8,11 +8,18 @@ license = "Apache-2.0"
 repository = "https://github.com/huggingface/kernels"
 
 [dependencies]
+base64 = "0.22"
+digest = "0.11"
 eyre = "0.6.12"
 itertools = "0.13"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-value = "0.7"
+sha2 = "0.11"
+walkdir = "2"
 thiserror = "1"
 url = { version = "2", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/kernels-data/src/digest.rs
+++ b/kernels-data/src/digest.rs
@@ -1,0 +1,185 @@
+use std::{collections::BTreeMap, fs, path::Path};
+
+use base64::prelude::{BASE64_STANDARD, Engine as _};
+use digest::{Digest as _, DynDigest};
+use eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Sha256, Sha512};
+use walkdir::WalkDir;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Digest {
+    algorithm: DigestAlgorithm,
+    files: BTreeMap<String, String>,
+}
+
+impl Digest {
+    pub fn hash_variant(
+        digest_algorithm: DigestAlgorithm,
+        variant_path: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let variant_path = variant_path.as_ref();
+
+        let mut files = BTreeMap::new();
+        for entry in WalkDir::new(variant_path) {
+            let entry = entry.wrap_err("Failed to read directory entry for hashing")?;
+            // Hub cache path can be symlinks.
+            let path = fs::canonicalize(entry.path())?;
+            if !path.is_file()
+                // Metadata file hash cannot be computed, since it stores
+                // hashes. It is protected by the detached signature.
+                || entry.path().file_name().and_then(|f| f.to_str()) == Some("metadata.json")
+                || entry.path().file_name().and_then(|f| f.to_str()) == Some("metadata.json.sigstore")
+                // Python likes to create .pyc files in the cache.
+                || entry.path().extension().and_then(|e| e.to_str()) == Some("pyc")
+            {
+                continue;
+            }
+
+            let path = entry.path();
+
+            // Read and hash contents.
+            let contents = fs::read(path)
+                .wrap_err_with(|| format!("Cannot read `{}` for hashing", path.display()))?;
+            let mut hasher: Box<dyn DynDigest> = digest_algorithm.into();
+            hasher.update(&contents);
+
+            let relative_path = path.strip_prefix(variant_path).wrap_err_with(|| {
+                format!("Cannot strip prefix from `{}` for hashing", path.display())
+            })?;
+
+            // Normalize Windows directory separators.
+            let relative_path_str = relative_path.to_string_lossy().replace('\\', "/");
+
+            let hash_base64 = BASE64_STANDARD.encode(hasher.finalize_reset());
+
+            files.insert(relative_path_str, hash_base64);
+        }
+
+        Ok(Digest {
+            files,
+            algorithm: digest_algorithm,
+        })
+    }
+
+    /// Algorithm used for hashing.
+    pub fn algorithm(&self) -> DigestAlgorithm {
+        self.algorithm
+    }
+
+    /// Mapping of relative path -> base64 digest.
+    pub fn files(&self) -> &BTreeMap<String, String> {
+        &self.files
+    }
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum DigestAlgorithm {
+    #[serde(rename = "sha256")]
+    SHA256,
+
+    #[serde(rename = "sha512")]
+    SHA512,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eyre::Result;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn hash_variant_hashes_file_with_sha256() -> Result<()> {
+        let dir = TempDir::new()?;
+        fs::write(dir.path().join("_extension.so"), b"hello world")?;
+
+        let digest = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+
+        assert_eq!(digest.files().len(), 1);
+        assert_eq!(
+            digest.files().get("_extension.so").map(String::as_str),
+            Some("uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn hash_variant_hashes_file_with_sha512() -> Result<()> {
+        let dir = TempDir::new()?;
+        fs::write(dir.path().join("_extension.so"), b"hello world")?;
+
+        let digest = Digest::hash_variant(DigestAlgorithm::SHA512, dir.path())?;
+
+        assert_eq!(digest.files().len(), 1);
+        assert_eq!(
+            digest.files().get("_extension.so").map(String::as_str),
+            Some(
+                "MJ7MSJwS1utMxA9QyQLytNDtd+5RGnx6m808qG1M2G+YndNbxf9JlnDaNCVbRbDP2DDoH2Bdz33FVC6TrpzXbw=="
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn hash_variant_skips_excluded_files() -> Result<()> {
+        let dir = TempDir::new()?;
+        fs::write(dir.path().join("_extension.so"), b"content")?;
+        fs::write(dir.path().join("metadata.json"), b"{}")?;
+        fs::write(dir.path().join("metadata.json.sigstore"), b"sig")?;
+        fs::write(dir.path().join("cache.pyc"), b"bytecode")?;
+
+        let digest = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+
+        assert_eq!(digest.files().len(), 1);
+        assert!(digest.files().contains_key("_extension.so"));
+        assert!(!digest.files().contains_key("metadata.json"));
+        assert!(!digest.files().contains_key("metadata.json.sigstore"));
+        assert!(!digest.files().contains_key("cache.pyc"));
+        Ok(())
+    }
+
+    #[test]
+    fn hash_variant_uses_forward_slash_paths() -> Result<()> {
+        let dir = TempDir::new()?;
+        let subdir = dir.path().join("some").join("subdir");
+        fs::create_dir_all(&subdir)?;
+        fs::write(subdir.join("__init__.py"), b"data")?;
+
+        let digest = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+
+        assert!(digest.files().contains_key("some/subdir/__init__.py"));
+        Ok(())
+    }
+
+    #[test]
+    fn hash_variant_returns_empty_map_for_empty_dir() -> Result<()> {
+        let dir = TempDir::new()?;
+
+        let digest = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+
+        assert!(digest.files().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn hash_variant_produces_deterministic_results() -> Result<()> {
+        let dir = TempDir::new()?;
+        fs::write(dir.path().join("_extension.so"), b"hello world")?;
+
+        let digest1 = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+        let digest2 = Digest::hash_variant(DigestAlgorithm::SHA256, dir.path())?;
+
+        assert_eq!(digest1.files(), digest2.files());
+        Ok(())
+    }
+}
+
+impl From<DigestAlgorithm> for Box<dyn DynDigest> {
+    fn from(digest_algorithm: DigestAlgorithm) -> Box<dyn DynDigest> {
+        match digest_algorithm {
+            DigestAlgorithm::SHA256 => Box::new(Sha256::new()),
+            DigestAlgorithm::SHA512 => Box::new(Sha512::new()),
+        }
+    }
+}

--- a/kernels-data/src/lib.rs
+++ b/kernels-data/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod digest;
 pub mod metadata;
 pub mod version;

--- a/kernels-data/src/metadata.rs
+++ b/kernels-data/src/metadata.rs
@@ -4,6 +4,7 @@ use eyre::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{Backend, KernelName};
+use crate::digest::Digest;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -26,6 +27,8 @@ pub struct Metadata {
     pub upstream: Option<url::Url>,
     pub python_depends: Vec<String>,
     pub backend: BackendInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub digest: Option<Digest>,
 }
 
 impl Metadata {

--- a/nix-builder/lib/extension/torch/arch.nix
+++ b/nix-builder/lib/extension/torch/arch.nix
@@ -14,6 +14,7 @@
   cmakeNvccThreadsHook,
   cuda_nvcc,
   get-kernel-check,
+  hash-kernel-hook,
   kernel-layout-check,
   torch-ops-check,
   ninja,
@@ -161,6 +162,7 @@ stdenv.mkDerivation (prevAttrs: {
 
   nativeBuildInputs = [
     cmake
+    hash-kernel-hook
     ninja
     kernel-builder
     kernel-layout-check

--- a/nix-builder/lib/extension/torch/no-arch.nix
+++ b/nix-builder/lib/extension/torch/no-arch.nix
@@ -9,6 +9,7 @@
 
   kernel-builder,
   get-kernel-check,
+  hash-kernel-hook,
   kernel-layout-check,
   python3,
   remove-bytecode-hook,
@@ -88,6 +89,7 @@ stdenv.mkDerivation (prevAttrs: {
   buildInputs = [ torch ];
 
   nativeBuildInputs = [
+    hash-kernel-hook
     kernel-builder
     kernel-layout-check
     remove-bytecode-hook

--- a/nix-builder/lib/extension/tvm-ffi/arch.nix
+++ b/nix-builder/lib/extension/tvm-ffi/arch.nix
@@ -14,6 +14,7 @@
   cmakeNvccThreadsHook,
   cuda_nvcc,
   get-kernel-check,
+  hash-kernel-hook,
   kernel-layout-check,
   ninja,
   python3,
@@ -158,6 +159,7 @@ stdenv.mkDerivation (prevAttrs: {
 
   nativeBuildInputs = [
     cmake
+    hash-kernel-hook
     ninja
     kernel-builder
     kernel-layout-check

--- a/nix-builder/overlay.nix
+++ b/nix-builder/overlay.nix
@@ -14,6 +14,8 @@ in
 
   get-kernel-check = final.callPackage ./pkgs/get-kernel-check { };
 
+  hash-kernel-hook = final.callPackage ./pkgs/hash-kernel-hook { };
+
   kernel-layout-check = final.callPackage ./pkgs/kernel-layout-check { };
 
   nvtx = final.callPackage ./pkgs/nvtx { };

--- a/nix-builder/pkgs/hash-kernel-hook/default.nix
+++ b/nix-builder/pkgs/hash-kernel-hook/default.nix
@@ -1,0 +1,8 @@
+{ makeSetupHook, kernel-builder }:
+
+makeSetupHook {
+  name = "remove-bytecode-hook";
+  substitutions = {
+    kernel_builder = kernel-builder;
+  };
+} ./hash-kernel-hook.sh

--- a/nix-builder/pkgs/hash-kernel-hook/hash-kernel-hook.sh
+++ b/nix-builder/pkgs/hash-kernel-hook/hash-kernel-hook.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Sourcing hash-kernel-hook.sh"
+
+hashKernelHook() {
+  echo "Writing kernel hashes to metadata"
+  @kernel_builder@/bin/kernel-builder hash $out/
+}
+
+if [ -z "${dontHashKernel-}" ]; then
+  appendToVar preDistPhases hashKernelHook
+fi


### PR DESCRIPTION
This change adds a `hash` subcommand to `kernel-builder` that computes the hashes of all kernel files and stores it in `metadata.json`. The hash of the metadata itself is not computed (since it could only be hashed without the hashes stored) and will be protected by a detached signature.

Also hook up this command in the Nix builder, so that all kernels will have file hashes going forward.

Python bindings will follow in later PRs (done already, but I'm breaking it up in smaller, reviewable parts).