### PR TITLE
Simplify handling of kernelized functions

### DIFF
--- a/docs/source/api/layers.md
+++ b/docs/source/api/layers.md
@@ -10,6 +10,10 @@
 
 [[autodoc]] kernels.use_kernel_func_from_hub
 
+### use_kernelized_func
+
+[autodoc]] kernels.use_kernelized_func
+
 ### replace_kernel_forward_from_hub
 
 [[autodoc]] kernels.replace_kernel_forward_from_hub

--- a/docs/source/api/layers.md
+++ b/docs/source/api/layers.md
@@ -12,7 +12,7 @@
 
 ### use_kernelized_func
 
-[autodoc]] kernels.use_kernelized_func
+[[autodoc]] kernels.use_kernelized_func
 
 ### replace_kernel_forward_from_hub
 

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -64,7 +64,7 @@ implementation of `__call__` that delegates to `forward`.
 
 For [`~kernels.kernelize`] to see the function, you must use
 [`~kernels.use_kernelized_func`] on an `torch.nn.Module` that is part
-of the to-be kernlized module to make the function visible to
+of the to-be kernlized model to make the function visible to
 [`~kernels.kernelize`]. The function is typically attached to the module
 that uses it. For example:
 
@@ -77,6 +77,9 @@ class FeedForward(nn.Module):
   def forward(self, x: torch.Tensor) -> torch.Tensor:
       return silu_and_mul(self.linear(x))
 ```
+
+Functions used by [`~kernels.use_kernelized_func`] must always have a
+[`~kernels.use_kernel_forward_from_hub`] decorator.
 
 ## Kernelizing a model
 

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -62,7 +62,7 @@ This will replace the function by an instantiated `torch.nn.Module`
 still behave as a function, since `torch.nn.Module` provides an
 implementation of `__call__` that delegates to `forward`.
 
-For kernelization to see the function, you must use
+For [`~kernels.kernelize`] to see the function, you must use
 [`~kernels.use_kernelized_func`] on an `torch.nn.Module` that is part
 of the to-be kernlized module to make the function visible to
 [`~kernels.kernelize`]. The function is typically attached to the module

--- a/docs/source/layers.md
+++ b/docs/source/layers.md
@@ -47,30 +47,35 @@ compatible with layers from the hub.
 
 Sometimes it can be useful to make a function extensible, for example
 because the function cannot be replaced by a layer. In such cases, you
-can annotate the function with the [`~kernels.use_kernel_func_from_hub`] decorator:
+can use the [`~kernels.use_kernel_forward_from_hub`] decorator on a
+function:
 
 ```python
-@use_kernel_func_from_hub("silu_and_mul")
+@use_kernel_forward_from_hub("silu_and_mul")
 def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
     d = x.shape[-1] // 2
     return F.silu(x[..., :d]) * x[..., d:]
 ```
 
 This will replace the function by an instantiated `torch.nn.Module`
-(singleton) that calls the function itself in its forward method.
+(singleton) that calls the function itself in its forward method. It will
+still behave as a function, since `torch.nn.Module` provides an
+implementation of `__call__` that delegates to `forward`.
 
-**Note:** for kernelization to see the function, it must be a member of
-another `torch.nn.Module` that is part of the model. For example:
+For kernelization to see the function, you must use
+[`~kernels.use_kernelized_func`] on an `torch.nn.Module` that is part
+of the to-be kernlized module to make the function visible to
+[`~kernels.kernelize`]. The function is typically attached to the module
+that uses it. For example:
 
 ```python
+@use_kernelized_func(silu_and_mul)
 class FeedForward(nn.Module):
   def __init__(self, in_features: int, out_features: int):
       self.linear = nn.Linear(in_features, out_features)
-      # Note: silu_and_mul is a Torch module.
-      self.silu_and_mul = silu_and_mul
 
   def forward(self, x: torch.Tensor) -> torch.Tensor:
