### PR TITLE
python3Packages.triton: fix ldconfig use

### DIFF
--- a/nix-builder/pkgs/python-modules/triton/generic.nix
+++ b/nix-builder/pkgs/python-modules/triton/generic.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
 
+  python,
   buildPythonPackage,
   autoPatchelfHook,
   autoAddDriverRunpath,
@@ -36,6 +37,23 @@ buildPythonPackage {
   dependencies = [
     pyelftools
   ];
+
+  postInstall =
+    let
+      # `libcuda_dirs` in Triton probes for libcuda.so.1 using ldconfig. We
+      # cannot use ldconfig on Nix and we know where libcuda.so.1 is, so just
+      # hardcode it.
+      replacement = ''
+        def libcuda_dirs():
+            return ['/run/opengl-driver/lib']
+
+        def _libcuda_dirs():
+      '';
+    in
+    ''
+      substituteInPlace $out/${python.sitePackages}/triton/backends/nvidia/driver.py \
+        --replace-fail "def libcuda_dirs():" ${lib.escapeShellArg replacement}
+    '';
 
   dontStrip = true;
 


### PR DESCRIPTION
Triton uses `ldconfig` to find `libcuda.so.1`. This fails on NixOS and pure Nix environment since `ldconfig` is not available. Since we know the path of `libcuda.so.1`, just use that.