### PR TITLE
feat: enable cutlass 4.5 on nix builder

### DIFF
--- a/kernel-builder/src/pyproject/deps.rs
+++ b/kernel-builder/src/pyproject/deps.rs
@@ -81,6 +81,17 @@ pub fn render_deps(env: &Environment, build: &Build, write: &mut impl Write) -> 
                     )
                     .wrap_err("Cannot render CUTLASS dependency template")?;
             }
+            Dependency::Cutlass4_5 => {
+                env.get_template("cuda/dep-cutlass.cmake")
+                    .wrap_err("Cannot get CUTLASS dependency template")?
+                    .render_captured_to(
+                        context! {
+                            version => "4.5.2",
+                        },
+                        &mut *write,
+                    )
+                    .wrap_err("Cannot render CUTLASS dependency template")?;
+            }
             Dependency::SyclTla => {
                 env.get_template("xpu/dep-sycl-tla.cmake")
                     .wrap_err("Cannot get SYCL TLA dependency template")?

--- a/kernels-data/src/config/deps.rs
+++ b/kernels-data/src/config/deps.rs
@@ -25,6 +25,8 @@ pub enum Dependency {
     Cutlass3_9,
     #[serde(rename = "cutlass_4_0")]
     Cutlass4_0,
+    #[serde(rename = "cutlass_4_5")]
+    Cutlass4_5,
     #[serde(rename = "sycl_tla")]
     SyclTla,
     #[serde(rename = "metal-cpp")]

--- a/nix-builder/lib/deps.nix
+++ b/nix-builder/lib/deps.nix
@@ -25,6 +25,9 @@ let
     "cutlass_4_0" = [
       pkgs.cutlass_4_0
     ];
+    "cutlass_4_5" = [
+      pkgs.cutlass_4_5
+    ];
     "torch" = [
       torch
     ];

--- a/nix-builder/pkgs/cutlass/default.nix
+++ b/nix-builder/pkgs/cutlass/default.nix
@@ -28,8 +28,14 @@ in
     version = "3.9.2";
     hash = "sha256-teziPNA9csYvhkG5t2ht8W8x5+1YGGbHm8VKx4JoxgI=";
   };
+
   cutlass_4_0 = builder {
     version = "4.0.0";
     hash = "sha256-HJY+Go1viPkSVZPEs/NyMtYJzas4mMLiIZF3kNX+WgA=";
+  };
+
+  cutlass_4_5 = builder {
+    version = "4.5.2";
+    hash = "sha256-jnxookfCEPynRrxMGGsMwPlK84ChQQW3xocmYcNTVLw=";
   };
 }


### PR DESCRIPTION
This PR attempts to enable more recent version of cutlass, v4.5.2 in this case, to support more recent architecture and dispatching like SM120