### PR TITLE
Request IEEE fp32 division for SYCL kernels

### DIFF
--- a/kernel-builder/src/pyproject/templates/torch/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/preamble.cmake
@@ -205,8 +205,10 @@ elseif(GPU_LANG STREQUAL "SYCL")
   endif()
 
 
-  set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
-  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
+  # -foffload-fp32-prec-* keeps fp32 division and sqrt IEEE correctly rounded,
+  # matching PyTorch; both the compile and the link step need them.
+  set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-foffload-fp32-prec-div;-foffload-fp32-prec-sqrt;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
+  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-foffload-fp32-prec-div;-foffload-fp32-prec-sqrt;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
   set(GPU_FLAGS "${sycl_flags}")
 
 

--- a/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/tvm_ffi/preamble.cmake
@@ -136,8 +136,10 @@ elseif(GPU_LANG STREQUAL "SYCL")
     message(STATUS "Using Intel SYCL C++ compiler: ${ICPX_COMPILER} and C compiler: ${ICX_COMPILER} Version: ${DPCPP_VERSION}")
   endif()
 
-  set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
-  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
+  # -foffload-fp32-prec-* keeps fp32 division and sqrt IEEE correctly rounded,
+  # matching PyTorch; both the compile and the link step need them.
+  set(sycl_link_flags "-Wl,-z,noexecstack;-fsycl;--offload-compress;-foffload-fp32-prec-div;-foffload-fp32-prec-sqrt;-fsycl-targets=spir64_gen,spir64;-Xs;-device pvc,xe-lpg,ats-m150 -options ' -cl-intel-enable-auto-large-GRF-mode -cl-poison-unsupported-fp64-kernels -cl-intel-greater-than-4GB-buffer-required';")
+  set(sycl_flags "-fPIC;-fsycl;-fhonor-nans;-fhonor-infinities;-fno-associative-math;-fno-approx-func;-foffload-fp32-prec-div;-foffload-fp32-prec-sqrt;-fno-sycl-instrument-device-code;--offload-compress;-fsycl-targets=spir64_gen,spir64;")
   set(GPU_FLAGS "${sycl_flags}")
 
   add_compile_definitions(XPU_KERNEL)


### PR DESCRIPTION
## Summary

Adds `-foffload-fp32-prec-div` and `-foffload-fp32-prec-sqrt` to the SYCL build
flags, matching how PyTorch builds its own XPU kernels in `torch-xpu-ops`.

Without them the compiler defaults to a fast floating-point model in which fp32
division is allowed several ULP of error and `a / b` is lowered to `a * rcp(b)`.
Kernels built this way return results that differ from the eager PyTorch ones in
the last bit, which breaks kernel tests that compare against PyTorch exactly.

These flags affect the offload backend and only take effect when passed to both
the device compile and the device link step, so the per-kernel `sycl-flags` in
`build.toml` cannot substitute for them. Applied to the `torch` and `tvm_ffi`
preambles alike.

## Validation

Verified with `kernels-community/activation` on Intel Arc Pro B60 with
`torch 2.13.0+xpu` and oneAPI 2026.0. Its `silu_and_mul` and `mul_and_silu`
operators go from 42 failures to a fully passing suite (396 cases), with no
change in measured throughput.
