### PR TITLE
nix-builder: remove the MKL override

### DIFF
--- a/nix-builder/overlay.nix
+++ b/nix-builder/overlay.nix
@@ -1,13 +1,5 @@
 final: prev:
-let
-  # For XPU we use MKL from the joined oneAPI toolkit.
-  useMKL = final.stdenv.isx86_64 && !(final.config.xpuSupport or false);
-in
 {
-  # Use MKL for BLAS/LAPACK on x86_64.
-  blas = if useMKL then prev.blas.override { blasProvider = prev.mkl; } else prev.blas;
-  lapack = if useMKL then prev.lapack.override { lapackProvider = prev.mkl; } else prev.lapack;
-
   kernel-builder = final.callPackage ./pkgs/kernel-builder { };
 
   cmakeNvccThreadsHook = final.callPackage ./pkgs/cmake-nvcc-threads-hook { };


### PR DESCRIPTION
This override stems from when we were still building Torch from source.
When we did so, we had to ensure that the build aligned as closely as
possible to upstream, meaning that we had to build it with MKL. Since we
repackage binary wheels, this is not necessary anymore, because the MKL
bits are baked into the wheel.

With this change, we can hit the NixOS cache for more dependencies on
x86_64-linux.
