### PR TITLE
Add acknowledgment for the xpu-kernels skill / Xe-Forge

### DIFF
--- a/kernel-builder/skills/cpu-kernels/SKILL.md
+++ b/kernel-builder/skills/cpu-kernels/SKILL.md
@@ -458,4 +458,4 @@ cpu-kernels/
 
 ## Acknowledgments
 
-The methodology of this skill — the YAML knowledge base, the benchmark/validation harnesses, and the branching trial-manager optimization loop — was adapted from the [xpu-kernels skill](../xpu-kernels/SKILL.md) built by the Intel XPU kernels team, which is itself based on [Xe-Forge](https://github.com/IntelLabs/Xe-Forge) (IntelLabs). Thanks to the original authors for a solid foundation to build on.
+The methodology of this skill — the YAML knowledge base, the benchmark/validation harnesses, and the branching trial-manager optimization loop — was adapted from the [xpu-kernels skill](../xpu-kernels/SKILL.md) built by a group of Intel AI researchers, the IntelLabs team behind [Xe-Forge](https://github.com/IntelLabs/Xe-Forge), where the methodology originates. Thanks to the original authors for a solid foundation to build on.

--- a/kernel-builder/skills/cpu-kernels/SKILL.md
+++ b/kernel-builder/skills/cpu-kernels/SKILL.md
@@ -453,3 +453,9 @@ cpu-kernels/
 - [Hugging Face Kernels](https://github.com/huggingface/kernels) — Kernel hub and builder CLI
 - [Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/)
 - [kernel-builder Documentation](https://github.com/huggingface/kernels/tree/main/docs)
+- [xpu-kernels skill](../xpu-kernels/SKILL.md) — the Intel XPU Triton skill this workflow was adapted from
+- [Xe-Forge](https://github.com/IntelLabs/Xe-Forge) — the LLM-driven optimization framework the skill methodology originates from
+
+## Acknowledgments
+
+The methodology of this skill — the YAML knowledge base, the benchmark/validation harnesses, and the branching trial-manager optimization loop — was adapted from the [xpu-kernels skill](../xpu-kernels/SKILL.md) built by the Intel XPU kernels team, which is itself based on [Xe-Forge](https://github.com/IntelLabs/Xe-Forge) (IntelLabs). Thanks to the original authors for a solid foundation to build on.


### PR DESCRIPTION
## Summary

The `cpu-kernels` skill adapted its overall methodology — the YAML knowledge
base, the benchmark/validation harnesses, and the branching trial-manager
optimization loop — from the existing `xpu-kernels` skill (built by the Intel
XPU kernels team), which is itself based on [Xe-Forge](https://github.com/IntelLabs/Xe-Forge).
This PR adds proper attribution so the original authors get visibility.

## Changes

- `kernel-builder/skills/cpu-kernels/SKILL.md`
  - Add an **Acknowledgments** section crediting the `xpu-kernels` skill and
    Xe-Forge as the origin of the workflow methodology.
  - Add the `xpu-kernels` skill and Xe-Forge to **External Resources**.

## Notes

The CPU-specific content (AVX2/AVX512 intrinsics, runtime dispatch, brgemm/AMX
integration, NUMA and threading discipline) remains original to this skill; the
acknowledgment is scoped to the shared workflow methodology.
