### PR TITLE
Fix #669: Support XPU and other backends in benchmark

### DIFF
--- a/kernels/src/kernels/benchmarks/attention.py
+++ b/kernels/src/kernels/benchmarks/attention.py
@@ -44,10 +44,10 @@ class FlashAttentionBenchmark(Benchmark):
     # Workload: small (B=2, S=128, H=8, D=64)
     def setup_small(self):
         B, S, H, D = 2, 128, 8, 64
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_small(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=False))
@@ -58,10 +58,10 @@ class FlashAttentionBenchmark(Benchmark):
     # Workload: medium (B=4, S=512, H=16, D=64)
     def setup_medium(self):
         B, S, H, D = 4, 512, 16, 64
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_medium(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=False))
@@ -72,10 +72,10 @@ class FlashAttentionBenchmark(Benchmark):
     # Workload: large (B=8, S=1024, H=32, D=128)
     def setup_large(self):
         B, S, H, D = 8, 1024, 32, 128
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_large(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=False))
@@ -90,10 +90,10 @@ class FlashAttentionCausalBenchmark(Benchmark):
     # Workload: small (B=2, S=128, H=8, D=64)
     def setup_small(self):
         B, S, H, D = 2, 128, 8, 64
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_small(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=True))
@@ -104,10 +104,10 @@ class FlashAttentionCausalBenchmark(Benchmark):
     # Workload: medium (B=4, S=512, H=16, D=64)
     def setup_medium(self):
         B, S, H, D = 4, 512, 16, 64
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_medium(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=True))
@@ -118,10 +118,10 @@ class FlashAttentionCausalBenchmark(Benchmark):
     # Workload: large (B=8, S=1024, H=32, D=128)
     def setup_large(self):
         B, S, H, D = 8, 1024, 32, 128
