### PR TITLE
add comment on trust_remote_code=True

### DIFF
--- a/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
+++ b/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
+++ b/examples/kernels/cutlass-gemm-tvm-ffi/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/cutlass-gemm/CARD.md
+++ b/examples/kernels/cutlass-gemm/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/cutlass-gemm/CARD.md
+++ b/examples/kernels/cutlass-gemm/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/extra-data/CARD.md
+++ b/examples/kernels/extra-data/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/extra-data/CARD.md
+++ b/examples/kernels/extra-data/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-archs-subset/CARD.md
+++ b/examples/kernels/relu-archs-subset/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-archs-subset/CARD.md
+++ b/examples/kernels/relu-archs-subset/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-backprop-compile/CARD.md
+++ b/examples/kernels/relu-backprop-compile/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-backprop-compile/CARD.md
+++ b/examples/kernels/relu-backprop-compile/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-compiler-flags/CARD.md
+++ b/examples/kernels/relu-compiler-flags/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-compiler-flags/CARD.md
+++ b/examples/kernels/relu-compiler-flags/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-invalid-capability/CARD.md
+++ b/examples/kernels/relu-invalid-capability/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-invalid-capability/CARD.md
+++ b/examples/kernels/relu-invalid-capability/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-metal-cpp/CARD.md
+++ b/examples/kernels/relu-metal-cpp/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-metal-cpp/CARD.md
+++ b/examples/kernels/relu-metal-cpp/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-nki/CARD.md
+++ b/examples/kernels/relu-nki/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-nki/CARD.md
+++ b/examples/kernels/relu-nki/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-specific-torch/CARD.md
+++ b/examples/kernels/relu-specific-torch/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-specific-torch/CARD.md
+++ b/examples/kernels/relu-specific-torch/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-torch-bounds/CARD.md
+++ b/examples/kernels/relu-torch-bounds/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-torch-bounds/CARD.md
+++ b/examples/kernels/relu-torch-bounds/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-torch-stable-abi/CARD.md
+++ b/examples/kernels/relu-torch-stable-abi/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-torch-stable-abi/CARD.md
+++ b/examples/kernels/relu-torch-stable-abi/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-triton/CARD.md
+++ b/examples/kernels/relu-triton/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-triton/CARD.md
+++ b/examples/kernels/relu-triton/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-tvm-ffi-compiler-flags/CARD.md
+++ b/examples/kernels/relu-tvm-ffi-compiler-flags/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-tvm-ffi-compiler-flags/CARD.md
+++ b/examples/kernels/relu-tvm-ffi-compiler-flags/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-tvm-ffi/CARD.md
+++ b/examples/kernels/relu-tvm-ffi/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu-tvm-ffi/CARD.md
+++ b/examples/kernels/relu-tvm-ffi/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu/CARD.md
+++ b/examples/kernels/relu/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/relu/CARD.md
+++ b/examples/kernels/relu/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/silu-and-mul-bad-registration/CARD.md
+++ b/examples/kernels/silu-and-mul-bad-registration/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/silu-and-mul-bad-registration/CARD.md
+++ b/examples/kernels/silu-and-mul-bad-registration/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/silu-and-mul/CARD.md
+++ b/examples/kernels/silu-and-mul/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/examples/kernels/silu-and-mul/CARD.md
+++ b/examples/kernels/silu-and-mul/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/kernel-builder/src/init/templates/CARD.md
+++ b/kernel-builder/src/init/templates/CARD.md
@@ -12,8 +12,10 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
-# If the org / user isn't a trusted publisher, then you should check out the kernel
-# source, and need to then pass `trust_remote_code=True`.
+# If the org / user isn't a trusted publisher, pass `trust_remote_code=True` to the
+# `get_kernel` call. You can find whether this kernel is from a trusted publisher
+# by going to the kernel's Hub page and finding the "Trusted publisher" status at
+# the top of the page.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 

--- a/kernel-builder/src/init/templates/CARD.md
+++ b/kernel-builder/src/init/templates/CARD.md
@@ -12,6 +12,8 @@ This is the repository card of {{ repo_id }} that has been pushed on the Hub. It
 # make sure `kernels` is installed: `pip install -U kernels`
 from kernels import get_kernel
 
+# If the org / user isn't a trusted publisher, then you should check out the kernel
+# source, and need to then pass `trust_remote_code=True`.
 kernel_module = get_kernel("{{ repo_id }}", version={{ version }})
 {{ functions[0] }} = kernel_module.{{ functions[0] }}
 


### PR DESCRIPTION
It is a bad experience for the users when most of the kernels on hf.co/kernels need `trust_remote_code=True` in the `get_kernel()` call. This PR adds a comment about that in our card template.