-      return self.silu_and_mul(self.linear(x))
+      return silu_and_mul(self.linear(x))
 ```
 
 ## Kernelizing a model

--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -23,6 +23,7 @@ from kernels.layer import (
     use_kernel_forward_from_hub,
     use_kernel_func_from_hub,
     use_kernel_mapping,
+    use_kernelized_func,
 )
 from kernels.utils import (
     LoadedKernel,
@@ -75,4 +76,5 @@ __all__ = [
     "use_kernel_forward_from_hub",
     "use_kernel_func_from_hub",
     "use_kernel_mapping",
+    "use_kernelized_func",
 ]

--- a/kernels/src/kernels/layer/__init__.py
+++ b/kernels/src/kernels/layer/__init__.py
@@ -16,6 +16,7 @@ from .layer import (
     LockedLayerRepository,
     replace_kernel_forward_from_hub,
     use_kernel_forward_from_hub,
+    use_kernelized_func,
 )
 from .mode import Mode
 
@@ -36,4 +37,5 @@ __all__ = [
     "use_kernel_forward_from_hub",
     "use_kernel_func_from_hub",
     "use_kernel_mapping",
+    "use_kernelized_func",
 ]

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -27,8 +27,9 @@ class FuncRepository:
     """
     Repository and name of a function for kernel mapping.
 
-    **Warning**: `FuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`~kernels.LayerRepository`] instead.
+    > [!WARNING]
+    > `FuncRepository` is deprecated and will be removed in kernels 0.17.
+    > Use [`~kernels.LayerRepository`] instead.
 
     Args:
         repo_id (`str`):
@@ -135,8 +136,9 @@ class LocalFuncRepository:
     """
     Repository and function name from a local directory for kernel mapping.
 
-    **Warning**: `LocalFuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`~kernels.LocalLayerRepository`] instead.
+    > [!WARNING]
+    > `LocalFuncRepository` is deprecated and will be removed in kernels 0.17.
+    > Use [`~kernels.LocalLayerRepository`] instead.
 
     Args:
         repo_path (`Path`):
@@ -203,8 +205,9 @@ def use_kernel_func_from_hub(func_name: str):
     kernelized, it **must** be a member of another `torch.nn.Module` that is
     part of the model (see the example).
 
-    **Warning**: `use_kernel_func_from_hub` is deprecated and will be removed in kernels
-    0.17. Use [`~kernels.use_kernel_forward_from_hub`] instead.
+    > [!WARNING]
+    > `use_kernel_func_from_hub` is deprecated and will be removed in kernels 0.17.
+    > Use [`~kernels.use_kernel_forward_from_hub`] instead.
 
     Args:
         func_name (`str`):
@@ -256,8 +259,9 @@ class LockedFuncRepository:
     In contrast to `FuncRepository`, this class uses repositories that
     are locked inside a project.
 
-    **Warning**: `LockedFuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`~kernels.LockedLayerRepository`] instead.
+    > [!WARNING]
+    > `LockedFuncRepository` is deprecated and will be removed in kernels 0.17.
+    > Use [`~kernels.LockedLayerRepository`] instead.
 
     Args:
         repo_id (`str`): The Hub repository containing the function.

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import warnings
 from inspect import Parameter, Signature
 from pathlib import Path
 from types import ModuleType
@@ -27,6 +28,9 @@ class FuncRepositoryProtocol(RepositoryProtocol, Protocol):
 class FuncRepository:
     """
     Repository and name of a function for kernel mapping.
+
+    **Warning**: `FuncRepository` is deprecated and will be removed in kernels
+    0.17. Use [`LayerRepository`] instead.
 
     Args:
         repo_id (`str`):
@@ -68,6 +72,12 @@ class FuncRepository:
         version: int | None = None,
         trust_remote_code: bool | list[str] = False,
     ):
+        warnings.warn(
+            "FuncRepository is deprecated and will be removed in kernels 0.17. Use LayerRepository instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if revision is not None and version is not None:
             raise ValueError("Either a revision or a version must be specified, not both.")
         if revision is None and version is None:
@@ -92,7 +102,9 @@ class FuncRepository:
 
     def load(self) -> Type["nn.Module"]:
         kernel = get_kernel(
-            self._repo_id, revision=self._resolve_revision(), trust_remote_code=self._trust_remote_code
+            self._repo_id,
+            revision=self._resolve_revision(),
+            trust_remote_code=self._trust_remote_code,
         )
         return _get_kernel_func(self, kernel)
 
@@ -107,7 +119,15 @@ class FuncRepository:
         )
 
     def __hash__(self):