-        self.q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
-        self.out = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(B, S, H, D, device=self.device, dtype=torch.float16)
+        self.out = torch.empty(B, S, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_large(self):
         self.out = _extract_output(self.kernel.flash_attn_func(self.q, self.k, self.v, causal=True))
@@ -139,16 +139,16 @@ class FlashAttentionVarlenBenchmark(Benchmark):
         # Pack sequences of lengths [32, 48, 64]
         seqlens = [32, 48, 64]
         total = sum(seqlens)
-        self.q = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
         self.cu_seqlens = torch.tensor(
             [0] + list(torch.cumsum(torch.tensor(seqlens), 0)),
-            device="cuda",
+            device=self.device,
             dtype=torch.int32,
         )
         self.max_seqlen = max(seqlens)
-        self.out = torch.empty(total, H, D, device="cuda", dtype=torch.float16)
+        self.out = torch.empty(total, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_small(self):
         self.out = _extract_output(
@@ -171,16 +171,16 @@ class FlashAttentionVarlenBenchmark(Benchmark):
         H, D = 16, 64
         seqlens = [128, 192, 256, 200, 150]
         total = sum(seqlens)
-        self.q = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
         self.cu_seqlens = torch.tensor(
             [0] + list(torch.cumsum(torch.tensor(seqlens), 0)),
-            device="cuda",
+            device=self.device,
             dtype=torch.int32,
         )
         self.max_seqlen = max(seqlens)
-        self.out = torch.empty(total, H, D, device="cuda", dtype=torch.float16)
+        self.out = torch.empty(total, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_medium(self):
         self.out = _extract_output(
@@ -203,16 +203,16 @@ class FlashAttentionVarlenBenchmark(Benchmark):
         H, D = 32, 128
         seqlens = [256, 384, 512, 448, 320, 480, 400, 512]
         total = sum(seqlens)
-        self.q = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.k = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
-        self.v = torch.randn(total, H, D, device="cuda", dtype=torch.float16)
+        self.q = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.k = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
+        self.v = torch.randn(total, H, D, device=self.device, dtype=torch.float16)
         self.cu_seqlens = torch.tensor(
             [0] + list(torch.cumsum(torch.tensor(seqlens), 0)),
-            device="cuda",
+            device=self.device,
             dtype=torch.int32,
         )
         self.max_seqlen = max(seqlens)
-        self.out = torch.empty(total, H, D, device="cuda", dtype=torch.float16)
+        self.out = torch.empty(total, H, D, device=self.device, dtype=torch.float16)
 
     def benchmark_large(self):
         self.out = _extract_output(

--- a/kernels/src/kernels/benchmarks/layer_norm.py
+++ b/kernels/src/kernels/benchmarks/layer_norm.py
@@ -10,8 +10,8 @@ class RMSNormBenchmark(Benchmark):
     # Workload: small (B=2, S=128, D=768)
     def setup_small(self):
         B, S, D = 2, 128, 768
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 
@@ -40,8 +40,8 @@ class RMSNormBenchmark(Benchmark):
     # Workload: medium (B=4, S=512, D=2048)
     def setup_medium(self):
         B, S, D = 4, 512, 2048
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 
@@ -70,8 +70,8 @@ class RMSNormBenchmark(Benchmark):
     # Workload: large (B=8, S=1024, D=4096)
     def setup_large(self):
         B, S, D = 8, 1024, 4096
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 
@@ -105,8 +105,8 @@ class LayerNormBenchmark(Benchmark):
     # Workload: small (B=2, S=128, D=768)
     def setup_small(self):
         B, S, D = 2, 128, 768
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 
@@ -134,8 +134,8 @@ class LayerNormBenchmark(Benchmark):
     # Workload: medium (B=4, S=512, D=2048)
     def setup_medium(self):
         B, S, D = 4, 512, 2048
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 
@@ -163,8 +163,8 @@ class LayerNormBenchmark(Benchmark):
     # Workload: large (B=8, S=1024, D=4096)
     def setup_large(self):
         B, S, D = 8, 1024, 4096
-        self.x = torch.randn(B, S, D, device="cuda", dtype=torch.float16)
-        self.weight = torch.ones(D, device="cuda", dtype=torch.float16)
+        self.x = torch.randn(B, S, D, device=self.device, dtype=torch.float16)
+        self.weight = torch.ones(D, device=self.device, dtype=torch.float16)
         self.out = torch.empty_like(self.x)
         self.B, self.S, self.D = B, S, D
 

--- a/kernels/src/kernels/cli/benchmark.py
+++ b/kernels/src/kernels/cli/benchmark.py
@@ -463,7 +463,7 @@ def run_benchmark_class(
     # Load kernel once for all workloads
     from kernels import get_kernel, get_local_kernel
 
-    # Detect the backend first
+    # Detect the backend
     backend_name = _backend().name
 
     if is_local:

--- a/kernels/src/kernels/cli/benchmark.py
+++ b/kernels/src/kernels/cli/benchmark.py
@@ -463,13 +463,16 @@ def run_benchmark_class(
     # Load kernel once for all workloads
     from kernels import get_kernel, get_local_kernel
 
+    # Detect the backend first
+    backend_name = _backend().name
+
     if is_local:
-        kernel = get_local_kernel(Path(repo_id))
+        kernel = get_local_kernel(Path(repo_id), backend=backend_name)
     else:
-        kernel = get_kernel(repo_id, revision=revision)
+        kernel = get_kernel(repo_id, revision=revision, backend=backend_name)
 
     kernel_sha = get_kernel_sha_from_build_name(kernel)
-    backend_name = _backend().name
+
     # Map backend names to torch device names
     device_map = {
         "rocm": "cuda",
@@ -477,7 +480,7 @@ def run_benchmark_class(
         "cann": "npu",
     }
     device = device_map.get(backend_name, backend_name)
-    print(f"  Running {benchmark_cls.__name__} on {device}", file=sys.stderr)
+    print(f"  Running {benchmark_cls.__name__} on {device} (backend: {backend_name})", file=sys.stderr)
 
     for method_name in benchmark_methods:
         workload_name = method_name.replace("benchmark_", "")

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -211,7 +211,8 @@ def _warn_if_dirty(metadata: Metadata, variant_str: str) -> None:
     so its git SHA does not fully identify the sources it was built from and
     the build may not be reproducible.
     """
-    provenance = metadata.provenance
+    # Check if provenance attribute exists (it may not in older metadata versions)
+    provenance = getattr(metadata, "provenance", None)
     if provenance is None or not provenance.dirty:
         return
 

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -211,8 +211,7 @@ def _warn_if_dirty(metadata: Metadata, variant_str: str) -> None:
     so its git SHA does not fully identify the sources it was built from and
     the build may not be reproducible.
     """
-    # Check if provenance attribute exists (it may not in older metadata versions)
-    provenance = getattr(metadata, "provenance", None)
+    provenance = metadata.provenance
     if provenance is None or not provenance.dirty:
         return
 


### PR DESCRIPTION
Closes #669

## What does this PR do?

- Fixes the hardcoded benchmarks for CUDA.
- Makes the benchmark system backend-agnostic by using the dynamically detected device.


## Changes

-  Added `backend` parameter to `get_kernel()` and `get_local_kernel()` to get the supported backend.
- Replaced all `device="cuda"` with `device=self.device`.

## Testing
- Tested with flash-attn benchmarking on XPU - ` kernels benchmark kernels-community/flash-attn2 --version 1`
- Output
```
Downloading kernels-community/flash-attn2@v1...
Running benchmark.py...

  GPU      N/A
  CPU      x86_64
  OS       Linux 7.0.0-27-generic
  PyTorch  2.12.0+xpu

Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
  Running FlashAttn on xpu (backend: xpu)
  Running FlashAttnCausal on xpu (backend: xpu)
  Running FlashAttnVarlen on xpu (backend: xpu)

┌─────────────────┬────────────┬─────┬───────────┬────────────┬───────────┬───────────┬───────────┬───────────┬────────────┬───────────┬─────────┐
│ Benchmark       │ Workload   │   N │ Speedup   │   Mean(ms) │   Std(ms) │   Min(ms) │   Max(ms) │   IQR(ms) │   Outliers │   Ref(ms) │ Match   │
├─────────────────┼────────────┼─────┼───────────┼────────────┼───────────┼───────────┼───────────┼───────────┼────────────┼───────────┼─────────┤
│ FlashAttn       │ large      │ 100 │ 11.81x    │     1.6025 │    0.1022 │    1.5189 │    2.2015 │    0.0649 │          8 │   18.9221 │ ✓       │
│ FlashAttn       │ medium     │ 100 │ 11.37x    │     0.1015 │    0.0068 │    0.0928 │    0.1424 │    0.0042 │          6 │    1.1543 │ ✓       │
│ FlashAttn       │ small      │ 100 │ 2.65x     │     0.0723 │    0.0033 │    0.0689 │    0.0851 │    0.0024 │         10 │    0.1917 │ ✓       │
│ FlashAttnCausal │ large      │ 100 │ 15.19x    │     1.2892 │    0.0455 │    1.2097 │    1.3777 │    0.0867 │          0 │   19.5821 │ ✓       │
│ FlashAttnCausal │ medium     │ 100 │ 11.69x    │     0.1046 │    0.0056 │    0.0973 │    0.1295 │    0.0049 │          6 │    1.2228 │ ✓       │
│ FlashAttnCausal │ small      │ 100 │ 3.34x     │     0.0722 │    0.0051 │    0.0677 │    0.1105 │    0.0023 │         13 │    0.2415 │ ✓       │
│ FlashAttnVarlen │ large      │ 100 │ 13.76x    │     0.3795 │    0.0225 │    0.3604 │    0.5332 │    0.0138 │          5 │    5.2222 │ ✓       │
│ FlashAttnVarlen │ medium     │ 100 │ 19.14x    │     0.0771 │    0.003  │    0.0731 │    0.0965 │    0.0018 │          9 │    1.4756 │ ✓       │
│ FlashAttnVarlen │ small      │ 100 │ 11.42x    │     0.0775 │    0.0028 │    0.0741 │    0.0869 │    0.0026 │         12 │    0.8851 │ ✓       │
└─────────────────┴────────────┴─────┴───────────┴────────────┴───────────┴───────────┴───────────┴───────────┴────────────┴───────────┴─────────┘

  large: 11.81x faster (95% CI: 1.5825-1.6225ms vs ref 18.9221ms) ✓ significant
  medium: 11.37x faster (95% CI: 0.1002-0.1028ms vs ref 1.1543ms) ✓ significant
  small: 2.65x faster (95% CI: 0.0717-0.0729ms vs ref 0.1917ms) ✓ significant
  large: 15.19x faster (95% CI: 1.2803-1.2981ms vs ref 19.5821ms) ✓ significant
  medium: 11.69x faster (95% CI: 0.1035-0.1057ms vs ref 1.2228ms) ✓ significant
  small: 3.34x faster (95% CI: 0.0712-0.0732ms vs ref 0.2415ms) ✓ significant
  large: 13.76x faster (95% CI: 0.3751-0.3839ms vs ref 5.2222ms) ✓ significant
  medium: 19.14x faster (95% CI: 0.0765-0.0777ms vs ref 1.4756ms) ✓ significant
  small: 11.42x faster (95% CI: 0.0770-0.0780ms vs ref 0.8851ms) ✓ significant

Kernel: f12afc9  Benchmark: 685a205
``` 

## Checklist

- [x] This PR is linked to an issue that was discussed and approved
- [x] I have tested these changes locally
- [ ] New/changed functionality has test coverage
- LLM disclosure:
  - [ ] I did not use an LLM to create this PR.
  - [x] I used and LLM for assistance while creating this PR.
  - [ ] This PR was mostly or completely generated by an LLM.
