### PR TITLE
feat: add a page for links to blog posts

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -85,4 +85,6 @@
 - sections:
     - local: talks
       title: Talks
+    - local: blog
+      title: Blog posts
   title: Resources

--- a/docs/source/blog.md
+++ b/docs/source/blog.md
@@ -1,0 +1,15 @@
+# Blog posts
+
+This page lists blog posts on the Kernels project. See the full list
+tagged [`kernels`](https://huggingface.co/blog?tag=kernels) on the
+Hugging Face blog:
+
+* [🤗 Kernels: Major Updates](https://huggingface.co/blog/revamped-kernels)
+* [Custom Kernels for All from Codex and Claude](https://huggingface.co/blog/custom-cuda-kernels-agent-skills)
+* [Easily Build and Share ROCm Kernels with Hugging Face](https://huggingface.co/blog/build-rocm-kernels)
+* [From Zero to GPU: A Guide to Building and Scaling Production-Ready CUDA Kernels](https://huggingface.co/blog/kernel-builder)
+* [Creating custom kernels for the AMD MI300](https://huggingface.co/blog/mi300kernels)
+* [Tricks from OpenAI gpt-oss YOU 🫵 can use with transformers](https://huggingface.co/blog/faster-transformers)
+* [Mixture of Experts (MoEs) in Transformers](https://huggingface.co/blog/moe-transformers)
+
+This page will be kept updated.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -32,5 +32,6 @@ If you're looking for a more involved "Why kernels?" answer, refer to
 [this page](./why_kernels.md).
 
 The [talks page](./talks.md) page has links to talks on the
-Kernels project.
+Kernels project. The [blog page](./blog.md) collects blog posts
+on the Kernels project.
 

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -224,6 +224,14 @@ The version **must** be bumped in the following cases:
 In both cases, build variants that are not updated must be removed from
 the new version's branch.
 
+> [!IMPORTANT]
+> The *kernel API* covered by these versioning guarantees is only the
+> public API: the symbols listed in the `__all__` of the kernel's
+> top-level `__init__.py`. Anything not in `__all__` (e.g. internal
+> helpers or names prefixed with `_`) is considered private and may
+> change or be removed at any time without a version bump. Export every
+> symbol you intend consumers to rely on in `__all__`.
+
 > [!NOTE]
 > By convention, we reserve version `0` for kernels that are still in
 > alpha or beta stage and are not recommended for production use (e.g.
@@ -393,6 +401,12 @@ __all__ = [
   # ...
 ]
 ```
+
+> [!IMPORTANT]
+> Only symbols listed in `__all__` are treated as the kernel's public
+> API. This is the surface that consumers can rely on and that the
+> [versioning guarantees](#versioning) apply to, so be sure to export
+> every function, class, and `layers` module you want to expose.
 
 ## Python requirements
 


### PR DESCRIPTION
this PR simply adds a new page in the docs for blog posts

**and a small note about requiring listing public apis in `__all__` 