### PR TITLE
fix: point get-kernel-check at the built variant

### DIFF
--- a/nix-builder/lib/build.nix
+++ b/nix-builder/lib/build.nix
@@ -157,6 +157,7 @@ rec {
           kernelProvenance
           ;
         kernelName = kernelConfig.name;
+        variant = variants.kernelVariant kernelConfig;
       }
     else if kernelConfig.isTvmFfi then
       extension.mkTvmFfiExtension {
@@ -176,6 +177,7 @@ rec {
 
         kernelName = kernelConfig.name;
         doAbiCheck = true;
+        variant = variants.kernelVariant kernelConfig;
       }
     else
       extension.mkTorchExtension {
@@ -197,6 +199,7 @@ rec {
 
         kernelName = kernelConfig.name;
         doAbiCheck = true;
+        variant = variants.kernelVariant kernelConfig;
       };
 
   # Build multiple Torch extensions.

--- a/nix-builder/lib/extension/torch/arch.nix
+++ b/nix-builder/lib/extension/torch/arch.nix
@@ -72,6 +72,9 @@
   # The Torch stable ABI version to check for.
   torchStableAbiVersion ? null,
 
+  # The variant that the build is expected to produce.
+  variant,
+
   # Revision to bake into the ops name.
   rev,
 
@@ -236,7 +239,10 @@ stdenv.mkDerivation (prevAttrs: {
   ++ extraDeps;
 
   env =
-    lib.optionalAttrs cudaSupport {
+    {
+      inherit variant;
+    }
+    // lib.optionalAttrs cudaSupport {
       CUDAToolkit_ROOT = "${lib.getDev cudaPackages.cuda_nvcc}";
     }
     // lib.optionalAttrs xpuSupport {

--- a/nix-builder/lib/extension/torch/no-arch.nix
+++ b/nix-builder/lib/extension/torch/no-arch.nix
@@ -46,6 +46,9 @@
 
   backendPythonDeps,
 
+  # The variant that the build is expected to produce.
+  variant,
+
   # Git provenance (`{ sha; dirty; }`, or `null`) of the kernel source, recorded
   # in the build metadata.
   kernelProvenance,
@@ -92,6 +95,10 @@ stdenv.mkDerivation (prevAttrs: {
   '';
 
   framework = "torch";
+
+  env = {
+    inherit variant;
+  };
 
   # Add Torch as a dependency, so that devshells for universal kernels
   # also get torch as a build input.

--- a/nix-builder/lib/extension/tvm-ffi/arch.nix
+++ b/nix-builder/lib/extension/tvm-ffi/arch.nix
@@ -69,6 +69,9 @@
   # Wheter to strip rpath for non-nix use.
   stripRPath ? false,
 
+  # The variant that the build is expected to produce.
+  variant,
+
   # Revision to bake into the ops name.
   rev,
 
@@ -234,7 +237,10 @@ stdenv.mkDerivation (prevAttrs: {
   ++ extraDeps;
 
   env =
-    lib.optionalAttrs cudaSupport {
+    {
+      inherit variant;
+    }
+    // lib.optionalAttrs cudaSupport {
       CUDAToolkit_ROOT = "${lib.getDev cudaPackages.cuda_nvcc}";
     }
     // lib.optionalAttrs xpuSupport {

--- a/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.py
+++ b/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.py
@@ -19,8 +19,14 @@ with open(kernelDeps) as f:
     kernel_paths = KernelPaths.from_json(f.read())
 
 kernel = KernelDependency(repo_id=out, version=KernelVersion.Version(0))
+
+# The build host may not expose the accelerator being targeted (e.g. Metal is
+# undetectable inside the sandboxed macOS build), so point the resolver at the
+# derivation's single variant instead of relying on backend auto-detection.
+[variant] = (p.parent for p in Path(out).glob("*/metadata.json"))
+
 resolvers = [
-    RepoPathsResolver(local_kernels={out: Path(out)}),
+    RepoPathsResolver(local_kernels={out: variant}),
     KernelPathsResolver(kernel_paths=kernel_paths),
 ]
 

--- a/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.py
+++ b/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.py
@@ -18,15 +18,25 @@ if not kernelDeps:
 with open(kernelDeps) as f:
     kernel_paths = KernelPaths.from_json(f.read())
 
+variant = os.getenv("variant")
+if not variant:
+    raise ValueError("`variant` environment variable is not set by Nix derivation")
+
 kernel = KernelDependency(repo_id=out, version=KernelVersion.Version(0))
 
 # The build host may not expose the accelerator being targeted (e.g. Metal is
 # undetectable inside the sandboxed macOS build), so point the resolver at the
-# derivation's single variant instead of relying on backend auto-detection.
-[variant] = (p.parent for p in Path(out).glob("*/metadata.json"))
+# variant the derivation is expected to produce instead of relying on backend
+# auto-detection. This also fails the check if the build produced a different
+# variant than expected.
+variant_path = Path(out) / variant
+if not variant_path.is_dir():
+    raise FileNotFoundError(
+        f"Expected build variant `{variant}` is not present in `{out}`"
+    )
 
 resolvers = [
-    RepoPathsResolver(local_kernels={out: variant}),
+    RepoPathsResolver(local_kernels={out: variant_path}),
     KernelPathsResolver(kernel_paths=kernel_paths),
 ]
 

--- a/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.sh
+++ b/nix-builder/pkgs/get-kernel-check/get-kernel-check-hook.sh
@@ -15,6 +15,11 @@ _getKernelCheckHook() {
     exit 1
   fi
 
+  if [ -z ${variant+x} ]; then
+    echo "variant must be set in derivation"
+    exit 1
+  fi
+
   echo "Check whether the kernel can be loaded with get-kernel: ${moduleName}"
 
   # We strip the full library paths from the extension. Unfortunately,


### PR DESCRIPTION
this pr fixes the macos ci failures where `get-kernel-check` rejects a kernel that built fine. first hit on the einops port in https://github.com/huggingface/kernels-community/pull/1092

tldr; the check handed `$out` to the resolver and let it pick a variant by detecting the backend at runtime. metal is the only backend detected from live hardware (`torch.backends.mps.is_available()`, everything else is baked into the torch build). the sandboxed macos build cannot see the gpu, so the `torch-metal` variant is never selected and the check fails even though the artifact is fine

repro (no kernel build needed)

```bash
mkdir -p /tmp/fake-kernel/torch-metal && touch /tmp/fake-kernel/torch-metal/metadata.json
kernels/.venv/bin/python -c "from pathlib import Path; import kernels; kernels.get_local_kernel(Path('/tmp/fake-kernel'))"
```

```
ValueError: Cannot parse metadata from `"/tmp/fake-kernel/torch-metal/metadata.json"`: EOF while parsing a value at line 1 column 0
```

on a mac with a visible gpu the variant is selected fine (it gets as far as reading the empty `metadata.json`). same command inside a seatbelt sandbox

```bash
sandbox-exec -p '(version 1)(allow default)(deny iokit-open)' \
    kernels/.venv/bin/python -c "from pathlib import Path; import kernels; kernels.get_local_kernel(Path('/tmp/fake-kernel'))"
```

```
FileNotFoundError: Cannot find a build variant for this system in /tmp/fake-kernel:
```

`sandbox-exec` is the same seatbelt mechanism the nix darwin sandbox uses. denying iokit hides the gpu, `mps.is_available()` returns false, and the same directory no longer resolves

note* this is also why only some metal builds fail in ci. arch metal builds set `__noChroot = metalSupport` since they need the host metal toolchain, so the gpu is still visible during the check. noarch metal builds like einops run fully sandboxed and always fail. the first command also fails on linux since there is no mps at all

the check now globs `$out` for `*/metadata.json` and points the resolver at that exact variant dir instead of auto detecting from the build host. each extension derivation produces exactly one variant, so zero or multiple variants still fail the check
