### PR TITLE
docs: fix broken kernel-builder link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ packages in that they are made to be:
 ## Components
 
 - You can load kernels from the Hub using the [`kernels`](kernels/) Python package.
-- If you are a kernel author, you can build your kernels with [kernel-builder](builder/).
+- If you are a kernel author, you can build your kernels with [kernel-builder](kernel-builder/).
 - Hugging Face maintains a set of kernels in [kernels-community](https://huggingface.co/kernels-community).
 
 ## 🚀 Quick Start


### PR DESCRIPTION
## Summary
The README links to the kernel-builder tool as `[kernel-builder](builder/)`, but the directory in this repo is `kernel-builder/`, not `builder/`. The link 404s. This fixes it to point to the correct path.

## Test plan
- Verified `kernel-builder/` exists at the repo root and `builder/` does not.