-        return hash((self.func_name, self._repo_id, self._revision, self._version, self._trust_remote_code))
+        return hash(
+            (
+                self.func_name,
+                self._repo_id,
+                self._revision,
+                self._version,
+                self._trust_remote_code,
+            )
+        )
 
     def __str__(self) -> str:
         return f"`{self._repo_id}` (revision: {self._resolve_revision()}), function `{self.func_name}`"
@@ -116,6 +136,9 @@ class FuncRepository:
 class LocalFuncRepository:
     """
     Repository and function name from a local directory for kernel mapping.
+
+    **Warning**: `LocalFuncRepository` is deprecated and will be removed in kernels
+    0.17. Use [`LocalLayerRepository`] instead.
 
     Args:
         repo_path (`Path`):
@@ -143,6 +166,12 @@ class LocalFuncRepository:
         *,
         func_name: str,
     ):
+        warnings.warn(
+            "LocalFuncRepository is deprecated and will be removed in kernels 0.17. Use LocalLayerRepository instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self._repo_path = repo_path
         self.func_name = func_name
 
@@ -225,6 +254,17 @@ class LockedFuncRepository:
 
     In contrast to `FuncRepository`, this class uses repositories that
     are locked inside a project.
+
+    **Warning**: `LockedFuncRepository` is deprecated and will be removed in kernels
+    0.17. Use [`LockedLayerRepository`] instead.
+
+    Args:
+        repo_id (`str`): The Hub repository containing the function.
+        lockfile (`Path`, *optional*): Path to the lockfile. If not provided,
+            the lockfile will be inferred from the caller's context.
+        func_name (`str`): The name of the function within the kernel repository.
+        trust_remote_code (`bool`, *optional*, defaults to `False`):
+            Whether to allow loading kernels from untrusted organisations.
     """
 
     def __init__(
@@ -238,14 +278,13 @@ class LockedFuncRepository:
         """
         Construct a function repository.
 
-        Args:
-            repo_id (`str`): The Hub repository containing the function.
-            lockfile (`Path`, *optional*): Path to the lockfile. If not provided,
-                the lockfile will be inferred from the caller's context.
-            func_name (`str`): The name of the function within the kernel repository.
-            trust_remote_code (`bool`, *optional*, defaults to `False`):
-                Whether to allow loading kernels from untrusted organisations.
         """
+        warnings.warn(
+            "LockedFuncRepository is deprecated and will be removed in kernels 0.17. Use LockedLayerRepository instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self._repo_id = repo_id
         self._lockfile = lockfile
         self.func_name = func_name
@@ -265,7 +304,11 @@ class LockedFuncRepository:
         return locked_sha
 
     def load(self) -> Type["nn.Module"]:
-        kernel = get_kernel(repo_id=self._repo_id, revision=self._revision, trust_remote_code=self._trust_remote_code)
+        kernel = get_kernel(
+            repo_id=self._repo_id,
+            revision=self._revision,
+            trust_remote_code=self._trust_remote_code,
+        )
         return _get_kernel_func(self, kernel)
 
     def __eq__(self, other):

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -28,7 +28,7 @@ class FuncRepository:
     Repository and name of a function for kernel mapping.
 
     **Warning**: `FuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`LayerRepository`] instead.
+    0.17. Use [`~kernels.LayerRepository`] instead.
 
     Args:
         repo_id (`str`):
@@ -136,7 +136,7 @@ class LocalFuncRepository:
     Repository and function name from a local directory for kernel mapping.
 
     **Warning**: `LocalFuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`LocalLayerRepository`] instead.
+    0.17. Use [`~kernels.LocalLayerRepository`] instead.
 
     Args:
         repo_path (`Path`):
@@ -203,6 +203,9 @@ def use_kernel_func_from_hub(func_name: str):
     kernelized, it **must** be a member of another `torch.nn.Module` that is
     part of the model (see the example).
 
+    **Warning**: `use_kernel_func_from_hub` is deprecated and will be removed in kernels
+    0.17. Use [`~kernels.use_kernel_forward_from_hub`] instead.
+
     Args:
         func_name (`str`):
             The name of the function name to use for kernel lookup in registered mappings.
@@ -254,7 +257,7 @@ class LockedFuncRepository:
     are locked inside a project.
 
     **Warning**: `LockedFuncRepository` is deprecated and will be removed in kernels
-    0.17. Use [`LockedLayerRepository`] instead.
+    0.17. Use [`~kernels.LockedLayerRepository`] instead.
 
     Args:
         repo_id (`str`): The Hub repository containing the function.

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -241,7 +241,7 @@ def use_kernel_func_from_hub(func_name: str):
         ```
     """
     warnings.warn(
-        "use_kernel_func_from_hub is deprecated and will be removed in kernels 0.17. Use [`use_kernel_func_from_hub`] instead.",
+        "use_kernel_func_from_hub is deprecated and will be removed in kernels 0.17. Use [`use_kernel_forward_from_hub`] instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -1,12 +1,8 @@
 import functools
-import inspect
 import warnings
-from inspect import Parameter, Signature
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Protocol, Type
-
-from kernels.layer.repos import RepositoryProtocol
+from typing import TYPE_CHECKING, Protocol, Type
 
 from .._versions import select_revision_or_version
 from ..utils import (
@@ -15,6 +11,8 @@ from ..utils import (
     get_kernel,
     get_local_kernel,
 )
+from .layer import _create_func_module, use_kernel_forward_from_hub
+from .repos import RepositoryProtocol
 
 if TYPE_CHECKING:
     from torch import nn
@@ -239,13 +237,13 @@ def use_kernel_func_from_hub(func_name: str):
         # model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE, device="cuda")
         ```
     """
+    warnings.warn(
+        "use_kernel_func_from_hub is deprecated and will be removed in kernels 0.17. Use [`use_kernel_func_from_hub`] instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    def decorator(func):
-        Func = _create_func_module(func)
-        Func.kernel_layer_name = func_name
-        return Func()
-
-    return decorator
+    return use_kernel_forward_from_hub(func_name)
 
 
 class LockedFuncRepository:
@@ -333,27 +331,3 @@ def _get_kernel_func(repo: FuncRepositoryProtocol, kernel: ModuleType) -> Type["
         raise ValueError(f"Function `{repo.func_name}` not found in `{repo}`")
 
     return _create_func_module(func)
-
-
-def _create_func_module(func: Callable) -> Type["nn.Module"]:
-    from torch import nn
-
-    class Func(nn.Module):
-        # Same flags as possible with normal `nn.Module` objects that are exchanged
-        can_torch_compile = getattr(func, "can_torch_compile", False)
-        has_backward = getattr(func, "has_backward", True)
-
-        def forward(self, *args, **kwargs):
-            return func(*args, **kwargs)
-
-    # Use function signature with args prepended by self to support
-    # module validation.
-    func_sig = inspect.signature(func)
-    new_args = [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-    new_args.extend(func_sig.parameters.values())
-    Func.forward.__signature__ = Signature(  # type: ignore[attr-defined]
-        parameters=new_args,
-        return_annotation=func_sig.return_annotation,
-    )
-
-    return Func

--- a/kernels/src/kernels/layer/kernelize.py
+++ b/kernels/src/kernels/layer/kernelize.py
@@ -258,10 +258,18 @@ def kernelize(
 
     for _, module in model.named_modules():
         module_class = type(module)
-        if not hasattr(module_class, "kernel_layer_name"):
-            continue
 
-        kernelize_layer(module, mode=mode, device_type=device_type, use_fallback=use_fallback)
+        # Kernel functions attached to a module through `use_kernelized_func`.
+        for kernel_func in getattr(module, "_kernel_funcs", {}).values():
+            kernelize_layer(
+                kernel_func,
+                mode=mode,
+                device_type=device_type,
+                use_fallback=use_fallback,
+            )
+
+        if hasattr(module_class, "kernel_layer_name"):
+            kernelize_layer(module, mode=mode, device_type=device_type, use_fallback=use_fallback)
 
     return model
 

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -278,7 +278,7 @@ def use_kernel_forward_from_hub(layer_name: str):
     made extensible using the given layer name, and then the class is instantiated.
     Since `nn.Module` also implements the `__call__` method, the module can still be
     used as if it was a function. Note that a decorated function is only visible to
-    [`kernelize`] if it is used as a member variable of another layer.
+    [`kernelize`] if it is attached to a module using [`use_kernelized_func`].
 
     Args:
         layer_name (`str`):
@@ -293,6 +293,7 @@ def use_kernel_forward_from_hub(layer_name: str):
         import torch.nn as nn
 
         from kernels import use_kernel_forward_from_hub
+        from kernels import use_kernelized_func
         from kernels import Mode, kernelize
 
         @use_kernel_forward_from_hub("MyCustomLayer")
@@ -315,12 +316,10 @@ def use_kernel_forward_from_hub(layer_name: str):
         def identity(x: torch.Tensor) -> torch.Tensor:
             return x
 
+        @use_kernelized_func(identity)
         class LayerUsingIdentity(nn.Module):
-            def __init__(self, ...):
-                # The function needs to be attached to a layer to be
-                # discoverable by `kernelize`.
-                self.identity = identity
-                # ...
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return identity(x)
 
         ```
     """
@@ -335,6 +334,70 @@ def use_kernel_forward_from_hub(layer_name: str):
             return ty
         else:
             raise TypeError("@use_kernel_forward_from_hub can only be applied to classes or functions")
+
+    return decorator
+
+
+def use_kernelized_func(*args: Callable):
+    """
+    This decorator attaches the target function within the module as a plain
+    attribute (not as a submodule). This makes the function visible to
+    [`kernelize`].
+
+    Args:
+        *args (`Callable`):
+            Kernel functions to attach to the module.
+
+    Returns:
+        `Callable`: A decorator function that can be applied to modules.
+
+    Example:
+        ```python
+        import torch
+        import torch.nn as nn
+
+        from kernels import use_kernel_forward_from_hub
+        from kernels import use_kernelized_func
+        from kernels import Mode, kernelize
+
+        # Use on a function (converts the function to `nn.Module`):
+        @use_kernel_forward_from_hub("MyCustomLayer")
+        def identity(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        @use_kernelized_func(identity)
+        class LayerUsingIdentity(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return identity(x)
+
+        model = LayerUsingIdentity()
+
+        # The layer can now be kernelized:
+        # model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE, device="cuda")
+        ```
+
+    """
+
+    decorator_args = args
+
+    def decorator(cls):
+        orig_init = cls.__init__
+
+        def new_init(self, *args, **kwargs):
+            orig_init(self, *args, **kwargs)
+
+            # Register new function as non-submodule within the modules dict
+            hidden_kernels = self.__dict__.setdefault("_kernel_funcs", {})
+            for fn in decorator_args:
+                name = getattr(fn, "__name__", None) or getattr(fn, "kernel_layer_name", None)
+                if name is None:
+                    raise ValueError(f"Could not infer kernel function name for {fn!r}")
+
+                # Do not register as submodule! Hide it behind a dict to be removed later after registering it
+                hidden_kernels[name] = fn
+
+        cls.__init__ = new_init
+        return cls
 
     return decorator
 

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -400,8 +400,7 @@ def use_kernelized_func(*args: Callable):
             hidden_kernels = self.__dict__.setdefault("_kernel_funcs", {})
             for fn in decorator_args:
                 name = getattr(fn, "__name__", None) or getattr(fn, "kernel_layer_name", None)
-                if name is None:
-                    raise ValueError(f"Could not infer kernel function name for {fn!r}")
+                assert name is not None
 
                 hidden_kernels[name] = fn
 

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -385,7 +385,6 @@ def use_kernelized_func(*args: Callable):
     def decorator(cls):
         # Validate that the functions that are passed are kernel functions.
         for fn in decorator_args:
-            print("Checking", fn)
             if not hasattr(fn, "kernel_layer_name"):
                 raise ValueError(
                     f"Function `{fn.__name__}` is not decorated with @use_kernel_forward_from_hub and cannot be used with @use_kernelized_func"

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -381,6 +381,14 @@ def use_kernelized_func(*args: Callable):
     decorator_args = args
 
     def decorator(cls):
+        # Validate that the functions that are passed are kernel functions.
+        for fn in decorator_args:
+            print("Checking", fn)
+            if not hasattr(fn, "kernel_layer_name"):
+                raise ValueError(
+                    f"Function `{fn.__name__}` is not decorated with @use_kernel_forward_from_hub and cannot be used with @use_kernelized_func"
+                )
+
         orig_init = cls.__init__
 
         def new_init(self, *args, **kwargs):

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -311,7 +311,8 @@ def use_kernel_forward_from_hub(layer_name: str):
         # The layer can now be kernelized:
         # model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE, device="cuda")
 
-        # Use on a function (converts the function to `nn.Module`):
+        # Use on a function (converts the function to `nn.Module`). The function
+        # can then be replaced with a layer mapping for `MyCustomLayer`.
         @use_kernel_forward_from_hub("MyCustomLayer")
         def identity(x: torch.Tensor) -> torch.Tensor:
             return x
@@ -360,7 +361,8 @@ def use_kernelized_func(*args: Callable):
         from kernels import use_kernelized_func
         from kernels import Mode, kernelize
 
-        # Use on a function (converts the function to `nn.Module`):
+        # Use on a function (converts the function to `nn.Module`). The function
+        # can then be replaced with a layer mapping for `MyCustomLayer`.
         @use_kernel_forward_from_hub("MyCustomLayer")
         def identity(x: torch.Tensor) -> torch.Tensor:
             return x

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -4,9 +4,10 @@ import functools
 import inspect
 import logging
 import warnings
+from inspect import Parameter, Signature
 from pathlib import Path
 from types import MethodType, ModuleType
-from typing import TYPE_CHECKING, Protocol, Type
+from typing import TYPE_CHECKING, Callable, Protocol, Type
 
 from .._versions import select_revision_or_version
 from ..utils import (
@@ -270,8 +271,14 @@ def use_kernel_forward_from_hub(layer_name: str):
     """
     Decorator factory that makes a layer extensible using the specified layer name.
 
-    This is a decorator factory that returns a decorator which prepares a layer class to use kernels from the
-    Hugging Face Hub.
+    This decorator which prepares a layer class to use kernel layers from the Hugging
+    Face Hub.
+
+    When applied to a function, the function is converted into a layer (`nn.Module`),
+    made extensible using the given layer name, and then the class is instantiated.
+    Since `nn.Module` also implements the `__call__` method, the module can still be
+    used as if it was a function. Note that a decorated function is only visible to
+    [`kernelize`] if it is used as a member variable of another layer.
 
     Args:
         layer_name (`str`):
@@ -302,12 +309,32 @@ def use_kernel_forward_from_hub(layer_name: str):
 
         # The layer can now be kernelized:
         # model = kernelize(model, mode=Mode.TRAINING | Mode.TORCH_COMPILE, device="cuda")
+
+        # Use on a function (converts the function to `nn.Module`):
+        @use_kernel_forward_from_hub("MyCustomLayer")
+        def identity(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        class LayerUsingIdentity(nn.Module):
+            def __init__(self, ...):
+                # The function needs to be attached to a layer to be
+                # discoverable by `kernelize`.
+                self.identity = identity
+                # ...
+
         ```
     """
 
-    def decorator(cls):
-        replace_kernel_forward_from_hub(cls, layer_name)
-        return cls
+    def decorator(ty):
+        if inspect.isfunction(ty):
+            Func = _create_func_module(ty)
+            replace_kernel_forward_from_hub(Func, layer_name)
+            return Func()
+        elif inspect.isclass(ty):
+            replace_kernel_forward_from_hub(ty, layer_name)
+            return ty
+        else:
+            raise TypeError("@use_kernel_forward_from_hub can only be applied to classes or functions")
 
     return decorator
 
@@ -505,3 +532,27 @@ def _get_layer_memoize(repo: RepositoryProtocol, module_class: Type["nn.Module"]
     _CACHED_LAYER[repo] = layer
 
     return layer
+
+
+def _create_func_module(func: Callable) -> Type["nn.Module"]:
+    from torch import nn
+
+    class Func(nn.Module):
+        # Same flags as possible with normal `nn.Module` objects that are exchanged
+        can_torch_compile = getattr(func, "can_torch_compile", False)
+        has_backward = getattr(func, "has_backward", True)
+
+        def forward(self, *args, **kwargs):
+            return func(*args, **kwargs)
+
+    # Use function signature with args prepended by self to support
+    # module validation.
+    func_sig = inspect.signature(func)
+    new_args = [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+    new_args.extend(func_sig.parameters.values())
+    Func.forward.__signature__ = Signature(  # type: ignore[attr-defined]
+        parameters=new_args,
+        return_annotation=func_sig.return_annotation,
+    )
+
+    return Func

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -403,7 +403,6 @@ def use_kernelized_func(*args: Callable):
                 if name is None:
                     raise ValueError(f"Could not infer kernel function name for {fn!r}")
 
-                # Do not register as submodule! Hide it behind a dict to be removed later after registering it
                 hidden_kernels[name] = fn
 
         cls.__init__ = new_init

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -278,7 +278,7 @@ def use_kernel_forward_from_hub(layer_name: str):
     made extensible using the given layer name, and then the class is instantiated.
     Since `nn.Module` also implements the `__call__` method, the module can still be
     used as if it was a function. Note that a decorated function is only visible to
-    [`kernelize`] if it is attached to a module using [`use_kernelized_func`].
+    [`~kernels.kernelize`] if it is attached to a module using [`~kernels.use_kernelized_func`].
 
     Args:
         layer_name (`str`):
@@ -342,7 +342,7 @@ def use_kernelized_func(*args: Callable):
     """
     This decorator attaches the target function within the module as a plain
     attribute (not as a submodule). This makes the function visible to
-    [`kernelize`].
+    [`~kernels.kernelize`].
 
     Args:
         *args (`Callable`):

--- a/kernels/tests/test_func.py
+++ b/kernels/tests/test_func.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -15,6 +17,7 @@ from kernels import (
     use_kernel_mapping,
     use_kernelized_func,
 )
+from kernels.layer.func import LockedFuncRepository
 
 
 # A function + layer that we can map arbitrary functions to for testing.
@@ -38,6 +41,7 @@ def test_decorator():
     assert isinstance(identity, nn.Module)
 
 
+@pytest.mark.filterwarnings("ignore:.*will be removed in kernels 0.17:DeprecationWarning")
 def test_deprecated_decorator():
     @use_kernel_func_from_hub("identity_func")
     def identity(x):
@@ -47,11 +51,13 @@ def test_deprecated_decorator():
     assert isinstance(identity, nn.Module)
 
 
+@pytest.mark.filterwarnings("ignore:.*will be removed in kernels 0.17:DeprecationWarning")
 def test_deprecated_func_repository_requires_version_or_revision():
     with pytest.raises(ValueError, match="Either a revision or a version must be specified"):
         FuncRepository("kernels-test/flattened-build", func_name="silu_and_mul")
 
 
+@pytest.mark.filterwarnings("ignore:.*will be removed in kernels 0.17:DeprecationWarning")
 def test_deprecated_func_repository(device):
     model = SurpriseMe()
 
@@ -110,6 +116,7 @@ def test_kernel_func_with_layer():
     assert model(x) is x
 
 
+@pytest.mark.filterwarnings("ignore:.*will be removed in kernels 0.17:DeprecationWarning")
 def test_deprecated_local_kernel_func(device):
     model = SurpriseMe()
 
@@ -136,6 +143,32 @@ def test_deprecated_local_kernel_func(device):
         model = kernelize(model, mode=Mode.INFERENCE, device=device)
 
     assert model(x) is x
+
+
+def test_deprecated_kernel_func():
+    with pytest.deprecated_call(match="kernels 0.17"):
+        FuncRepository("kernels-test/flattened-build", func_name="silu_and_mul", version=1)
+
+    project_dir = Path(__file__).parent / "layer_locking"
+    with pytest.deprecated_call(match="kernels 0.17"):
+        LockedFuncRepository(
+            "kernels-test/versions",
+            func_name="version",
+            lockfile=project_dir / "kernels.lock",
+        )
+
+    with pytest.deprecated_call(match="kernels 0.17"):
+        LocalFuncRepository(
+            # We are never loading the kernel, so we can just use an invalid path.
+            repo_path=Path("."),
+            func_name="silu_and_mul",
+        )
+
+    with pytest.deprecated_call(match="kernels 0.17"):
+
+        @use_kernel_func_from_hub("deprecated")
+        def deprecated_func(x):
+            return x
 
 
 def test_use_kernelized_func_used_on_non_kernelized_func():

--- a/kernels/tests/test_func.py
+++ b/kernels/tests/test_func.py
@@ -10,13 +10,14 @@ from kernels import (
     Mode,
     install_kernel,
     kernelize,
+    use_kernel_forward_from_hub,
     use_kernel_func_from_hub,
     use_kernel_mapping,
 )
 
 
 # A function + layer that we can map arbitrary functions to for testing.
-@use_kernel_func_from_hub("surprise_me")
+@use_kernel_forward_from_hub("surprise_me")
 def surprise_me(x: torch.Tensor):
     return x
 
@@ -31,6 +32,15 @@ class SurpriseMe(nn.Module):
 
 
 def test_decorator():
+    @use_kernel_forward_from_hub("identity_func")
+    def identity(x):
+        return x
+
+    assert type(identity).kernel_layer_name == "identity_func"
+    assert isinstance(identity, nn.Module)
+
+
+def test_deprecated_decorator():
     @use_kernel_func_from_hub("identity_func")
     def identity(x):
         return x
@@ -39,12 +49,12 @@ def test_decorator():
     assert isinstance(identity, nn.Module)
 
 
-def test_kernel_func_requires_version_or_revision():
+def test_deprecated_func_repository_requires_version_or_revision():
     with pytest.raises(ValueError, match="Either a revision or a version must be specified"):
         FuncRepository("kernels-test/flattened-build", func_name="silu_and_mul")
 
 
-def test_kernel_func(device):
+def test_deprecated_func_repository(device):
     model = SurpriseMe()
 
     x = torch.arange(-10, 10, device=device).float()
@@ -102,7 +112,7 @@ def test_kernel_func_with_layer():
     assert model(x) is x
 
 
-def test_local_kernel_func(device):
+def test_deprecated_local_kernel_func(device):
     model = SurpriseMe()
 
     x = torch.arange(-10, 10).float()

--- a/kernels/tests/test_func.py
+++ b/kernels/tests/test_func.py
@@ -138,6 +138,18 @@ def test_deprecated_local_kernel_func(device):
     assert model(x) is x
 
 
+def test_use_kernelized_func_used_on_non_kernelized_func():
+    def not_kernelized(x):
+        return x
+
+    with pytest.raises(ValueError, match="Function `not_kernelized` is not decorated"):
+
+        @use_kernelized_func(not_kernelized)
+        class NotKernelized(nn.Module):
+            def forward(self, x: torch.Tensor):
+                return not_kernelized(x)
+
+
 def _silu_and_mul(x: torch.Tensor) -> torch.Tensor:
     d = x.shape[-1] // 2
     return F.silu(x[..., :d]) * x[..., d:]

--- a/kernels/tests/test_func.py
+++ b/kernels/tests/test_func.py
@@ -13,6 +13,7 @@ from kernels import (
     use_kernel_forward_from_hub,
     use_kernel_func_from_hub,
     use_kernel_mapping,
+    use_kernelized_func,
 )
 
 
@@ -22,13 +23,10 @@ def surprise_me(x: torch.Tensor):
     return x
 
 
+@use_kernelized_func(surprise_me)
 class SurpriseMe(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.surprise_me = surprise_me
-
     def forward(self, x: torch.Tensor):
-        return self.surprise_me(x)
+        return surprise_me(x)
 
 
 def test_decorator():


### PR DESCRIPTION
This is a set of related changes based on internal discussions:

- Deprecate the `FuncRepository` classes. Kernel-side functions are not a great interface, because one typically has to set attributes to permit `torch.compile` and backward passes. However for functions, these are detached. It also hides that the functions are converted to `nn.Module` underneath.
- Deprecate the `use_kernel_from_hub` decorator and extend `use_kernel_forward_from_hub` to provide the same functionality. This makes it clearer that when decorating a function, it gets replaced by a module instance.
- Adopt `use_kernelized_func` from transformers. This annotation makes it unnecessary to assign functions as member variables, which cause issues in some applications. Instead, they are registered in a module separate from (sub-)modules. `kernelize` is updated to pick up these attached functions as well.