### PR TITLE
Key the doc build concurrency group on the pull request number

### DIFF
--- a/.github/workflows/build_pr_documentation.yaml
+++ b/.github/workflows/build_pr_documentation.yaml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/build_pr_documentation.yaml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

`build_pr_documentation.yaml` keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks whose branches share a name therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

Shared names are common, because many contributors push to their fork's default branch instead of creating one. No two of the 12 currently open PRs here share a head branch name, but 4 of them come from forks, so the collision is reachable, and a doc build takes around a minute, which is the window in which it would cancel a build.

`github.event.pull_request.number` is unique per pull request. This workflow only triggers on `pull_request`, so the `github.run_id` fallback is never reached, but keeping it means that a later trigger would fall back to never cancelling rather than to grouping by branch name.

The template this workflow was copied from carries the same expression, and the same one-liner is proposed there in huggingface/doc-builder#829.
