### PR TITLE
kernel-builder: fix collision of static variables between kernels

### DIFF
--- a/.github/workflows/build_kernel_cpu.yaml
+++ b/.github/workflows/build_kernel_cpu.yaml
@@ -1,0 +1,41 @@
+name: "Build and test kernel (CPU)"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened] # trigger on PRs
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build kernel
+    runs-on:
+      group: aws-highmemory-32-plus-nix
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+        with:
+          extra-conf: |
+            max-jobs = 4
+            cores = 12
+            sandbox-fallback = false
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        with:
+          name: huggingface
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+        env:
+          USER: runner
+      - name: Nix info
+        run: nix-shell -p nix-info --run "nix-info -m"
+      # CPU kernels don't require special hardware, so we build and run
+      # their CI tests (e.g. the symbol-conflicts pytest suite) in one step.
+      - name: Build and test all CPU example kernels
+        run: nix build -L ./examples/kernels#ci-build-cpu

--- a/examples/kernels/flake.nix
+++ b/examples/kernels/flake.nix
@@ -91,6 +91,11 @@
             sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-${cudaVersion}-${sys}"};
         }
         {
+          name = "relu-kernel-cpu";
+          path = ./relu;
+          drv = sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-cpu-${sys}"};
+        }
+        {
           name = "cutlass-gemm-kernel";
           path = ./cutlass-gemm;
           drv =
@@ -312,11 +317,6 @@
 
       # CPU kernels to build in CI.
       ciCpuKernels = [
-        {
-          name = "relu-kernel-cpu";
-          path = ./relu;
-          drv = sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-cpu-${sys}"};
-        }
         {
           # This test only requires a CPU, so let's run the test directly during the build.
           name = "symbol-conflicts-pytest";

--- a/examples/kernels/flake.nix
+++ b/examples/kernels/flake.nix
@@ -91,11 +91,6 @@
             sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-${cudaVersion}-${sys}"};
         }
         {
-          name = "relu-kernel-cpu";
-          path = ./relu;
-          drv = sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-cpu-${sys}"};
-        }
-        {
           name = "cutlass-gemm-kernel";
           path = ./cutlass-gemm;
           drv =
@@ -315,8 +310,50 @@
         }
       ];
 
+      # CPU kernels to build in CI.
+      ciCpuKernels = [
+        {
+          name = "relu-kernel-cpu";
+          path = ./relu;
+          drv = sys: out: out.packages.${sys}.redistributable.${"torch${torchVersion}-cxx11-cpu-${sys}"};
+        }
+        {
+          # This test only requires a CPU, so let's run the test directly during the build.
+          name = "symbol-conflicts-pytest";
+          path = ./symbol-conflicts2;
+          drv =
+            sys: _out:
+            let
+              variant = "torch${torchVersion}-cxx11-cpu-${sys}";
+              conflictsFlake = mkKernelOutputs { path = ./symbol-conflicts; };
+              conflicts2Flake = mkKernelOutputs { path = ./symbol-conflicts2; };
+              conflicts = conflictsFlake.packages.${sys}.redistributable.${variant};
+              conflicts2 = conflicts2Flake.packages.${sys}.redistributable.${variant};
+              kernelPkgs = conflictsFlake.packages.${sys}.pkgs.${variant};
+              testPython = kernelPkgs.python3.withPackages (
+                ps: with ps; [
+                  torch
+                  pytest
+                  kernels
+                ]
+              );
+            in
+            kernelPkgs.runCommand "symbol-conflicts-pytest"
+              {
+                nativeBuildInputs = [ testPython ];
+              }
+              ''
+                export HOME=$TMPDIR
+                export LOCAL_KERNELS="kernels-test/symbol-conflicts=${conflicts}:kernels-test/symbol-conflicts2=${conflicts2}"
+                python -m pytest ${conflicts2.src}/tests -m kernels_ci -p no:cacheprovider
+                touch $out
+              '';
+        }
+      ];
+
       ciXpuKernelOutputs = mkKernelOutputs' ciXpuKernels;
       ciMetalKernelOutputs = mkKernelOutputs' ciMetalKernels;
+      ciCpuKernelOutputs = mkKernelOutputs' ciCpuKernels;
     in
     flake-utils.lib.eachSystem
       [
@@ -416,6 +453,7 @@
           ci-build-rocm = mkCiBuild "ci-kernels-rocm" ciRocmKernelOutputs;
           ci-build-xpu = mkCiBuild "ci-kernels-xpu" ciXpuKernelOutputs;
           ci-build-metal = mkCiBuild "ci-kernels-metal" ciMetalKernelOutputs;
+          ci-build-cpu = mkCiBuild "ci-kernels-cpu" ciCpuKernelOutputs;
         in
         {
           packages = {
@@ -424,6 +462,7 @@
               ci-build-rocm
               ci-build-xpu
               ci-build-metal
+              ci-build-cpu
               ;
             default = ci-build-cuda;
           };

--- a/examples/kernels/symbol-conflicts/build.toml
+++ b/examples/kernels/symbol-conflicts/build.toml
@@ -8,7 +8,7 @@ version = 1
 edition = 5
 
 [general.hub]
-repo-id = "kernels-test/symbol-conflicts2"
+repo-id = "kernels-test/symbol-conflicts"
 
 [torch]
 src = [

--- a/examples/kernels/symbol-conflicts/build.toml
+++ b/examples/kernels/symbol-conflicts/build.toml
@@ -1,0 +1,22 @@
+[general]
+name = "symbol-conflicts"
+license = "Apache-2.0"
+backends = [
+  "cpu",
+]
+version = 1
+edition = 5
+
+[general.hub]
+repo-id = "kernels-test/symbol-conflicts2"
+
+[torch]
+src = [
+  "torch-ext/torch_binding.cpp",
+  "torch-ext/torch_binding.h",
+]
+
+[kernel.conflicts_cpu]
+backend = "cpu"
+depends = ["torch"]
+src = ["conflicts_cpu/conflicts_cpu.cpp"]

--- a/examples/kernels/symbol-conflicts/conflicts_cpu/conflicts_cpu.cpp
+++ b/examples/kernels/symbol-conflicts/conflicts_cpu/conflicts_cpu.cpp
@@ -1,0 +1,32 @@
+#include <cstddef>
+
+#include <torch/all.h>
+
+
+namespace test {
+
+static int64_t global_counter = 0;
+
+int64_t conflicts(torch::Tensor const &input) {
+  return global_counter++;
+}
+
+int64_t conflicts_dynamic(torch::Tensor const &input) {
+  static int64_t func_counter = 0;
+  return func_counter++;
+}
+
+struct Conflicts {
+  static int value() {
+    static int64_t class_counter = 0;
+    return class_counter++;
+  }
+};
+
+static Conflicts conflicts_obj;
+
+int64_t conflicts_class(torch::Tensor const &input) {
+  return conflicts_obj.value();
+}
+
+}

--- a/examples/kernels/symbol-conflicts/flake.nix
+++ b/examples/kernels/symbol-conflicts/flake.nix
@@ -1,0 +1,11 @@
+{
+  inputs = {
+    kernel-builder.url = "path:../../..";
+  };
+  outputs =
+    { self, kernel-builder, ... }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/examples/kernels/symbol-conflicts/torch-ext/symbol_conflicts/__init__.py
+++ b/examples/kernels/symbol-conflicts/torch-ext/symbol_conflicts/__init__.py
@@ -1,0 +1,15 @@
+import torch
+
+from ._ops import ops
+
+
+def conflicts(x: torch.Tensor) -> int:
+    return ops.conflicts(x)
+
+
+def conflicts_dynamic(x: torch.Tensor) -> int:
+    return ops.conflicts_dynamic(x)
+
+
+def conflicts_class(x: torch.Tensor) -> int:
+    return ops.conflicts_class(x)

--- a/examples/kernels/symbol-conflicts/torch-ext/torch_binding.cpp
+++ b/examples/kernels/symbol-conflicts/torch-ext/torch_binding.cpp
@@ -1,0 +1,17 @@
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def("conflicts(Tensor x) -> int");
+  ops.def("conflicts_dynamic(Tensor x) -> int");
+  ops.def("conflicts_class(Tensor x) -> int");
+#if defined(CPU_KERNEL)
+  ops.impl("conflicts", torch::kCPU, &test::conflicts);
+  ops.impl("conflicts_dynamic", torch::kCPU, &test::conflicts_dynamic);
+  ops.impl("conflicts_class", torch::kCPU, &test::conflicts_class);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/examples/kernels/symbol-conflicts/torch-ext/torch_binding.h
+++ b/examples/kernels/symbol-conflicts/torch-ext/torch_binding.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace test {
+
+int64_t conflicts(torch::Tensor const &input);
+int64_t conflicts_dynamic(torch::Tensor const &input);
+int64_t conflicts_class(torch::Tensor const &input);
+
+}

--- a/examples/kernels/symbol-conflicts2/build.toml
+++ b/examples/kernels/symbol-conflicts2/build.toml
@@ -1,0 +1,22 @@
+[general]
+name = "symbol-conflicts2"
+license = "Apache-2.0"
+backends = [
+  "cpu",
+]
+version = 1
+edition = 5
+
+[general.hub]
+repo-id = "kernels-test/symbol-conflicts2"
+
+[torch]
+src = [
+  "torch-ext/torch_binding.cpp",
+  "torch-ext/torch_binding.h",
+]
+
+[kernel.conflicts_cpu]
+backend = "cpu"
+depends = ["torch"]
+src = ["conflicts_cpu/conflicts_cpu.cpp"]

--- a/examples/kernels/symbol-conflicts2/conflicts_cpu/conflicts_cpu.cpp
+++ b/examples/kernels/symbol-conflicts2/conflicts_cpu/conflicts_cpu.cpp
@@ -1,0 +1,32 @@
+#include <cstddef>
+
+#include <torch/all.h>
+
+
+namespace test {
+
+static int64_t global_counter = 0;
+
+int64_t conflicts(torch::Tensor const &input) {
+  return global_counter++;
+}
+
+int64_t conflicts_dynamic(torch::Tensor const &input) {
+  static int64_t func_counter = 0;
+  return func_counter++;
+}
+
+struct Conflicts {
+  static int value() {
+    static int64_t class_counter = 0;
+    return class_counter++;
+  }
+};
+
+static Conflicts conflicts_obj;
+
+int64_t conflicts_class(torch::Tensor const &input) {
+  return conflicts_obj.value();
+}
+
+}

--- a/examples/kernels/symbol-conflicts2/flake.nix
+++ b/examples/kernels/symbol-conflicts2/flake.nix
@@ -1,0 +1,11 @@
+{
+  inputs = {
+    kernel-builder.url = "path:../../..";
+  };
+  outputs =
+    { self, kernel-builder, ... }:
+    kernel-builder.lib.genKernelFlakeOutputs {
+      inherit self;
+      path = ./.;
+    };
+}

--- a/examples/kernels/symbol-conflicts2/tests/test_conflicts.py
+++ b/examples/kernels/symbol-conflicts2/tests/test_conflicts.py
@@ -1,0 +1,48 @@
+from types import ModuleType
+from typing import Tuple
+
+from kernels import get_kernel
+import pytest
+import torch
+
+
+@pytest.fixture
+def kernels() -> Tuple[ModuleType, ModuleType]:
+    # These are not actually uploaded kernels, but we need to use
+    # a trusted namespace to avoid attacks.
+    kernel = get_kernel("kernels-test/symbol-conflicts", version=1)
+    kernel2 = get_kernel("kernels-test/symbol-conflicts2", version=1)
+    return kernel, kernel2
+
+
+@pytest.mark.kernels_ci
+def test_conflicts(kernels):
+    kernel, kernel2 = kernels
+    scalar = torch.Tensor(10)
+    kernel.conflicts(scalar)
+    kernel.conflicts(scalar)
+    assert kernel.conflicts(scalar) == 2
+    assert kernel2.conflicts(scalar) == 0
+    assert kernel2.conflicts(scalar) == 1
+
+
+@pytest.mark.kernels_ci
+def test_conflicts_dynamic(kernels):
+    kernel, kernel2 = kernels
+    scalar = torch.Tensor(10)
+    kernel.conflicts_dynamic(scalar)
+    kernel.conflicts_dynamic(scalar)
+    assert kernel.conflicts_dynamic(scalar) == 2
+    assert kernel2.conflicts_dynamic(scalar) == 0
+    assert kernel2.conflicts_dynamic(scalar) == 1
+
+
+@pytest.mark.kernels_ci
+def test_conflicts_class(kernels):
+    kernel, kernel2 = kernels
+    scalar = torch.Tensor(10)
+    kernel.conflicts_class(scalar)
+    kernel.conflicts_class(scalar)
+    assert kernel.conflicts_class(scalar) == 2
+    assert kernel2.conflicts_class(scalar) == 0
+    assert kernel2.conflicts_class(scalar) == 1

--- a/examples/kernels/symbol-conflicts2/torch-ext/symbol_conflicts2/__init__.py
+++ b/examples/kernels/symbol-conflicts2/torch-ext/symbol_conflicts2/__init__.py
@@ -1,0 +1,15 @@
+import torch
+
+from ._ops import ops
+
+
+def conflicts(x: torch.Tensor) -> int:
+    return ops.conflicts(x)
+
+
+def conflicts_dynamic(x: torch.Tensor) -> int:
+    return ops.conflicts_dynamic(x)
+
+
+def conflicts_class(x: torch.Tensor) -> int:
+    return ops.conflicts_class(x)

--- a/examples/kernels/symbol-conflicts2/torch-ext/torch_binding.cpp
+++ b/examples/kernels/symbol-conflicts2/torch-ext/torch_binding.cpp
@@ -1,0 +1,17 @@
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def("conflicts(Tensor x) -> int");
+  ops.def("conflicts_dynamic(Tensor x) -> int");
+  ops.def("conflicts_class(Tensor x) -> int");
+#if defined(CPU_KERNEL)
+  ops.impl("conflicts", torch::kCPU, &test::conflicts);
+  ops.impl("conflicts_dynamic", torch::kCPU, &test::conflicts_dynamic);
+  ops.impl("conflicts_class", torch::kCPU, &test::conflicts_class);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/examples/kernels/symbol-conflicts2/torch-ext/torch_binding.h
+++ b/examples/kernels/symbol-conflicts2/torch-ext/torch_binding.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <torch/torch.h>
+
+namespace test {
+
+int64_t conflicts(torch::Tensor const &input);
+int64_t conflicts_dynamic(torch::Tensor const &input);
+int64_t conflicts_class(torch::Tensor const &input);
+
+}

--- a/kernel-builder/src/pyproject/templates/torch/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/preamble.cmake
@@ -28,6 +28,7 @@ set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1
 # we set the arches per-file later anyway.
 set(ENV{PYTORCH_ROCM_ARCH} "${HIP_SUPPORTED_ARCHS}")
 
+include(CheckCXXCompilerFlag)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/kernel.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/get_gpu_lang.cmake)

--- a/kernel-builder/src/pyproject/templates/torch/torch-extension.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/torch-extension.cmake
@@ -14,6 +14,15 @@ define_gpu_extension_target(
   USE_SABI 3
   WITH_SOABI)
 
+# Avoid that definitions of template static data members and static local
+# variables in inline functions collide. Leads to subtle bugs between kernels
+# that happen to have clashes.
+check_cxx_compiler_flag("-fno-gnu-unique" CXX_HAS_NO_GNU_UNIQUE)
+if(CXX_HAS_NO_GNU_UNIQUE)
+  target_compile_options(${OPS_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fno-gnu-unique>)
+  target_compile_options(${OPS_NAME} PRIVATE $<$<COMPILE_LANGUAGE:GPU_LANGUAGE>:-fno-gnu-unique>)
+endif()
+
 if(GPU_LANG STREQUAL "SYCL")
     target_link_options(${OPS_NAME} PRIVATE ${sycl_link_flags})
     target_link_libraries(${OPS_NAME} PRIVATE dnnl)

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
@@ -22,6 +22,7 @@ include(FetchContent)
 file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
 message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 
+include(CheckCXXCompilerFlag)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/kernel.cmake)
 

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
@@ -11,6 +11,7 @@ tvm_ffi_configure_target(${OPS_NAME})
 # that happen to have clashes.
 check_cxx_compiler_flag("-fno-gnu-unique" CXX_HAS_NO_GNU_UNIQUE)
 if(CXX_HAS_NO_GNU_UNIQUE)
+  target_compile_options(${OPS_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fno-gnu-unique>)
   target_compile_options(${OPS_NAME} PRIVATE $<$<COMPILE_LANGUAGE:GPU_LANGUAGE>:-fno-gnu-unique>)
 endif()
 

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/tvm-ffi-extension.cmake
@@ -6,6 +6,14 @@ target_compile_definitions(${OPS_NAME} PRIVATE
   "-DTVM_FFI_EXTENSION_NAME=${OPS_NAME}")
 tvm_ffi_configure_target(${OPS_NAME})
 
+# Avoid that definitions of template static data members and static local
+# variables in inline functions collide. Leads to subtle bugs between kernels
+# that happen to have clashes.
+check_cxx_compiler_flag("-fno-gnu-unique" CXX_HAS_NO_GNU_UNIQUE)
+if(CXX_HAS_NO_GNU_UNIQUE)
+  target_compile_options(${OPS_NAME} PRIVATE $<$<COMPILE_LANGUAGE:GPU_LANGUAGE>:-fno-gnu-unique>)
+endif()
+
 if(GPU_LANG STREQUAL "SYCL")
     target_link_options(${OPS_NAME} PRIVATE ${sycl_link_flags})
     target_link_libraries(${OPS_NAME} PRIVATE dnnl)

--- a/nix-builder/lib/gen-flake-outputs.nix
+++ b/nix-builder/lib/gen-flake-outputs.nix
@@ -287,6 +287,15 @@ in
           meta.mainProgram = "kernels";
         };
 
+      # Package set by build variant, makes them easily available for tests,
+      # ad-hoc shells, etc.
+      pkgs = builtins.listToAttrs (
+        map (buildSet: {
+          name = buildSet.variants.kernelVariant kernelConfig;
+          value = buildSet.pkgs;
+        }) applicableBuildSets
+      );
+
       redistributable = build.mkDistTorchExtensions {
         inherit path doGetKernelCheck kernelProvenance;
         bundleOnly = false;


### PR DESCRIPTION
gcc makes template static data members and static local variables in inline functions globally unique. This is, however, a problem for kernels, since two kernels or kernel versions could use a static variable with the same name, resulting in inconsistent state.

Note that this is not resolved by `RTLD_LOCAL` being used when `dlopen`'ing Python extensions. These globally unique symbols are excepted in hiding by `RTLD_LOCAL`.

We resolve this by passing `-fno-gnu-unique` to compilers that support it (compilers that don't support it, most likely do not make these symbols globally unique).

Also add tests that would catch such unwanted sharing in the future.