### PR TITLE
Enable Windows on ARM CUDA target

### DIFF
--- a/kernel-builder/src/pyproject/templates/torch/preamble.cmake
+++ b/kernel-builder/src/pyproject/templates/torch/preamble.cmake
@@ -155,6 +155,13 @@ if(GPU_LANG STREQUAL "CUDA")
     list(APPEND GPU_FLAGS "--threads=${NVCC_THREADS}")
   endif()
 
+  # CCCL shipped with CUDA 13+ hard-errors when nvcc uses MSVC's traditional
+  # preprocessor as host preprocessor. Tell cl.exe to use the standard
+  # conforming one instead.
+  if(MSVC)
+    list(APPEND GPU_FLAGS "-Xcompiler=/Zc:preprocessor")
+  endif()
+
   # TODO: deprecate one of these settings.
   add_compile_definitions(USE_CUDA=1)
   add_compile_definitions(CUDA_KERNEL)


### PR DESCRIPTION
# Summary
This PR enables building the CUDA backend for Windows on Arm by adding a target architecture option to the Windows builder, plus a small CMake fix required by newer CUDA toolkits.
Previously, builder.ps1 always derived the build architecture from the host process architecture, making it impossible to cross-compile ARM64 binaries from an x64 machine. This PR introduces an explicit -TargetArch parameter so the CUDA backend can now be built natively on ARM64 machines or cross-compiled from x64 hosts.

# Changes
- New -TargetArch parameter (x64 | ARM64), defaulting to the host architecture — preserving existing behavior.
- Initialize-VSEnvironment selects the correct vcvarsall.bat argument for the host/target combination (arm64, x64_arm64, arm64_x64), enabling cross-compilation.
- Get-CMakeConfigureArgs passes the target architecture to the Visual Studio generator (-A ARM64 / -A x64) instead of hardcoding the detected host platform.
- Informative message when targeting Windows ARM64 with CUDA (requires CUDA 13.0+ for Windows ARM64 support), and a warning when ARM64 is requested with a non-CUDA backend (only CUDA officially supports Windows ARM64).
kernel-builder/src/pyproject/templates/torch/preamble.cmake
- When building with MSVC, add -Xcompiler=/Zc:preprocessor to the nvcc flags. CCCL shipped with CUDA 13+ hard-errors when nvcc uses MSVC's traditional (non-conforming) preprocessor as the host preprocessor, which is required for the ARM64 CUDA build to succeed.

# Usage
## Native ARM64 build on an ARM64 machine
`.\builder.ps1 -SourceFolder ./examples/relu -Backend cuda -TargetArch ARM64 -ArchList "12.1" -Build`

## Cross-compile from an x64 host
`.\builder.ps1 -SourceFolder ./examples/relu -Backend cuda -TargetArch ARM64 -ArchList "12.1" -Build`

# Notes
- CUDA support for Windows ARM64 requires CUDA toolkit 13.0 or newer.
- x64-only workflows are unaffected: without -TargetArch, the script behaves exactly as before.