### PR TITLE
skills: update to use new testing methodology

### DIFF
--- a/kernel-builder/skills/cuda-kernels/SKILL.md
+++ b/kernel-builder/skills/cuda-kernels/SKILL.md
@@ -378,13 +378,13 @@ kernel-builder build-and-upload
 ```
 The target repo is set by `repo-id` under `[general.hub]` and `version` under `[general]` in `build.toml`. Uploads go to a **`kernel`-type** Hub repository (not a model repo); the owning user/org needs kernel-creation access ("Request Kernels Creation" at [huggingface.co/settings/account](https://huggingface.co/settings/account)).
 
-### Editable install for local development
-Never hand-write a `setup.py` (it leads to `torch.utils.cpp_extension`/pybind11, which cannot build under ABI3). Let kernel-builder generate the project files:
+### Local build for development
+Never hand-write a `setup.py` (it leads to `torch.utils.cpp_extension`/pybind11, which cannot build under ABI3). Let kernel-builder generate the project files, then build with `setup.py build_kernel` (no `pip install`/editable install needed):
 ```bash
 kernel-builder create-pyproject -f
-pip install wheel
-pip install --no-build-isolation -e .
+python setup.py build_kernel
 ```
+This builds the kernel and puts the output in `build`, which can be loaded directly with `kernels.get_local_kernel(Path("build"))`. Inside `kernel-builder devshell`/`testshell`, `LOCAL_KERNELS` is set automatically so `get_kernel("<repo-id>")` resolves to this local build.
 
 ### build.toml Configuration
 ```toml

--- a/kernel-builder/skills/cuda-kernels/references/diffusers-h100.md
+++ b/kernel-builder/skills/cuda-kernels/references/diffusers-h100.md
@@ -224,13 +224,13 @@ All kernels support three precision modes:
 nix run .#build-and-copy --max-jobs 2 --cores 8 -L
 ```
 
-### Editable install for local development
-Never hand-write a `setup.py` (it leads to `torch.utils.cpp_extension`/pybind11, which cannot build under ABI3). Let kernel-builder generate the project files:
+### Local build for development
+Never hand-write a `setup.py` (it leads to `torch.utils.cpp_extension`/pybind11, which cannot build under ABI3). Let kernel-builder generate the project files, then build with `setup.py build_kernel` (no `pip install`/editable install needed):
 ```bash
 kernel-builder create-pyproject -f
-pip install wheel
-pip install --no-build-isolation -e .
+python setup.py build_kernel
 ```
+This builds the kernel and puts the output in `build`, which can be loaded directly with `kernels.get_local_kernel(Path("build"))`. Inside `kernel-builder devshell`/`testshell`, `LOCAL_KERNELS` is set automatically so `get_kernel("<repo-id>")` resolves to this local build.
 
 ### build.toml Configuration
 ```toml

--- a/kernel-builder/skills/cuda-kernels/references/huggingface-kernels-integration.md
+++ b/kernel-builder/skills/cuda-kernels/references/huggingface-kernels-integration.md
@@ -363,12 +363,12 @@ kernel-builder build-and-upload
 
 The target repository is determined by the `repo-id` and `version` fields in `build.toml` (see above). Uploads go to a **`kernel`-type** Hub repository (the first-class kernel repository type), not a model repo — the owning user or org needs kernel-creation access, requested via [huggingface.co/settings/account](https://huggingface.co/settings/account) ("Request Kernels Creation"). If a `CARD.md` template is present in the source repo, it is filled and uploaded as the `README.md`.
 
-**Editable install for local development** (never hand-write a `setup.py` — `torch.utils.cpp_extension`/pybind11 cannot build under ABI3):
+**Local build for development** (never hand-write a `setup.py` — `torch.utils.cpp_extension`/pybind11 cannot build under ABI3):
 ```bash
 kernel-builder create-pyproject -f
-pip install wheel
-pip install --no-build-isolation -e .
+python setup.py build_kernel
 ```
+This builds the kernel into `build`, loadable directly with `kernels.get_local_kernel(Path("build"))`. In `kernel-builder devshell`/`testshell`, `LOCAL_KERNELS` is set automatically so `get_kernel("<repo-id>")` resolves to this local build instead of the Hub.
 
 ## Available Community Kernels
 

--- a/kernel-builder/skills/cuda-kernels/references/kernel-templates.md
+++ b/kernel-builder/skills/cuda-kernels/references/kernel-templates.md
@@ -688,8 +688,8 @@ nix run .#build-and-copy -L
 nix run .#ci-test
 ```
 
-For an editable dev install, generate the project files with kernel-builder (never hand-write a `setup.py`):
+For a local dev build, generate the project files with kernel-builder (never hand-write a `setup.py`):
 ```bash
 kernel-builder create-pyproject -f
-pip install wheel && pip install --no-build-isolation -e .
+python setup.py build_kernel
 ```


### PR DESCRIPTION
- Use `setup.py build_kernel`, not `pip install`.
- Give hints on how to load the kernel.
