### PR TITLE
Add Helion as a supported Python dependency

### DIFF
--- a/docs/source/builder/writing-kernels.md
+++ b/docs/source/builder/writing-kernels.md
@@ -205,8 +205,8 @@ The following sections enumerate all supported options for `build.toml`.
   formatted source repository. This repository must contain a `build.toml` and
   `flake.nix` so that it can be pulled and built with the kernel builder.
 - `python-depends` (**experimental**): a list of additional Python dependencies
-  that the kernel requires. The only supported dependencies are `einops`
-  and `nvidia-cutlass-dsl`.
+  that the kernel requires. The only supported dependencies are `einops`,
+  `helion`, and `nvidia-cutlass-dsl`.
 
 ### `general.hub`
 

--- a/docs/source/kernel-requirements.md
+++ b/docs/source/kernel-requirements.md
@@ -200,6 +200,7 @@ The following dependencies are currently allowed:
 **General dependencies:**
 
 - `einops`
+- `helion`
 
 **Backend-specific dependencies:**
 

--- a/kernels-data/src/python_dependencies.json
+++ b/kernels-data/src/python_dependencies.json
@@ -4,6 +4,10 @@
       "nix": ["einops"],
       "python": [{ "pkg": "einops", "import": "einops" }]
     },
+    "helion": {
+      "nix": ["helion"],
+      "python": [{ "pkg": "helion", "import": "helion" }]
+    },
     "tvm-ffi": {
       "nix": ["tvm-ffi"],
       "python": [{ "pkg": "apache-tvm-ffi", "import": "tvm_ffi" }]

--- a/kernels/src/kernels/python_depends.json
+++ b/kernels/src/kernels/python_depends.json
@@ -4,6 +4,10 @@
       "nix": ["einops"],
       "python": [{ "pkg": "einops", "import": "einops" }]
     },
+    "helion": {
+      "nix": ["helion"],
+      "python": [{ "pkg": "helion", "import": "helion" }]
+    },
     "tvm-ffi": {
       "nix": ["tvm-ffi"],
       "python": [{ "pkg": "apache-tvm-ffi", "import": "tvm_ffi" }]

--- a/nix-builder/overlay.nix
+++ b/nix-builder/overlay.nix
@@ -147,6 +147,16 @@ final: prev:
           };
         });
 
+        helion = python-super.helion.overrideAttrs (
+          _: prevAttrs: {
+            # nixpkgs marks Helion as broken without CUDA, but it also
+            # supports ROCm and XPU through Triton.
+            meta = prevAttrs.meta // {
+              broken = false;
+            };
+          }
+        );
+
         jax = python-super.jax.overrideAttrs (
           _: prevAttrs: {
             dontUsePytestCheck = true;


### PR DESCRIPTION
## What does this PR do?

Fixes #686 

Adds [Helion](https://github.com/pytorch/helion) to the supported `python-depends` list so that Helion kernels can be built and published as noarch kernels:

```toml
[general]
backends = ["cuda", "rocm", "xpu"]
python-depends = ["helion"]

[torch-noarch]
```

Helion kernels are pure Python (Triton-based, JIT-compiled at runtime, with optional pretuned/AOT heuristics shipped as `.py` files next to the kernel source), so no new build machinery is needed — only a dependency-registry entry.

### Verification

Tested end-to-end with a Helion vector-add kernel (based on Helion's [pretuned `vector_add`](https://github.com/pytorch/helion/blob/main/pretuned_kernels/vector_add/vector_add.py)) declaring `backends = ["cuda", "rocm", "xpu"]` and `python-depends = ["helion"]`:

- Bundle evaluates to all three noarch variants (`torch-cuda`, `torch-rocm`, `torch-xpu`) on x86_64-linux; without the overlay override, ROCm/XPU evaluation fails on the nixpkgs broken flag.
- The `torch-cuda` variant builds on aarch64-linux, passes `get-kernel-check` (which imports the kernel, and therefore Helion, inside the sandbox), and records `"python-depends": ["helion"]` in `metadata.json`.
- The built variant loads through `kernels.get_local_kernel` and produces correct results on an NVIDIA GB10.
- Helion's pretuned/AOT flow (`helion.experimental.aot_kernel` + `_helion_aot_*_sm<NN>.py` heuristic files, available since Helion 1.0.0) also works from a package dir: on sm121 it falls back to the sm100 heuristics and runs correctly.

### Notes

- Helion requires `torch >= 2.9` but does not declare it as a dependency (peer dep); the builder's Torch range satisfies this.
- nixpkgs is at Helion 1.0.0 while PyPI is at 1.2.0; if newer features are ever needed at build-check time, the overlay can bump the version.

Generated kernel: https://huggingface.co/kernels/sayakpaul/vector-add-helion

🤖 Generated with [Claude Code](https://claude.com/claude-code). Edited by me (Sayak)