### PR TITLE
Add CUTLASS 4.4.2 dependency and fix 4.5.2 source hash

### DIFF
--- a/kernels-data/src/config/deps.rs
+++ b/kernels-data/src/config/deps.rs
@@ -25,6 +25,8 @@ pub enum Dependency {
     Cutlass3_9,
     #[serde(rename = "cutlass_4_0")]
     Cutlass4_0,
+    #[serde(rename = "cutlass_4_4")]
+    Cutlass4_4,
     #[serde(rename = "cutlass_4_5")]
     Cutlass4_5,
     #[serde(rename = "sycl_tla")]

--- a/nix-builder/lib/deps.nix
+++ b/nix-builder/lib/deps.nix
@@ -25,6 +25,9 @@ let
     "cutlass_4_0" = [
       pkgs.cutlass_4_0
     ];
+    "cutlass_4_4" = [
+      pkgs.cutlass_4_4
+    ];
     "cutlass_4_5" = [
       pkgs.cutlass_4_5
     ];

--- a/nix-builder/pkgs/cutlass/default.nix
+++ b/nix-builder/pkgs/cutlass/default.nix
@@ -36,6 +36,6 @@ in
 
   cutlass_4_5 = builder {
     version = "4.5.2";
-    hash = "sha256-jnxookfCEPynRrxMGGsMwPlK84ChQQW3xocmYcNTVLw=";
+    hash = "sha256-5SMEfoqB2QXRfH5wBwTKKjez0x2zhR8T8EA0bqPMqwM=";
   };
 }

--- a/nix-builder/pkgs/cutlass/default.nix
+++ b/nix-builder/pkgs/cutlass/default.nix
@@ -34,6 +34,11 @@ in
     hash = "sha256-HJY+Go1viPkSVZPEs/NyMtYJzas4mMLiIZF3kNX+WgA=";
   };
 
+  cutlass_4_4 = builder {
+    version = "4.4.2";
+    hash = "sha256-0q9Ad0Z6E/rO2PdM4uQc8H0E0qs9uKc3reHepiHhjEc=";
+  };
+
   cutlass_4_5 = builder {
     version = "4.5.2";
     hash = "sha256-5SMEfoqB2QXRfH5wBwTKKjez0x2zhR8T8EA0bqPMqwM=";


### PR DESCRIPTION
This does two narrowly scoped builder dependency updates needed by FlashRT FMHA packaging:\n\n- adds `cutlass_4_4` backed by CUTLASS v4.4.2; example-77 FMHA sources use the pre-4.5 `SM100_MMA_F8F6F4_SS` template interface and do not compile against 4.5.2;\n- updates the stale CUTLASS 4.5.2 fixed-output hash reported by Nix.\n\n`cargo test -p kernels-data` passes (29/29). The FlashRT package using `cutlass_4_4` now builds successfully through HF Jobs.