### PR TITLE
Untangle kernel loading, part 3

### DIFF
--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -28,7 +28,7 @@ from kernels.layer import (
     use_kernel_mapping,
     use_kernelized_func,
 )
-from kernels.utils import (
+from kernels.load import (
     get_kernel,
     get_local_kernel,
     get_locked_kernel,

--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -8,6 +8,7 @@ from kernels._windows import _add_additional_dll_paths
 from kernels.benchmark import Benchmark
 from kernels.hf_hub import RepoInfo
 from kernels.importer import LoadedKernel, get_loaded_kernels
+from kernels.install import install_kernel
 from kernels.layer import (
     CUDAProperties,
     Device,
@@ -32,7 +33,6 @@ from kernels.utils import (
     get_local_kernel,
     get_locked_kernel,
     has_kernel,
-    install_kernel,
     load_kernel,
 )
 from kernels.variants import (

--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -29,7 +29,6 @@ from kernels.layer import (
 from kernels.utils import (
     LoadedKernel,
     get_kernel,
-    get_kernel_variants,
     get_loaded_kernels,
     get_local_kernel,
     get_locked_kernel,
@@ -40,6 +39,7 @@ from kernels.utils import (
 from kernels.variants import (
     VariantAccepted,
     VariantRejected,
+    get_kernel_variants,
 )
 
 _add_additional_dll_paths()

--- a/kernels/src/kernels/__init__.py
+++ b/kernels/src/kernels/__init__.py
@@ -7,6 +7,7 @@ from kernels_data import Metadata
 from kernels._windows import _add_additional_dll_paths
 from kernels.benchmark import Benchmark
 from kernels.hf_hub import RepoInfo
+from kernels.importer import LoadedKernel, get_loaded_kernels
 from kernels.layer import (
     CUDAProperties,
     Device,
@@ -27,9 +28,7 @@ from kernels.layer import (
     use_kernelized_func,
 )
 from kernels.utils import (
-    LoadedKernel,
     get_kernel,
-    get_loaded_kernels,
     get_local_kernel,
     get_locked_kernel,
     has_kernel,

--- a/kernels/src/kernels/cli/__init__.py
+++ b/kernels/src/kernels/cli/__init__.py
@@ -8,11 +8,11 @@ from kernels.cli.info import print_kernel_info
 from kernels.cli.verify_signature import verify_signature
 from kernels.cli.versions import print_kernel_versions
 from kernels.compat import tomllib
-from kernels.locking import KernelLock, get_kernel_locks
-from kernels.utils import (
+from kernels.install import (
     install_kernel,
     install_kernel_all_variants,
 )
+from kernels.locking import KernelLock, get_kernel_locks
 
 
 def main():

--- a/kernels/src/kernels/cli/benchmark.py
+++ b/kernels/src/kernels/cli/benchmark.py
@@ -20,9 +20,9 @@ from huggingface_hub.utils import (
     hf_raise_for_status,
 )
 
+from kernels.backends import _backend
 from kernels.benchmark import Benchmark
 from kernels.hf_hub import _get_hf_api
-from kernels.utils import _backend
 
 MISSING_DEPS: list[str] = []
 

--- a/kernels/src/kernels/cli/verify_signature.py
+++ b/kernels/src/kernels/cli/verify_signature.py
@@ -7,7 +7,7 @@ else:
     from typing_extensions import assert_never
 
 from kernels._versions import select_revision_or_version
-from kernels.utils import install_kernel, install_kernel_all_variants
+from kernels.install import install_kernel, install_kernel_all_variants
 from kernels.variants import get_variants_local
 from kernels.verify import VerificationResult, verify_variant
 

--- a/kernels/src/kernels/deps.py
+++ b/kernels/src/kernels/deps.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from huggingface_hub.dataclasses import strict
+from kernels_data import Metadata
 
-from kernels.backends import Backend
+from kernels.backends import Backend, _backend
 
 
 @strict
@@ -57,6 +58,11 @@ try:
         _DEPENDENCY_DATA = DependencyData.from_dict(json.load(f))
 except FileNotFoundError:
     raise FileNotFoundError("Cannot load dependency data, is `kernels` correctly installed?")
+
+
+def validate_variant_dependencies(variant_path: Path) -> None:
+    metadata = Metadata.read_from_file(variant_path / "metadata.json")
+    validate_dependencies(metadata.name.python_name, metadata.python_depends, _backend())
 
 
 def validate_dependencies(kernel_module_name: str, dependencies: list[str], backend: Backend):

--- a/kernels/src/kernels/importer.py
+++ b/kernels/src/kernels/importer.py
@@ -1,0 +1,122 @@
+import importlib
+import sys
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+from kernels_data import Metadata
+
+from kernels.hf_hub import RepoInfo
+
+
+@dataclass(frozen=True)
+class LoadedKernel:
+    """
+    This dataclass provides information about a loaded kernel:
+
+    - `metadata` (`Metadata`): kernel metadata.
+    - `module` (`ModuleType`): the imported kernel module.
+    - `repo_info` (`kernels.utils.RepoInfo | None`): populated only for
+      kernels loaded via `get_kernel`. Loaders that work from a local path
+      (`get_local_kernel`) or a lockfile (`get_locked_kernel`, `load_kernel`)
+      leave this as `None`.
+
+    The metadata includes the following properties that describe a kernel:
+
+    - `id` (`str`): kernel identifier that is unique to the kernel version + backend.
+    - `name` (`str`): the name of the kernel.
+    - `version` (`int`): the version of the kernel.
+    - `license` (`str`): the license of the kernel.
+    - `upstream` (`str | None`): the original upstream repository of the kernel.
+    - `source` (`str | None`): the kernel-builder formatted source repository.
+    - `python_depends` (`list[str]`): required Python dependencies.
+    - `backend`: information about the kernel's backend.
+    """
+
+    metadata: Metadata
+    module: ModuleType
+    repo_info: RepoInfo | None
+
+
+_loaded_kernels: dict[Path, LoadedKernel] = {}
+
+
+def get_loaded_kernels() -> list[LoadedKernel]:
+    """
+    Return a snapshot of every kernel that has been loaded into the current process.
+
+    The returned list is a new list; mutating it does not affect the registry.
+
+    Returns:
+        `list[LoadedKernel]`: One [`LoadedKernel`] per distinct kernel variant path
+        loaded in this process.
+
+    Example:
+        ```python
+        from kernels import get_kernel, get_loaded_kernels
+
+        get_kernel("kernels-community/activation", version=1)
+        for loaded in get_loaded_kernels():
+            print(loaded.metadata.name, loaded.repo_info)
+        ```
+    """
+    return list(_loaded_kernels.values())
+
+
+def _warn_if_dirty(metadata: Metadata, variant_str: str) -> None:
+    """Warn when a kernel variant was built from a dirty git tree.
+
+    A dirty build was produced from a working tree with uncommitted changes,
+    so its git SHA does not fully identify the sources it was built from and
+    the build may not be reproducible.
+    """
+    provenance = metadata.provenance
+    if provenance is None or not provenance.dirty:
+        return
+
+    dirty_sources = []
+    if provenance.kernel is not None and provenance.kernel.dirty:
+        dirty_sources.append("kernel source")
+    builder_git = provenance.kernel_builder.git
+    if builder_git is not None and builder_git.dirty:
+        dirty_sources.append("kernel-builder")
+
+    warnings.warn(
+        f"Kernel '{metadata.name}' variant '{variant_str}' was built from a dirty "
+        f"git tree ({', '.join(dirty_sources)} had uncommitted changes). Its "
+        "recorded git revision does not fully identify the sources it was built "
+        "from, so the build may not be reproducible.",
+        stacklevel=3,
+    )
+
+
+def _import_from_path(variant_path: Path, repo_info: RepoInfo | None = None) -> ModuleType:
+    if (loaded_kernel := _loaded_kernels.get(variant_path)) is not None:
+        return loaded_kernel.module
+
+    metadata = Metadata.read_from_file(variant_path / "metadata.json")
+    _warn_if_dirty(metadata, variant_path.name)
+    module_name = metadata.name.python_name
+
+    file_path = variant_path / "__init__.py"
+    if not file_path.exists():
+        file_path = variant_path / module_name / "__init__.py"
+    if not file_path.exists():
+        raise FileNotFoundError(f"No kernel module found at: `{variant_path}`")
+
+    spec = importlib.util.spec_from_file_location(metadata.id, file_path)
+    if spec is None:
+        raise ImportError(f"Cannot load spec for {module_name} from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    if module is None:
+        raise ImportError(f"Cannot load module {module_name} from spec")
+    sys.modules[metadata.id] = module
+    spec.loader.exec_module(module)  # type: ignore
+
+    _loaded_kernels[variant_path] = LoadedKernel(
+        metadata=metadata,
+        module=module,
+        repo_info=repo_info,
+    )
+    return module

--- a/kernels/src/kernels/importer.py
+++ b/kernels/src/kernels/importer.py
@@ -17,7 +17,7 @@ class LoadedKernel:
 
     - `metadata` (`Metadata`): kernel metadata.
     - `module` (`ModuleType`): the imported kernel module.
-    - `repo_info` (`kernels.utils.RepoInfo | None`): populated only for
+    - `repo_info` (`kernels.hf_hub.RepoInfo | None`): populated only for
       kernels loaded via `get_kernel`. Loaders that work from a local path
       (`get_local_kernel`) or a lockfile (`get_locked_kernel`, `load_kernel`)
       leave this as `None`.

--- a/kernels/src/kernels/install.py
+++ b/kernels/src/kernels/install.py
@@ -1,0 +1,198 @@
+from pathlib import Path
+
+from huggingface_hub import HfApi
+from huggingface_hub.errors import LocalEntryNotFoundError
+
+from kernels.deps import validate_variant_dependencies
+from kernels.hf_hub import CACHE_DIR, _get_hf_api
+from kernels.status import resolve_status
+from kernels.variants import (
+    Variant,
+    get_variants,
+    get_variants_local,
+    resolve_variant,
+    variants_trace_str,
+)
+
+# Exclude pattern for bytecode. These are not included in kernel builds,
+# but builds not done using kernel-builder might accidentally include
+# bytecode. So these patterns are used to ensure that they are never
+# downloaded.
+_BYTECODE_IGNORE_PATTERNS = ["*.pyc", "**/__pycache__/**"]
+
+
+def install_kernel(
+    repo_id: str,
+    *,
+    revision: str,
+    local_files_only: bool = False,
+    backend: str | None = None,
+    user_agent: str | dict | None = None,
+    validate_dependencies: bool = False,
+) -> Path:
+    """
+    Download a kernel for the current environment to the cache.
+
+    The output path is validated against the hashes in `variant_locks` when provided.
+
+    Args:
+        repo_id (`str`):
+            The Hub repository containing the kernel.
+        revision (`str`):
+            The specific revision (branch, tag, or commit) to download.
+        local_files_only (`bool`, *optional*, defaults to `False`):
+            Whether to only use local files and not download from the Hub.
+        backend (`str`, *optional*):
+            The backend to load the kernel for. Can only be `cpu` or the backend that Torch is compiled for.
+            The backend will be detected automatically if not provided.
+        user_agent (`Union[str, dict]`, *optional*):
+            The `user_agent` info to pass to `snapshot_download()` for internal telemetry.
+        validate_dependencies (`bool`, defaults to False):
+            When set to True, performs dependency validation. Useful for kernels that have
+            extra Python dependencies.
+
+    Returns:
+        `Path`: The path to the variant directory.
+    """
+    api = _get_hf_api(user_agent=user_agent)
+    if local_files_only:
+        # Same local-cache resolution path used by `load_kernel`, which is
+        # always offline. Sharing the helper avoids the network dependency
+        # that `get_variants` would otherwise introduce.
+        variant_path = _resolve_local_variant_path(
+            api,
+            repo_id,
+            revision=revision,
+            backend=backend,
+        )
+        # For locally downloaded kernels, we run the validation after resolving the path
+        if validate_dependencies:
+            validate_variant_dependencies(variant_path)
+        return variant_path
+
+    repo_id, revision = resolve_status(api, repo_id, revision)
+    variants = get_variants(api, repo_id=repo_id, revision=revision)
+    variant, trace = resolve_variant(variants, backend)
+
+    if variant is None:
+        raise FileNotFoundError(
+            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(trace)}"
+        )
+
+    # Validate Python dependencies before downloading the variant.
+    if validate_dependencies:
+        metadata_path = api.hf_hub_download(
+            repo_id,
+            repo_type="kernel",
+            filename=f"build/{variant.variant_str}/metadata.json",
+            cache_dir=CACHE_DIR,
+            revision=revision,
+            local_files_only=False,
+        )
+        validate_variant_dependencies(Path(metadata_path).parent)
+
+    allow_patterns = [f"build/{variant.variant_str}/*"]
+    ignore_patterns = _BYTECODE_IGNORE_PATTERNS
+
+    repo_path = Path(
+        str(
+            api.snapshot_download(
+                repo_id,
+                repo_type="kernel",
+                allow_patterns=allow_patterns,
+                ignore_patterns=ignore_patterns,
+                cache_dir=CACHE_DIR,
+                revision=revision,
+                local_files_only=False,
+            )
+        )
+    )
+
+    try:
+        return _find_kernel_in_repo_path(
+            repo_path,
+            variant=variant,
+        )
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Cannot install kernel from repo {repo_id} (revision: {revision})")
+
+
+def _resolve_local_variant_path(
+    api: HfApi,
+    repo_id: str,
+    *,
+    revision: str,
+    backend: str | None = None,
+) -> Path:
+    """Resolve a kernel variant path from the local Hugging Face cache only.
+
+    Used by `load_kernel` (which always operates on a pre-downloaded, locked
+    kernel) and by the offline branch of `install_kernel`.
+    """
+    try:
+        local_repo_path = Path(
+            str(
+                api.snapshot_download(
+                    repo_id,
+                    repo_type="kernel",
+                    ignore_patterns=_BYTECODE_IGNORE_PATTERNS,
+                    cache_dir=CACHE_DIR,
+                    revision=revision,
+                    local_files_only=True,
+                )
+            )
+        )
+    except LocalEntryNotFoundError as e:
+        raise FileNotFoundError(
+            f"Cannot find a local snapshot for {repo_id} (revision: {revision}). "
+            "When Hugging Face Hub is in offline mode the kernel must already "
+            "be present in the local cache."
+        ) from e
+
+    variants = get_variants_local(local_repo_path / "build")
+    variant, status = resolve_variant(variants, backend)
+    if variant is None:
+        raise FileNotFoundError(
+            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(status)}"
+        )
+
+    return _find_kernel_in_repo_path(
+        local_repo_path,
+        variant=variant,
+    )
+
+
+def _find_kernel_in_repo_path(
+    repo_path: Path,
+    *,
+    variant: Variant,
+) -> Path:
+    variant_str = variant.variant_str
+    variant_path = repo_path / "build" / variant_str
+    if not variant_path.exists():
+        raise FileNotFoundError(f"Variant path does not exist: `{variant_path}`")
+
+    return variant_path
+
+
+def install_kernel_all_variants(
+    repo_id: str,
+    *,
+    revision: str,
+) -> Path:
+    api = _get_hf_api()
+
+    repo_path = Path(
+        str(
+            api.snapshot_download(
+                repo_id,
+                repo_type="kernel",
+                allow_patterns="build/*",
+                ignore_patterns=_BYTECODE_IGNORE_PATTERNS,
+                cache_dir=CACHE_DIR,
+                revision=revision,
+            )
+        )
+    )
+
+    return repo_path / "build"

--- a/kernels/src/kernels/layer/func.py
+++ b/kernels/src/kernels/layer/func.py
@@ -5,13 +5,13 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Protocol, Type
 
 from .._versions import select_revision_or_version
+from ..load import (
+    get_kernel,
+    get_local_kernel,
+)
 from ..locking import (
     get_caller_locked_kernel_revision,
     get_locked_kernel_revision,
-)
-from ..utils import (
-    get_kernel,
-    get_local_kernel,
 )
 from .layer import _create_func_module, use_kernel_forward_from_hub
 from .repos import RepositoryProtocol

--- a/kernels/src/kernels/layer/layer.py
+++ b/kernels/src/kernels/layer/layer.py
@@ -10,13 +10,13 @@ from types import MethodType, ModuleType
 from typing import TYPE_CHECKING, Callable, Protocol, Type
 
 from .._versions import select_revision_or_version
+from ..load import (
+    get_kernel,
+    get_local_kernel,
+)
 from ..locking import (
     get_caller_locked_kernel_revision,
     get_locked_kernel_revision,
-)
-from ..utils import (
-    get_kernel,
-    get_local_kernel,
 )
 from .device import Device
 from .globals import _DISABLE_KERNEL_MAPPING, _KERNEL_MAPPING

--- a/kernels/src/kernels/load.py
+++ b/kernels/src/kernels/load.py
@@ -226,9 +226,7 @@ def load_kernel(
         )
 
     try:
-        variant_path = install_kernel(
-            repo_id, revision=locked_sha, backend=backend, local_files_only=True
-        )
+        variant_path = install_kernel(repo_id, revision=locked_sha, backend=backend, local_files_only=True)
     except FileNotFoundError as e:
         raise FileNotFoundError(
             f"Locked kernel `{repo_id}` was not downloaded or does not have an "

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -1,9 +1,5 @@
 import functools
-import importlib
 import os
-import sys
-import warnings
-from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
@@ -15,6 +11,7 @@ from kernels._versions import select_revision_or_version
 from kernels.backends import _backend
 from kernels.deps import validate_dependencies
 from kernels.hf_hub import CACHE_DIR, RepoInfo, _check_trust_remote_code, _get_hf_api
+from kernels.importer import _import_from_path
 from kernels.locking import (
     get_caller_locked_kernel_revision,
     get_locked_kernel_revision,
@@ -33,60 +30,6 @@ from kernels.variants import (
 # bytcode. So these patterns are used to ensure that they are never
 # downloaded.
 _BYTECODE_IGNORE_PATTERNS = ["*.pyc", "**/__pycache__/**"]
-
-
-@dataclass(frozen=True)
-class LoadedKernel:
-    """
-    This dataclass provides information about a loaded kernel:
-
-    - `metadata` (`Metadata`): kernel metadata.
-    - `module` (`ModuleType`): the imported kernel module.
-    - `repo_info` (`kernels.utils.RepoInfo | None`): populated only for
-      kernels loaded via `get_kernel`. Loaders that work from a local path
-      (`get_local_kernel`) or a lockfile (`get_locked_kernel`, `load_kernel`)
-      leave this as `None`.
-
-    The metadata includes the following properties that describe a kernel:
-
-    - `id` (`str`): kernel identifier that is unique to the kernel version + backend.
-    - `name` (`str`): the name of the kernel.
-    - `version` (`int`): the version of the kernel.
-    - `license` (`str`): the license of the kernel.
-    - `upstream` (`str | None`): the original upstream repository of the kernel.
-    - `source` (`str | None`): the kernel-builder formatted source repository.
-    - `python_depends` (`list[str]`): required Python dependencies.
-    - `backend`: information about the kernel's backend.
-    """
-
-    metadata: Metadata
-    module: ModuleType
-    repo_info: RepoInfo | None
-
-
-_loaded_kernels: dict[Path, LoadedKernel] = {}
-
-
-def get_loaded_kernels() -> list[LoadedKernel]:
-    """
-    Return a snapshot of every kernel that has been loaded into the current process.
-
-    The returned list is a new list; mutating it does not affect the registry.
-
-    Returns:
-        `list[LoadedKernel]`: One [`LoadedKernel`] per distinct kernel variant path
-        loaded in this process.
-
-    Example:
-        ```python
-        from kernels import get_kernel, get_loaded_kernels
-
-        get_kernel("kernels-community/activation", version=1)
-        for loaded in get_loaded_kernels():
-            print(loaded.metadata.name, loaded.repo_info)
-        ```
-    """
-    return list(_loaded_kernels.values())
 
 
 def _get_local_kernel_overrides() -> dict[str, Path]:
@@ -115,64 +58,6 @@ def _parse_local_kernel_overrides(local_kernels: str) -> dict[str, Path]:
 def _validate_variant_dependencies(variant_path: Path) -> None:
     metadata = Metadata.read_from_file(variant_path / "metadata.json")
     validate_dependencies(metadata.name.python_name, metadata.python_depends, _backend())
-
-
-def _warn_if_dirty(metadata: Metadata, variant_str: str) -> None:
-    """Warn when a kernel variant was built from a dirty git tree.
-
-    A dirty build was produced from a working tree with uncommitted changes,
-    so its git SHA does not fully identify the sources it was built from and
-    the build may not be reproducible.
-    """
-    provenance = metadata.provenance
-    if provenance is None or not provenance.dirty:
-        return
-
-    dirty_sources = []
-    if provenance.kernel is not None and provenance.kernel.dirty:
-        dirty_sources.append("kernel source")
-    builder_git = provenance.kernel_builder.git
-    if builder_git is not None and builder_git.dirty:
-        dirty_sources.append("kernel-builder")
-
-    warnings.warn(
-        f"Kernel '{metadata.name}' variant '{variant_str}' was built from a dirty "
-        f"git tree ({', '.join(dirty_sources)} had uncommitted changes). Its "
-        "recorded git revision does not fully identify the sources it was built "
-        "from, so the build may not be reproducible.",
-        stacklevel=3,
-    )
-
-
-def _import_from_path(variant_path: Path, repo_info: RepoInfo | None = None) -> ModuleType:
-    if (loaded_kernel := _loaded_kernels.get(variant_path)) is not None:
-        return loaded_kernel.module
-
-    metadata = Metadata.read_from_file(variant_path / "metadata.json")
-    _warn_if_dirty(metadata, variant_path.name)
-    module_name = metadata.name.python_name
-
-    file_path = variant_path / "__init__.py"
-    if not file_path.exists():
-        file_path = variant_path / module_name / "__init__.py"
-    if not file_path.exists():
-        raise FileNotFoundError(f"No kernel module found at: `{variant_path}`")
-
-    spec = importlib.util.spec_from_file_location(metadata.id, file_path)
-    if spec is None:
-        raise ImportError(f"Cannot load spec for {module_name} from {file_path}")
-    module = importlib.util.module_from_spec(spec)
-    if module is None:
-        raise ImportError(f"Cannot load module {module_name} from spec")
-    sys.modules[metadata.id] = module
-    spec.loader.exec_module(module)  # type: ignore
-
-    _loaded_kernels[variant_path] = LoadedKernel(
-        metadata=metadata,
-        module=module,
-        repo_info=repo_info,
-    )
-    return module
 
 
 def install_kernel(

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -3,31 +3,22 @@ import os
 from pathlib import Path
 from types import ModuleType
 
-from huggingface_hub import HfApi, constants
-from huggingface_hub.errors import LocalEntryNotFoundError
+from huggingface_hub import constants
 
 from kernels._versions import select_revision_or_version
 from kernels.deps import validate_variant_dependencies
-from kernels.hf_hub import CACHE_DIR, RepoInfo, _check_trust_remote_code, _get_hf_api
+from kernels.hf_hub import RepoInfo, _check_trust_remote_code, _get_hf_api
 from kernels.importer import _import_from_path
+from kernels.install import install_kernel
 from kernels.locking import (
     get_caller_locked_kernel_revision,
     get_locked_kernel_revision,
 )
-from kernels.status import resolve_status
 from kernels.variants import (
-    Variant,
     get_variants,
     get_variants_local,
     resolve_variant,
-    variants_trace_str,
 )
-
-# Exclude patter for bytecode. These are not included in kernel builds,
-# but builds not done using kernel-builder might accidentally include
-# bytcode. So these patterns are used to ensure that they are never
-# downloaded.
-_BYTECODE_IGNORE_PATTERNS = ["*.pyc", "**/__pycache__/**"]
 
 
 def _get_local_kernel_overrides() -> dict[str, Path]:
@@ -51,183 +42,6 @@ def _parse_local_kernel_overrides(local_kernels: str) -> dict[str, Path]:
         overrides[repo_id] = Path(path)
 
     return overrides
-
-
-def install_kernel(
-    repo_id: str,
-    *,
-    revision: str,
-    local_files_only: bool = False,
-    backend: str | None = None,
-    user_agent: str | dict | None = None,
-    validate_dependencies: bool = False,
-) -> Path:
-    """
-    Download a kernel for the current environment to the cache.
-
-    The output path is validated against the hashes in `variant_locks` when provided.
-
-    Args:
-        repo_id (`str`):
-            The Hub repository containing the kernel.
-        revision (`str`):
-            The specific revision (branch, tag, or commit) to download.
-        local_files_only (`bool`, *optional*, defaults to `False`):
-            Whether to only use local files and not download from the Hub.
-        backend (`str`, *optional*):
-            The backend to load the kernel for. Can only be `cpu` or the backend that Torch is compiled for.
-            The backend will be detected automatically if not provided.
-        user_agent (`Union[str, dict]`, *optional*):
-            The `user_agent` info to pass to `snapshot_download()` for internal telemetry.
-        validate_dependencies (`bool`, defaults to False):
-            When set to True, performs dependency validation. Useful for kernels that have
-            extra Python dependencies.
-
-    Returns:
-        `Path`: The path to the variant directory.
-    """
-    api = _get_hf_api(user_agent=user_agent)
-    if local_files_only:
-        # Same local-cache resolution path used by `load_kernel`, which is
-        # always offline. Sharing the helper avoids the network dependency
-        # that `get_variants` would otherwise introduce.
-        variant_path = _resolve_local_variant_path(
-            api,
-            repo_id,
-            revision=revision,
-            backend=backend,
-        )
-        # For locally downloaded kernels, we run the validation after resolving the path
-        if validate_dependencies:
-            validate_variant_dependencies(variant_path)
-        return variant_path
-
-    repo_id, revision = resolve_status(api, repo_id, revision)
-    variants = get_variants(api, repo_id=repo_id, revision=revision)
-    variant, trace = resolve_variant(variants, backend)
-
-    if variant is None:
-        raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(trace)}"
-        )
-
-    # Validate Python dependencies before downloading the variant.
-    if validate_dependencies:
-        metadata_path = api.hf_hub_download(
-            repo_id,
-            repo_type="kernel",
-            filename=f"build/{variant.variant_str}/metadata.json",
-            cache_dir=CACHE_DIR,
-            revision=revision,
-            local_files_only=False,
-        )
-        validate_variant_dependencies(Path(metadata_path).parent)
-
-    allow_patterns = [f"build/{variant.variant_str}/*"]
-    ignore_patterns = _BYTECODE_IGNORE_PATTERNS
-
-    repo_path = Path(
-        str(
-            api.snapshot_download(
-                repo_id,
-                repo_type="kernel",
-                allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns,
-                cache_dir=CACHE_DIR,
-                revision=revision,
-                local_files_only=False,
-            )
-        )
-    )
-
-    try:
-        return _find_kernel_in_repo_path(
-            repo_path,
-            variant=variant,
-        )
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Cannot install kernel from repo {repo_id} (revision: {revision})")
-
-
-def _resolve_local_variant_path(
-    api: HfApi,
-    repo_id: str,
-    *,
-    revision: str,
-    backend: str | None = None,
-) -> Path:
-    """Resolve a kernel variant path from the local Hugging Face cache only.
-
-    Used by `load_kernel` (which always operates on a pre-downloaded, locked
-    kernel) and by the offline branch of `install_kernel`.
-    """
-    try:
-        local_repo_path = Path(
-            str(
-                api.snapshot_download(
-                    repo_id,
-                    repo_type="kernel",
-                    ignore_patterns=_BYTECODE_IGNORE_PATTERNS,
-                    cache_dir=CACHE_DIR,
-                    revision=revision,
-                    local_files_only=True,
-                )
-            )
-        )
-    except LocalEntryNotFoundError as e:
-        raise FileNotFoundError(
-            f"Cannot find a local snapshot for {repo_id} (revision: {revision}). "
-            "When Hugging Face Hub is in offline mode the kernel must already "
-            "be present in the local cache."
-        ) from e
-
-    variants = get_variants_local(local_repo_path / "build")
-    variant, status = resolve_variant(variants, backend)
-    if variant is None:
-        raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(status)}"
-        )
-
-    return _find_kernel_in_repo_path(
-        local_repo_path,
-        variant=variant,
-    )
-
-
-def _find_kernel_in_repo_path(
-    repo_path: Path,
-    *,
-    variant: Variant,
-) -> Path:
-    variant_str = variant.variant_str
-    variant_path = repo_path / "build" / variant_str
-    if not variant_path.exists():
-        raise FileNotFoundError(f"Variant path does not exist: `{variant_path}`")
-
-    return variant_path
-
-
-def install_kernel_all_variants(
-    repo_id: str,
-    *,
-    revision: str,
-) -> Path:
-    api = _get_hf_api()
-
-    repo_path = Path(
-        str(
-            api.snapshot_download(
-                repo_id,
-                repo_type="kernel",
-                allow_patterns="build/*",
-                ignore_patterns=_BYTECODE_IGNORE_PATTERNS,
-                cache_dir=CACHE_DIR,
-                revision=revision,
-            )
-        )
-    )
-
-    return repo_path / "build"
 
 
 def get_kernel(

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -21,12 +21,10 @@ from kernels.locking import (
 )
 from kernels.status import resolve_status
 from kernels.variants import (
-    Decision,
     Variant,
     get_variants,
     get_variants_local,
     resolve_variant,
-    resolve_variants,
     variants_trace_str,
 )
 
@@ -499,55 +497,6 @@ def has_kernel(
         revision=revision,
         filename=f"build/{variant.variant_str}/metadata.json",
     )
-
-
-def get_kernel_variants(
-    repo_id: str,
-    revision: str | None = None,
-    version: int | None = None,
-    backend: str | None = None,
-) -> list[Decision]:
-    """
-    Resolve all build variants of a kernel against the current environment.
-
-    The decisions are sorted with compatible variants first, the most preferred
-    variant leading.
-
-    Args:
-        repo_id (`str`):
-            The Hub repository containing the kernel.
-        revision (`str`, *optional*):
-            The specific revision (branch, tag, or commit) to inspect. Cannot be used together with `version`.
-        version (`int`, *optional*):
-            The kernel version to inspect. Cannot be used together with `revision`.
-            Either `version` or `revision` must be specified.
-        backend (`str`, *optional*):
-            The backend to resolve variants for. Can only be `cpu` or the backend that Torch is compiled for.
-            The backend will be detected automatically if not provided.
-
-    Returns:
-        `list[Decision]`: One `VariantAccepted` or `VariantRejected` per build variant
-            in the repository, compatible variants first.
-
-    Example:
-        ```python
-        from kernels import get_kernel_variants, VariantAccepted
-
-        for decision in get_kernel_variants("kernels-community/activation", version=1):
-            name = decision.variant.variant_str
-            if isinstance(decision, VariantAccepted):
-                print(f"{name}: compatible")
-            else:
-                print(f"{name}: rejected ({decision.reason})")
-
-        ```
-    """
-    revision = select_revision_or_version(repo_id, revision=revision, version=version)
-
-    api = _get_hf_api()
-    variants = get_variants(api, repo_id=repo_id, revision=revision)
-    _, trace = resolve_variants(variants, backend)
-    return trace
 
 
 def load_kernel(

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -30,8 +30,6 @@ from kernels.variants import (
     variants_trace_str,
 )
 
-KNOWN_BACKENDS = {"cpu", "cuda", "metal", "neuron", "rocm", "xpu", "npu"}
-
 # Exclude patter for bytecode. These are not included in kernel builds,
 # but builds not done using kernel-builder might accidentally include
 # bytcode. So these patterns are used to ensure that they are never

--- a/kernels/src/kernels/utils.py
+++ b/kernels/src/kernels/utils.py
@@ -5,11 +5,9 @@ from types import ModuleType
 
 from huggingface_hub import HfApi, constants
 from huggingface_hub.errors import LocalEntryNotFoundError
-from kernels_data import Metadata
 
 from kernels._versions import select_revision_or_version
-from kernels.backends import _backend
-from kernels.deps import validate_dependencies
+from kernels.deps import validate_variant_dependencies
 from kernels.hf_hub import CACHE_DIR, RepoInfo, _check_trust_remote_code, _get_hf_api
 from kernels.importer import _import_from_path
 from kernels.locking import (
@@ -53,11 +51,6 @@ def _parse_local_kernel_overrides(local_kernels: str) -> dict[str, Path]:
         overrides[repo_id] = Path(path)
 
     return overrides
-
-
-def _validate_variant_dependencies(variant_path: Path) -> None:
-    metadata = Metadata.read_from_file(variant_path / "metadata.json")
-    validate_dependencies(metadata.name.python_name, metadata.python_depends, _backend())
 
 
 def install_kernel(
@@ -106,7 +99,7 @@ def install_kernel(
         )
         # For locally downloaded kernels, we run the validation after resolving the path
         if validate_dependencies:
-            _validate_variant_dependencies(variant_path)
+            validate_variant_dependencies(variant_path)
         return variant_path
 
     repo_id, revision = resolve_status(api, repo_id, revision)
@@ -128,7 +121,7 @@ def install_kernel(
             revision=revision,
             local_files_only=False,
         )
-        _validate_variant_dependencies(Path(metadata_path).parent)
+        validate_variant_dependencies(Path(metadata_path).parent)
 
     allow_patterns = [f"build/{variant.variant_str}/*"]
     ignore_patterns = _BYTECODE_IGNORE_PATTERNS
@@ -330,14 +323,14 @@ def get_local_kernel(
 
         if variant is not None:
             variant_path = base_path / variant.variant_str
-            _validate_variant_dependencies(variant_path)
+            validate_variant_dependencies(variant_path)
             return _import_from_path(variant_path)
 
     # If we didn't find the package in the repo we may have a explicit
     # package path.
     variant_path = repo_path
     if variant_path.exists():
-        _validate_variant_dependencies(variant_path)
+        validate_variant_dependencies(variant_path)
         return _import_from_path(variant_path)
 
     raise FileNotFoundError(f"Could not find kernel in {repo_path}")

--- a/kernels/src/kernels/variants.py
+++ b/kernels/src/kernels/variants.py
@@ -13,6 +13,7 @@ from huggingface_hub.dataclasses import strict
 from huggingface_hub.hf_api import RepoFolder
 from packaging.version import Version, parse
 
+from kernels._versions import select_revision_or_version
 from kernels.backends import (
     CANN,
     CUDA,
@@ -552,6 +553,57 @@ def _sort_variants(
             return (decision_order, 2, 0, 0, universal_order)
 
     return sorted(variants, key=sort_key)
+
+
+def get_kernel_variants(
+    repo_id: str,
+    revision: str | None = None,
+    version: int | None = None,
+    backend: str | None = None,
+) -> list[Decision]:
+    """
+    Resolve all build variants of a kernel against the current environment.
+
+    The decisions are sorted with compatible variants first, the most preferred
+    variant leading.
+
+    Args:
+        repo_id (`str`):
+            The Hub repository containing the kernel.
+        revision (`str`, *optional*):
+            The specific revision (branch, tag, or commit) to inspect. Cannot be used together with `version`.
+        version (`int`, *optional*):
+            The kernel version to inspect. Cannot be used together with `revision`.
+            Either `version` or `revision` must be specified.
+        backend (`str`, *optional*):
+            The backend to resolve variants for. Can only be `cpu` or the backend that Torch is compiled for.
+            The backend will be detected automatically if not provided.
+
+    Returns:
+        `list[Decision]`: One `VariantAccepted` or `VariantRejected` per build variant
+            in the repository, compatible variants first.
+
+    Example:
+        ```python
+        from kernels import get_kernel_variants, VariantAccepted
+
+        for decision in get_kernel_variants("kernels-community/activation", version=1):
+            name = decision.variant.variant_str
+            if isinstance(decision, VariantAccepted):
+                print(f"{name}: compatible")
+            else:
+                print(f"{name}: rejected ({decision.reason})")
+
+        ```
+    """
+    from kernels.hf_hub import _get_hf_api
+
+    revision = select_revision_or_version(repo_id, revision=revision, version=version)
+
+    api = _get_hf_api()
+    variants = get_variants(api, repo_id=repo_id, revision=revision)
+    _, trace = resolve_variants(variants, backend)
+    return trace
 
 
 def variants_trace_str(trace: list[Decision]) -> str:

--- a/kernels/tests/test_dirty_provenance.py
+++ b/kernels/tests/test_dirty_provenance.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from kernels_data import Metadata
 
-from kernels.utils import _import_from_path, _loaded_kernels, _warn_if_dirty
+from kernels.importer import _import_from_path, _loaded_kernels, _warn_if_dirty
 
 
 def _write_variant(tmp_path, provenance):

--- a/kernels/tests/test_layer.py
+++ b/kernels/tests/test_layer.py
@@ -19,12 +19,12 @@ from kernels import (
     use_kernel_forward_from_hub,
     use_kernel_mapping,
 )
+from kernels.install import (
+    install_kernel,
+)
 from kernels.layer.layer import (
     _KERNEL_MAPPING,
     _validate_layer,
-)
-from kernels.utils import (
-    install_kernel,
 )
 
 

--- a/kernels/tests/test_loaded_kernels.py
+++ b/kernels/tests/test_loaded_kernels.py
@@ -4,7 +4,7 @@ import pytest
 
 from kernels import get_kernel, get_loaded_kernels, get_local_kernel, install_kernel
 from kernels.hf_hub import RepoInfo
-from kernels.utils import LoadedKernel, _loaded_kernels
+from kernels.importer import LoadedKernel, _loaded_kernels
 
 _REPO_ID = "kernels-community/relu"
 _PACKAGE_NAME = "relu"

--- a/kernels/tests/test_verify.py
+++ b/kernels/tests/test_verify.py
@@ -2,7 +2,7 @@ from kernels_data import DigestViolation
 from sigstore.verify import policy
 
 from kernels import install_kernel
-from kernels.utils import select_revision_or_version
+from kernels._versions import select_revision_or_version
 from kernels.verify import VerificationResult, verify_variant
 
 TEST_POLICIES: list[policy.VerificationPolicy] = [

--- a/src/kernels/load.py
+++ b/src/kernels/load.py
@@ -226,7 +226,9 @@ def load_kernel(
         )
 
     try:
-        variant_path = install_kernel(repo_id, revision=locked_sha, backend=backend, local_files_only=True)
+        variant_path = install_kernel(
+            repo_id, revision=locked_sha, backend=backend, local_files_only=True
+        )
     except FileNotFoundError as e:
         raise FileNotFoundError(
             f"Locked kernel `{repo_id}` was not downloaded or does not have an "


### PR DESCRIPTION
- Remove unused `KNOWN_BACKENDS` variable.
- Move `get_kernel_variants` to the `variants` module.
- Move import-related functions to `importer` (note that we cannot have `import` because it is a keyboard).
- Move `validate_variant_dependencies` to `deps`.
- Move install functions to `install`.
- Rename `utils` module to `load`.