### PR TITLE
Suggest newer kernel version when no compatible variant on current revision

### DIFF
--- a/kernels/src/kernels/_upgrade_hint.py
+++ b/kernels/src/kernels/_upgrade_hint.py
@@ -8,7 +8,7 @@ from huggingface_hub import HfApi
 from huggingface_hub.errors import LocalEntryNotFoundError
 
 from kernels._versions import _get_available_versions
-from kernels.backends import CANN, CUDA, ROCm, XPU
+from kernels.backends import CANN, CUDA, XPU, ROCm
 from kernels.hf_hub import CACHE_DIR
 from kernels.variants import (
     ArchVariant,

--- a/kernels/src/kernels/_upgrade_hint.py
+++ b/kernels/src/kernels/_upgrade_hint.py
@@ -1,0 +1,138 @@
+"""Best-effort upgrade suggestion when no build variant matches the current revision."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from huggingface_hub import HfApi
+from huggingface_hub.errors import LocalEntryNotFoundError
+
+from kernels._versions import _get_available_versions
+from kernels.backends import CANN, CUDA, ROCm, XPU
+from kernels.hf_hub import CACHE_DIR
+from kernels.variants import (
+    ArchVariant,
+    NoarchVariant,
+    Torch,
+    TorchStableAbi,
+    TvmFfi,
+    Variant,
+    get_variants,
+    get_variants_local,
+    resolve_variant,
+)
+
+_MAX_NEWER_SCANS = 16
+_BYTECODE_IGNORE_PATTERNS = ["*.pyc", "**/__pycache__/**"]
+
+
+def _parse_version_revision(revision: str) -> int | None:
+    """Return N when revision is exactly ``v<N>`` with a digit suffix; else None."""
+    if not revision.startswith("v") or len(revision) < 2:
+        return None
+    try:
+        return int(revision[1:])
+    except ValueError:
+        return None
+
+
+def _env_identity_from_variant(variant: Variant) -> str:
+    """Short parenthetical env identity from an accepted variant (omit missing pieces)."""
+    parts: list[str] = []
+
+    if isinstance(variant, ArchVariant):
+        framework = variant.framework
+        if isinstance(framework, Torch):
+            parts.append(f"torch {framework.version.major}.{framework.version.minor}")
+        elif isinstance(framework, TorchStableAbi):
+            parts.append(f"torch-stable-abi {framework.version.major}.{framework.version.minor}")
+        elif isinstance(framework, TvmFfi):
+            parts.append(f"tvm-ffi {framework.version.major}.{framework.version.minor}")
+
+        backend = variant.arch.backend
+        if isinstance(backend, (CUDA, ROCm, XPU, CANN)):
+            parts.append(f"{backend.name} {backend.version.major}.{backend.version.minor}")
+        else:
+            parts.append(backend.name)
+    elif isinstance(variant, NoarchVariant):
+        parts.append(variant.arch.backend_name)
+
+    return ", ".join(parts)
+
+
+def _format_suggestion(repo_id: str, version: int, env_identity: str) -> str:
+    identity = f" ({env_identity})" if env_identity else ""
+    return (
+        f"However, version v{version} of '{repo_id}' has a build compatible "
+        f"with your system{identity}. Consider upgrading to that version."
+    )
+
+
+def _variants_for_revision(
+    api: HfApi,
+    repo_id: str,
+    revision: str,
+    *,
+    local_files_only: bool,
+) -> list[Variant]:
+    if local_files_only:
+        local_repo_path = Path(
+            str(
+                api.snapshot_download(
+                    repo_id,
+                    repo_type="kernel",
+                    ignore_patterns=_BYTECODE_IGNORE_PATTERNS,
+                    cache_dir=CACHE_DIR,
+                    revision=revision,
+                    local_files_only=True,
+                )
+            )
+        )
+        return get_variants_local(local_repo_path / "build")
+    return get_variants(api, repo_id=repo_id, revision=revision)
+
+
+def maybe_upgrade_hint(
+    repo_id: str,
+    revision: str,
+    *,
+    api: HfApi,
+    backend: str | None = None,
+    local_files_only: bool = False,
+) -> str | None:
+    """Return an upgrade suggestion string, or None if none / best-effort failed.
+
+    Never raises into the caller's error path.
+    """
+    try:
+        current = _parse_version_revision(revision)
+        if current is None:
+            return None
+
+        versions = _get_available_versions(repo_id)
+        newer = sorted((v for v in versions if v > current), reverse=True)
+
+        for version in newer[:_MAX_NEWER_SCANS]:
+            try:
+                ref = versions[version]
+                variants = _variants_for_revision(
+                    api,
+                    repo_id,
+                    ref.name,
+                    local_files_only=local_files_only,
+                )
+                variant, _ = resolve_variant(variants, backend)
+                if variant is not None:
+                    return _format_suggestion(
+                        repo_id,
+                        version,
+                        _env_identity_from_variant(variant),
+                    )
+            except LocalEntryNotFoundError:
+                continue
+            except Exception:
+                continue
+
+        return None
+    except Exception:
+        return None

--- a/kernels/src/kernels/install.py
+++ b/kernels/src/kernels/install.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from huggingface_hub import HfApi
 from huggingface_hub.errors import LocalEntryNotFoundError
 
+from kernels._upgrade_hint import maybe_upgrade_hint
 from kernels.deps import validate_variant_dependencies
 from kernels.hf_hub import CACHE_DIR, _get_hf_api
 from kernels.status import resolve_status
@@ -75,9 +76,20 @@ def install_kernel(
     variant, trace = resolve_variant(variants, backend)
 
     if variant is None:
-        raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(trace)}"
+        msg = (
+            f"Cannot find a build variant for this system in {repo_id} "
+            f"(revision: {revision}):\n\n{variants_trace_str(trace)}"
         )
+        suggestion = maybe_upgrade_hint(
+            repo_id,
+            revision,
+            api=api,
+            backend=backend,
+            local_files_only=False,
+        )
+        if suggestion is not None:
+            msg = f"{msg}\n\n{suggestion}"
+        raise FileNotFoundError(msg)
 
     # Validate Python dependencies before downloading the variant.
     if validate_dependencies:
@@ -152,9 +164,20 @@ def _resolve_local_variant_path(
     variants = get_variants_local(local_repo_path / "build")
     variant, status = resolve_variant(variants, backend)
     if variant is None:
-        raise FileNotFoundError(
-            f"Cannot find a build variant for this system in {repo_id} (revision: {revision}):\n\n{variants_trace_str(status)}"
+        msg = (
+            f"Cannot find a build variant for this system in {repo_id} "
+            f"(revision: {revision}):\n\n{variants_trace_str(status)}"
         )
+        suggestion = maybe_upgrade_hint(
+            repo_id,
+            revision,
+            api=api,
+            backend=backend,
+            local_files_only=True,
+        )
+        if suggestion is not None:
+            msg = f"{msg}\n\n{suggestion}"
+        raise FileNotFoundError(msg)
 
     return _find_kernel_in_repo_path(
         local_repo_path,

--- a/kernels/tests/test_upgrade_hint.py
+++ b/kernels/tests/test_upgrade_hint.py
@@ -1,0 +1,256 @@
+"""Unit tests for upgrade-hint suggestion on no-variant errors (#744)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from huggingface_hub.hf_api import GitRefInfo
+
+from kernels._upgrade_hint import (
+    _MAX_NEWER_SCANS,
+    _env_identity_from_variant,
+    maybe_upgrade_hint,
+)
+from kernels.install import _resolve_local_variant_path, install_kernel
+from kernels.variants import VariantRejected, parse_variant, variants_trace_str
+
+
+def _ref(version: int) -> GitRefInfo:
+    return GitRefInfo(name=f"v{version}", ref=f"v{version}", target_commit=f"c{version}")
+
+
+COMPATIBLE = parse_variant("torch213-cxx11-cu128-x86_64-linux")
+
+
+def _resolve_by_revision(calls: list[str]):
+    """Side-effect factory: accept only when last get_variants revision is in accept_set."""
+
+    def _make(accept: set[str]):
+        def resolve_variant(variants, backend=None):
+            revision = calls[-1] if calls else ""
+            if revision in accept:
+                return COMPATIBLE, []
+            return None, []
+
+        return resolve_variant
+
+    return _make
+
+
+# --- Helper unit tests (T1–T5) ---
+
+
+def test_suggests_newest_compatible():
+    """T1 / A1: newest compatible newer v<N> is suggested with env identity."""
+    versions = {3: _ref(3), 4: _ref(4), 5: _ref(5)}
+    calls: list[str] = []
+    api = MagicMock()
+
+    def get_variants(api_arg, *, repo_id, revision):
+        calls.append(revision)
+        return []
+
+    with (
+        patch("kernels._upgrade_hint._get_available_versions", return_value=versions),
+        patch("kernels._upgrade_hint.get_variants", side_effect=get_variants),
+        patch(
+            "kernels._upgrade_hint.resolve_variant",
+            side_effect=_resolve_by_revision(calls)({"v5", "v4"}),
+        ),
+    ):
+        hint = maybe_upgrade_hint("kernels-community/activation", "v3", api=api)
+
+    assert hint is not None
+    assert "However, version v5 of 'kernels-community/activation'" in hint
+    assert "torch 2.13, cuda 12.8" in hint
+    assert "Consider upgrading to that version." in hint
+    # Newest-first: stop at v5; never consult v4.
+    assert calls == ["v5"]
+    assert "v4" not in hint
+
+
+def test_no_suggestion_when_none_compatible():
+    """T2 / A2: newer versions exist but none compatible → no suggestion."""
+    versions = {3: _ref(3), 4: _ref(4), 5: _ref(5)}
+    calls: list[str] = []
+    api = MagicMock()
+
+    def get_variants(api_arg, *, repo_id, revision):
+        calls.append(revision)
+        return []
+
+    with (
+        patch("kernels._upgrade_hint._get_available_versions", return_value=versions),
+        patch("kernels._upgrade_hint.get_variants", side_effect=get_variants),
+        patch(
+            "kernels._upgrade_hint.resolve_variant",
+            side_effect=_resolve_by_revision(calls)(set()),
+        ),
+    ):
+        hint = maybe_upgrade_hint("kernels-community/activation", "v3", api=api)
+
+    assert hint is None
+    assert calls == ["v5", "v4"]
+
+
+def test_suggestion_path_swallows_errors():
+    """T3 / A3: Hub/version failures must not escape; return None."""
+    api = MagicMock()
+
+    with patch(
+        "kernels._upgrade_hint._get_available_versions",
+        side_effect=RuntimeError("hub down"),
+    ):
+        assert maybe_upgrade_hint("repo/id", "v3", api=api) is None
+
+    versions = {3: _ref(3), 4: _ref(4)}
+    with (
+        patch("kernels._upgrade_hint._get_available_versions", return_value=versions),
+        patch(
+            "kernels._upgrade_hint.get_variants",
+            side_effect=RuntimeError("list_repo_tree failed"),
+        ),
+    ):
+        assert maybe_upgrade_hint("repo/id", "v3", api=api) is None
+
+
+def test_offline_empty_cache_no_suggestion():
+    """T4 / A4: HF_HUB_OFFLINE with empty enumeration → no hang, no suggestion."""
+    api = MagicMock()
+
+    with (
+        patch("kernels._versions.constants.HF_HUB_OFFLINE", True),
+        patch("kernels._upgrade_hint._get_available_versions", return_value={}),
+    ):
+        hint = maybe_upgrade_hint("repo/id", "v3", api=api, local_files_only=True)
+
+    assert hint is None
+
+
+def test_scan_cap_skips_beyond_16():
+    """T5 / Q3: only the first 16 newer versions (newer-first) are consulted."""
+    current = 1
+    # 17 newer versions: 2..18. Newer-first order: 18,17,...,3 then 2 is 17th.
+    versions = {v: _ref(v) for v in range(current, 19)}
+    calls: list[str] = []
+    api = MagicMock()
+
+    def get_variants(api_arg, *, repo_id, revision):
+        calls.append(revision)
+        return []
+
+    # Only the 17th-scanned candidate (v2) would be compatible — must NOT be seen.
+    with (
+        patch("kernels._upgrade_hint._get_available_versions", return_value=versions),
+        patch("kernels._upgrade_hint.get_variants", side_effect=get_variants),
+        patch(
+            "kernels._upgrade_hint.resolve_variant",
+            side_effect=_resolve_by_revision(calls)({"v2"}),
+        ),
+    ):
+        hint = maybe_upgrade_hint("repo/id", "v1", api=api)
+
+    assert hint is None
+    assert len(calls) == _MAX_NEWER_SCANS
+    assert calls == [f"v{v}" for v in range(18, 18 - _MAX_NEWER_SCANS, -1)]
+    assert "v2" not in calls
+
+
+def test_non_version_revision_skips_suggestion():
+    """Non-v<N> revisions must not claim an upgrade path."""
+    api = MagicMock()
+    with patch("kernels._upgrade_hint._get_available_versions") as get_versions:
+        assert maybe_upgrade_hint("repo/id", "main", api=api) is None
+        assert maybe_upgrade_hint("repo/id", "abc123def", api=api) is None
+        get_versions.assert_not_called()
+
+
+def test_env_identity_from_variant():
+    variant = parse_variant("torch213-cxx11-cu128-x86_64-linux")
+    assert _env_identity_from_variant(variant) == "torch 2.13, cuda 12.8"
+
+    cpu = parse_variant("torch25-cpu-x86_64-linux")
+    assert _env_identity_from_variant(cpu) == "torch 2.5, cpu"
+
+    noarch = parse_variant("torch-cuda")
+    assert _env_identity_from_variant(noarch) == "cuda"
+
+
+# --- install.py wiring (error message shape) ---
+
+
+def test_install_kernel_appends_suggestion():
+    """T1 via install_kernel: FileNotFoundError includes However clause."""
+    api = MagicMock()
+    rejected = VariantRejected(
+        variant=parse_variant("torch25-cxx11-cu118-x86_64-linux"),
+        reason="Torch version (2.5) does not match environment Torch version (2.13)",
+    )
+    suggestion = (
+        "However, version v5 of 'kernels-community/activation' has a build compatible "
+        "with your system (torch 2.13, cuda 12.8). Consider upgrading to that version."
+    )
+
+    with (
+        patch("kernels.install._get_hf_api", return_value=api),
+        patch("kernels.install.resolve_status", return_value=("kernels-community/activation", "v3")),
+        patch("kernels.install.get_variants", return_value=[rejected.variant]),
+        patch("kernels.install.resolve_variant", return_value=(None, [rejected])),
+        patch("kernels.install.maybe_upgrade_hint", return_value=suggestion),
+    ):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            install_kernel("kernels-community/activation", revision="v3")
+
+    msg = str(exc_info.value)
+    assert msg.startswith(
+        "Cannot find a build variant for this system in kernels-community/activation (revision: v3):"
+    )
+    assert variants_trace_str([rejected]) in msg
+    assert "However, version v5" in msg
+    assert "torch 2.13, cuda 12.8" in msg
+
+
+def test_install_kernel_no_false_upgrade():
+    """T2 via install_kernel: no However when helper returns None."""
+    api = MagicMock()
+    rejected = VariantRejected(
+        variant=parse_variant("torch25-cxx11-cu118-x86_64-linux"),
+        reason="incompatible",
+    )
+
+    with (
+        patch("kernels.install._get_hf_api", return_value=api),
+        patch("kernels.install.resolve_status", return_value=("repo/id", "v3")),
+        patch("kernels.install.get_variants", return_value=[rejected.variant]),
+        patch("kernels.install.resolve_variant", return_value=(None, [rejected])),
+        patch("kernels.install.maybe_upgrade_hint", return_value=None),
+    ):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            install_kernel("repo/id", revision="v3")
+
+    msg = str(exc_info.value)
+    assert "However" not in msg
+    assert msg.startswith("Cannot find a build variant for this system in repo/id (revision: v3):")
+
+
+def test_local_resolve_preserves_error_when_hint_absent():
+    """T3 via local path: missing suggestion keeps original FileNotFoundError."""
+    api = MagicMock()
+    api.snapshot_download.return_value = "/tmp/fake-kernel-cache"
+    rejected = VariantRejected(
+        variant=parse_variant("torch25-cxx11-cu118-x86_64-linux"),
+        reason="incompatible",
+    )
+
+    with (
+        patch("kernels.install.get_variants_local", return_value=[rejected.variant]),
+        patch("kernels.install.resolve_variant", return_value=(None, [rejected])),
+        patch("kernels.install.maybe_upgrade_hint", return_value=None),
+    ):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            _resolve_local_variant_path(api, "repo/id", revision="v3")
+
+    msg = str(exc_info.value)
+    assert "However" not in msg
+    assert "Cannot find a build variant for this system in repo/id (revision: v3):" in msg


### PR DESCRIPTION
## Summary
When `install_kernel` / local resolve cannot find a build variant for the current revision, best-effort scan newer `v<N>` branches and append an upgrade suggestion if one is compatible. Does not auto-switch versions; Hub failures never mask the original error.

Fixes #744

## Test plan
- [x] `uv run pytest tests/test_upgrade_hint.py -q` → 10 passed
- [ ] Upstream CI

Assisted-by: Cursor Agent

Made with [Cursor](https://cursor.com)